### PR TITLE
Add created_at field for entries

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -137,6 +137,7 @@ type Entry struct {
 	Title       string     `json:"title"`
 	URL         string     `json:"url"`
 	Date        time.Time  `json:"published_at"`
+	CreatedAt   time.Time  `json:"created_at"`
 	Content     string     `json:"content"`
 	Author      string     `json:"author"`
 	ShareCode   string     `json:"share_code"`

--- a/database/migration.go
+++ b/database/migration.go
@@ -12,7 +12,7 @@ import (
 	"miniflux.app/logger"
 )
 
-const schemaVersion = 41
+const schemaVersion = 42
 
 // Migrate executes database migrations.
 func Migrate(db *sql.DB) {

--- a/database/sql.go
+++ b/database/sql.go
@@ -205,6 +205,7 @@ alter table users add column entry_direction entry_sorting_direction default 'as
 `,
 	"schema_version_41": `alter table entries add column reading_time int not null default 0;`,
 	"schema_version_42": `alter table entries add column created_at timestamp with time zone not null default now();
+update entries set created_at = published_at;
 `,
 	"schema_version_5": `create table integrations (
     user_id int not null,
@@ -268,7 +269,7 @@ var SqlMapChecksums = map[string]string{
 	"schema_version_4":  "216ea3a7d3e1704e40c797b5dc47456517c27dbb6ca98bf88812f4f63d74b5d9",
 	"schema_version_40": "6a8fec92399f853ed6817aff4cfa43255dce4c19afad796e41519d09de62105e",
 	"schema_version_41": "128e118ce61267ea1f6ae03b63a6d4734eae87e520b00e309ad083f1f6afdfe5",
-	"schema_version_42": "8135224155b790be7f8c08ae2529a2e788207ad68f231bceb98e9f9c7c54a8fb",
+	"schema_version_42": "3d0cd422c6d9d13e7a619a8dbf081e17750881e0ae9ae380475b09d37ada9e33",
 	"schema_version_5":  "46397e2f5f2c82116786127e9f6a403e975b14d2ca7b652a48cd1ba843e6a27c",
 	"schema_version_6":  "9d05b4fb223f0e60efc716add5048b0ca9c37511cf2041721e20505d6d798ce4",
 	"schema_version_7":  "33f298c9aa30d6de3ca28e1270df51c2884d7596f1283a75716e2aeb634cd05c",

--- a/database/sql.go
+++ b/database/sql.go
@@ -204,6 +204,8 @@ alter table users add column entry_direction entry_sorting_direction default 'as
 ;
 `,
 	"schema_version_41": `alter table entries add column reading_time int not null default 0;`,
+	"schema_version_42": `alter table entries add column created_at timestamp with time zone not null default now();
+`,
 	"schema_version_5": `create table integrations (
     user_id int not null,
     pinboard_enabled bool default 'f',
@@ -266,6 +268,7 @@ var SqlMapChecksums = map[string]string{
 	"schema_version_4":  "216ea3a7d3e1704e40c797b5dc47456517c27dbb6ca98bf88812f4f63d74b5d9",
 	"schema_version_40": "6a8fec92399f853ed6817aff4cfa43255dce4c19afad796e41519d09de62105e",
 	"schema_version_41": "128e118ce61267ea1f6ae03b63a6d4734eae87e520b00e309ad083f1f6afdfe5",
+	"schema_version_42": "8135224155b790be7f8c08ae2529a2e788207ad68f231bceb98e9f9c7c54a8fb",
 	"schema_version_5":  "46397e2f5f2c82116786127e9f6a403e975b14d2ca7b652a48cd1ba843e6a27c",
 	"schema_version_6":  "9d05b4fb223f0e60efc716add5048b0ca9c37511cf2041721e20505d6d798ce4",
 	"schema_version_7":  "33f298c9aa30d6de3ca28e1270df51c2884d7596f1283a75716e2aeb634cd05c",

--- a/database/sql/schema_version_42.sql
+++ b/database/sql/schema_version_42.sql
@@ -1,0 +1,1 @@
+alter table entries add column created_at timestamp with time zone not null default now();

--- a/database/sql/schema_version_42.sql
+++ b/database/sql/schema_version_42.sql
@@ -1,1 +1,2 @@
 alter table entries add column created_at timestamp with time zone not null default now();
+update entries set created_at = published_at;

--- a/model/entry.go
+++ b/model/entry.go
@@ -29,6 +29,7 @@ type Entry struct {
 	URL         string        `json:"url"`
 	CommentsURL string        `json:"comments_url"`
 	Date        time.Time     `json:"published_at"`
+	CreatedAt   time.Time     `json:"created_at"`
 	Content     string        `json:"content"`
 	Author      string        `json:"author"`
 	ShareCode   string        `json:"share_code"`
@@ -54,11 +55,11 @@ func ValidateEntryStatus(status string) error {
 // ValidateEntryOrder makes sure the sorting order is valid.
 func ValidateEntryOrder(order string) error {
 	switch order {
-	case "id", "status", "changed_at", "published_at", "category_title", "category_id":
+	case "id", "status", "changed_at", "published_at", "created_at", "category_title", "category_id":
 		return nil
 	}
 
-	return fmt.Errorf(`Invalid entry order, valid order values are: "id", "status", "changed_at", "published_at", "category_title", "category_id"`)
+	return fmt.Errorf(`Invalid entry order, valid order values are: "id", "status", "changed_at", "published_at", "created_at", "category_title", "category_id"`)
 }
 
 // ValidateDirection makes sure the sorting direction is valid.

--- a/model/entry_test.go
+++ b/model/entry_test.go
@@ -19,7 +19,7 @@ func TestValidateEntryStatus(t *testing.T) {
 }
 
 func TestValidateEntryOrder(t *testing.T) {
-	for _, status := range []string{"id", "status", "changed_at", "published_at", "category_title", "category_id"} {
+	for _, status := range []string{"id", "status", "changed_at", "published_at", "created_at", "category_title", "category_id"} {
 		if err := ValidateEntryOrder(status); err != nil {
 			t.Error(`A valid order should not generate any error`)
 		}

--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -227,6 +227,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 			e.status,
 			e.starred,
 			e.reading_time,
+			e.created_at,
 			f.title as feed_title,
 			f.feed_url,
 			f.site_url,
@@ -286,6 +287,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 			&entry.Status,
 			&entry.Starred,
 			&entry.ReadingTime,
+			&entry.CreatedAt,
 			&entry.Feed.Title,
 			&entry.Feed.FeedURL,
 			&entry.Feed.SiteURL,
@@ -312,6 +314,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 
 		// Make sure that timestamp fields contains timezone information (API)
 		entry.Date = timezone.Convert(tz, entry.Date)
+		entry.CreatedAt = timezone.Convert(tz, entry.CreatedAt)
 		entry.Feed.CheckedAt = timezone.Convert(tz, entry.Feed.CheckedAt)
 
 		entry.Feed.ID = entry.FeedID


### PR DESCRIPTION
Addresses #848.

Adds a "created_at" field to the entries table/model/API which corresponds to the time that miniflux created/scraped the entry.

Caveats:
- "created_at" is populated using the DB's "now()" timestamp via the column default. Please let me know if we'd like to explicitly send a "created_at" timestamp from miniflux.
- I wasn't sure if this should be "created_at" or "scraped_at", so I went with the name suggested in the original issue.