### PR TITLE
Add rewrite rule replace for custom search and replace

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -221,3 +221,12 @@ func replaceTextLinks(input string) string {
 func replaceLineFeeds(input string) string {
 	return strings.Replace(input, "\n", "<br>", -1)
 }
+
+func replaceCustom(entryContent string, searchTerm string, replaceTerm string) string {
+	re, err := regexp.Compile(searchTerm)
+	if err == nil {
+		return re.ReplaceAllString(entryContent, replaceTerm)
+	}
+	return entryContent
+}
+

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -230,3 +230,13 @@ func TestRewriteNoScriptImageWithNoScriptTag(t *testing.T) {
 		t.Errorf(`Not expected output: %s`, output)
 	}
 }
+
+func TestRewriteReplaceCustom(t *testing.T) {
+	content := `<img src="http://example.org/logo.svg"><img src="https://example.org/article/picture.svg">`
+	expected := `<img src="http://example.org/logo.svg"><img src="https://example.org/article/picture.png">`
+	output := Rewriter("https://example.org/artcle", content, `replace("article/(.*).svg"|"article/$1.png")`)
+
+	if expected != output {
+		t.Errorf(`Not expected output: %s`, output)
+	}
+}


### PR DESCRIPTION
The rule should be formatted like this:
`replace("search term"|"replace term")`
Standard golang regex and replace syntax can be used.

I think this will be useful for small rewrite cases which aren't covered by the existing rewrite rules. 

My specific use-case is for webtoons.com: replacing `webtoon` with `swebtoon` fixes the image src links and renders them properly..
