### PR TITLE
Do not escape HTML for Atom 1.0 text content during parsing

### DIFF
--- a/reader/atom/atom_10.go
+++ b/reader/atom/atom_10.go
@@ -6,7 +6,6 @@ package atom // import "miniflux.app/reader/atom"
 
 import (
 	"encoding/xml"
-	"html"
 	"strconv"
 	"strings"
 	"time"
@@ -221,10 +220,8 @@ func (a *atom10Text) String() string {
 	switch {
 	case a.Type == "xhtml":
 		content = a.XML
-	case a.Type == "html":
+	default:
 		content = a.Data
-	case a.Type == "text" || a.Type == "":
-		content = html.EscapeString(a.Data)
 	}
 
 	return strings.TrimSpace(content)

--- a/reader/atom/atom_10_test.go
+++ b/reader/atom/atom_10_test.go
@@ -359,7 +359,7 @@ func TestParseEntrySummaryWithPlainText(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if feed.Entries[0].Content != "&lt;Some text.&gt;" {
+	if feed.Entries[0].Content != "<Some text.>" {
 		t.Errorf("Incorrect entry content, got: %s", feed.Entries[0].Content)
 	}
 }
@@ -596,6 +596,63 @@ func TestParseInvalidXml(t *testing.T) {
 	_, err := Parse(bytes.NewBufferString(data))
 	if err == nil {
 		t.Error("Parse should returns an error")
+	}
+}
+
+func TestParseTitleWithSingleQuote(t *testing.T) {
+	data := `
+		<?xml version="1.0" encoding="utf-8"?>
+		<feed xmlns="http://www.w3.org/2005/Atom">
+			<title>' or ’</title>
+			<link href="http://example.org/"/>
+		</feed>
+	`
+
+	feed, err := Parse(bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feed.Title != "' or ’" {
+		t.Errorf(`Incorrect title, got: %q`, feed.Title)
+	}
+}
+
+func TestParseTitleWithEncodedSingleQuote(t *testing.T) {
+	data := `
+		<?xml version="1.0" encoding="utf-8"?>
+		<feed xmlns="http://www.w3.org/2005/Atom">
+			<title type="html">Test&#39;s Blog</title>
+			<link href="http://example.org/"/>
+		</feed>
+	`
+
+	feed, err := Parse(bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feed.Title != "Test's Blog" {
+		t.Errorf(`Incorrect title, got: %q`, feed.Title)
+	}
+}
+
+func TestParseTitleWithSingleQuoteAndHTMLType(t *testing.T) {
+	data := `
+		<?xml version="1.0" encoding="utf-8"?>
+		<feed xmlns="http://www.w3.org/2005/Atom">
+			<title type="html">O’Hara</title>
+			<link href="http://example.org/"/>
+		</feed>
+	`
+
+	feed, err := Parse(bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feed.Title != "O’Hara" {
+		t.Errorf(`Incorrect title, got: %q`, feed.Title)
 	}
 }
 


### PR DESCRIPTION
Avoid encoding single quotes to HTML entities (&#39;).

Feed contents are sanitized after parsing.