### PR TITLE
Only attempt to change password if the confirmation field is filled in

### DIFF
--- a/ui/form/settings.go
+++ b/ui/form/settings.go
@@ -43,7 +43,12 @@ func (s *SettingsForm) Validate() error {
 		return errors.NewLocalizedError("error.settings_mandatory_fields")
 	}
 
-	if s.Password != "" {
+	if s.Confirmation == "" {
+		// Firefox insists on auto-completing the password field.
+		// If the confirmation field is blank, the user probably
+		// didn't intend to change their password.
+		s.Password = ""
+	} else if s.Password != "" {
 		if s.Password != s.Confirmation {
 			return errors.NewLocalizedError("error.different_passwords")
 		}

--- a/ui/form/settings_test.go
+++ b/ui/form/settings_test.go
@@ -1,0 +1,60 @@
+package form // import "miniflux.app/ui/form"
+
+import (
+	"testing"
+)
+
+func TestValid(t *testing.T) {
+	settings := &SettingsForm{
+		Username:       "user",
+		Password:       "hunter2",
+		Confirmation:   "hunter2",
+		Theme:          "default",
+		Language:       "en_US",
+		Timezone:       "UTC",
+		EntryDirection: "asc",
+	}
+
+	err := settings.Validate()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestConfirmationEmpty(t *testing.T) {
+	settings := &SettingsForm{
+		Username:       "user",
+		Password:       "hunter2",
+		Confirmation:   "",
+		Theme:          "default",
+		Language:       "en_US",
+		Timezone:       "UTC",
+		EntryDirection: "asc",
+	}
+
+	err := settings.Validate()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if settings.Password != "" {
+		t.Error("Password should have been cleared")
+	}
+}
+
+func TestConfirmationIncorrect(t *testing.T) {
+	settings := &SettingsForm{
+		Username:       "user",
+		Password:       "hunter2",
+		Confirmation:   "unter2",
+		Theme:          "default",
+		Language:       "en_US",
+		Timezone:       "UTC",
+		EntryDirection: "asc",
+	}
+
+	err := settings.Validate()
+	if err == nil {
+		t.Error("Validate should return an error")
+	}
+}


### PR DESCRIPTION
Firefox autocompletes the password field (but not the password confirmation field) for me. This makes it annoying to use the settings page, because miniflux thinks I'm trying to change my password and it complains that the fields don't match.