### PR TITLE
Fix: If not set HTTP_CLIENT_PROXY, use default http transport

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -268,6 +268,7 @@ func (c *Client) buildRequest(method string, body io.Reader) (*http.Request, err
 func (c *Client) buildClient() http.Client {
 	client := http.Client{Timeout: time.Duration(c.ClientTimeout) * time.Second}
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			// Default is 30s.
 			Timeout: 10 * time.Second,


### PR DESCRIPTION
If not set HTTP_CLIENT_PROXY, use default http transport(which would get HTTP_PROXY/HTTPS_PROXY from env). Users only need to set HTTP_PROXY/HTTPS_PROXY to bypass traffic to their proxy(as set feed using proxy one by one is frustrating, if they had more than 250+ feeds!).