### PR TITLE
Add a resolve redirects rewriter

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -111,6 +111,16 @@ func (c *Client) Get() (*Response, error) {
 	return c.executeRequest(request)
 }
 
+// Head execute a HEAD HTTP request.
+func (c *Client) Head() (*Response, error) {
+	request, err := c.buildRequest(http.MethodHead, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.executeRequest(request)
+}
+
 // PostForm execute a POST HTTP request with form values.
 func (c *Client) PostForm(values url.Values) (*Response, error) {
 	request, err := c.buildRequest(http.MethodPost, strings.NewReader(values.Encode()))

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -43,6 +43,8 @@ func Rewriter(entryURL, entryContent, customRewriteRules string) string {
 			entryContent = replaceLineFeeds(entryContent)
 		case "convert_text_link", "convert_text_links":
 			entryContent = replaceTextLinks(entryContent)
+		case "resolve_redirects":
+			entryContent = resolveRedirects(entryContent)
 		}
 	}
 


### PR DESCRIPTION
This PR adds a rewriter called `resolve_redirects` to convert links like:
`https://news.google.com/articles/CAIiEKf9gMYBAETczUz0iOTkzdMqFwgEKg8IACoHCAowjuuKAzCWrzwwt4QY?hl=en-US&gl=US&ceid=US%3Aen`
into the actual URL:
`https://www.nytimes.com/2020/05/29/us/politics/trump-hong-kong-china-WHO.html`

This is useful to avoid tracking on Google News feeds.