### PR TITLE
Add support for setting a global default User-Agent

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -52,6 +52,7 @@ const (
 	defaultHTTPClientTimeout                  = 20
 	defaultHTTPClientMaxBodySize              = 15
 	defaultHTTPClientProxy                    = ""
+	defaultHTTPClientUserAgent                = ""
 	defaultAuthProxyHeader                    = ""
 	defaultAuthProxyUserCreation              = false
 	defaultMaintenanceMode                    = false
@@ -59,7 +60,6 @@ const (
 	defaultMetricsCollector                   = false
 	defaultMetricsRefreshInterval             = 60
 	defaultMetricsAllowedNetworks             = "127.0.0.1/8"
-	defaultUserAgent                          = ""
 )
 
 // Options contains configuration options.
@@ -106,6 +106,7 @@ type Options struct {
 	httpClientTimeout                  int
 	httpClientMaxBodySize              int64
 	httpClientProxy                    string
+	httpClientUserAgent                string
 	authProxyHeader                    string
 	authProxyUserCreation              bool
 	maintenanceMode                    bool
@@ -113,7 +114,6 @@ type Options struct {
 	metricsCollector                   bool
 	metricsRefreshInterval             int
 	metricsAllowedNetworks             []string
-	userAgent                          string
 }
 
 // NewOptions returns Options with default values.
@@ -166,7 +166,7 @@ func NewOptions() *Options {
 		metricsCollector:                   defaultMetricsCollector,
 		metricsRefreshInterval:             defaultMetricsRefreshInterval,
 		metricsAllowedNetworks:             []string{defaultMetricsAllowedNetworks},
-		userAgent:                          defaultUserAgent,
+		httpClientUserAgent:                defaultHTTPClientUserAgent,
 	}
 }
 
@@ -425,9 +425,9 @@ func (o *Options) MetricsAllowedNetworks() []string {
 	return o.metricsAllowedNetworks
 }
 
-// UserAgent returns the global User-Agent header for miniflux.
-func (o *Options) UserAgent() string {
-	return o.userAgent
+// HTTPClientUserAgent returns the global User-Agent header for miniflux.
+func (o *Options) HTTPClientUserAgent() string {
+	return o.httpClientUserAgent
 }
 
 func (o *Options) String() string {
@@ -474,6 +474,7 @@ func (o *Options) String() string {
 	builder.WriteString(fmt.Sprintf("HTTP_CLIENT_TIMEOUT: %v\n", o.httpClientTimeout))
 	builder.WriteString(fmt.Sprintf("HTTP_CLIENT_MAX_BODY_SIZE: %v\n", o.httpClientMaxBodySize))
 	builder.WriteString(fmt.Sprintf("HTTP_CLIENT_PROXY: %v\n", o.httpClientProxy))
+	builder.WriteString(fmt.Sprintf("HTTP_CLIENT_USER_AGENT: %v\n", o.httpClientUserAgent))
 	builder.WriteString(fmt.Sprintf("AUTH_PROXY_HEADER: %v\n", o.authProxyHeader))
 	builder.WriteString(fmt.Sprintf("AUTH_PROXY_USER_CREATION: %v\n", o.authProxyUserCreation))
 	builder.WriteString(fmt.Sprintf("MAINTENANCE_MODE: %v\n", o.maintenanceMode))
@@ -481,6 +482,5 @@ func (o *Options) String() string {
 	builder.WriteString(fmt.Sprintf("METRICS_COLLECTOR: %v\n", o.metricsCollector))
 	builder.WriteString(fmt.Sprintf("METRICS_REFRESH_INTERVAL: %v\n", o.metricsRefreshInterval))
 	builder.WriteString(fmt.Sprintf("METRICS_ALLOWED_NETWORKS: %v\n", o.metricsAllowedNetworks))
-	builder.WriteString(fmt.Sprintf("USER_AGENT: %v\n", o.userAgent))
 	return builder.String()
 }

--- a/config/options.go
+++ b/config/options.go
@@ -59,6 +59,7 @@ const (
 	defaultMetricsCollector                   = false
 	defaultMetricsRefreshInterval             = 60
 	defaultMetricsAllowedNetworks             = "127.0.0.1/8"
+	defaultUserAgent                          = ""
 )
 
 // Options contains configuration options.
@@ -112,6 +113,7 @@ type Options struct {
 	metricsCollector                   bool
 	metricsRefreshInterval             int
 	metricsAllowedNetworks             []string
+	userAgent                          string
 }
 
 // NewOptions returns Options with default values.
@@ -164,6 +166,7 @@ func NewOptions() *Options {
 		metricsCollector:                   defaultMetricsCollector,
 		metricsRefreshInterval:             defaultMetricsRefreshInterval,
 		metricsAllowedNetworks:             []string{defaultMetricsAllowedNetworks},
+		userAgent:                          defaultUserAgent,
 	}
 }
 
@@ -422,6 +425,11 @@ func (o *Options) MetricsAllowedNetworks() []string {
 	return o.metricsAllowedNetworks
 }
 
+// UserAgent returns the global User-Agent header for miniflux.
+func (o *Options) UserAgent() string {
+	return o.userAgent
+}
+
 func (o *Options) String() string {
 	var builder strings.Builder
 	builder.WriteString(fmt.Sprintf("LOG_DATE_TIME: %v\n", o.logDateTime))
@@ -473,5 +481,6 @@ func (o *Options) String() string {
 	builder.WriteString(fmt.Sprintf("METRICS_COLLECTOR: %v\n", o.metricsCollector))
 	builder.WriteString(fmt.Sprintf("METRICS_REFRESH_INTERVAL: %v\n", o.metricsRefreshInterval))
 	builder.WriteString(fmt.Sprintf("METRICS_ALLOWED_NETWORKS: %v\n", o.metricsAllowedNetworks))
+	builder.WriteString(fmt.Sprintf("USER_AGENT: %v\n", o.userAgent))
 	return builder.String()
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -170,6 +170,8 @@ func (p *Parser) parseLines(lines []string) (err error) {
 			p.opts.httpClientMaxBodySize = int64(parseInt(value, defaultHTTPClientMaxBodySize) * 1024 * 1024)
 		case "HTTP_CLIENT_PROXY":
 			p.opts.httpClientProxy = parseString(value, defaultHTTPClientProxy)
+		case "HTTP_CLIENT_USER_AGENT":
+			p.opts.httpClientUserAgent = parseString(value, defaultHTTPClientUserAgent)
 		case "AUTH_PROXY_HEADER":
 			p.opts.authProxyHeader = parseString(value, defaultAuthProxyHeader)
 		case "AUTH_PROXY_USER_CREATION":
@@ -184,8 +186,6 @@ func (p *Parser) parseLines(lines []string) (err error) {
 			p.opts.metricsRefreshInterval = parseInt(value, defaultMetricsRefreshInterval)
 		case "METRICS_ALLOWED_NETWORKS":
 			p.opts.metricsAllowedNetworks = parseStringList(value, []string{defaultMetricsAllowedNetworks})
-		case "USER_AGENT":
-			p.opts.userAgent = parseString(value, defaultUserAgent)
 		}
 	}
 

--- a/config/parser.go
+++ b/config/parser.go
@@ -184,6 +184,8 @@ func (p *Parser) parseLines(lines []string) (err error) {
 			p.opts.metricsRefreshInterval = parseInt(value, defaultMetricsRefreshInterval)
 		case "METRICS_ALLOWED_NETWORKS":
 			p.opts.metricsAllowedNetworks = parseStringList(value, []string{defaultMetricsAllowedNetworks})
+		case "USER_AGENT":
+			p.opts.userAgent = parseString(value, defaultUserAgent)
 		}
 	}
 

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -72,7 +72,7 @@ func New(url string) *Client {
 
 // NewClientWithConfig initializes a new HTTP client with application config options.
 func NewClientWithConfig(url string, opts *config.Options) *Client {
-	userAgent := opts.UserAgent()
+	userAgent := opts.HTTPClientUserAgent()
 	if userAgent == "" {
 		userAgent = DefaultUserAgent
 	}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -72,9 +72,13 @@ func New(url string) *Client {
 
 // NewClientWithConfig initializes a new HTTP client with application config options.
 func NewClientWithConfig(url string, opts *config.Options) *Client {
+	userAgent := opts.UserAgent()
+	if userAgent == "" {
+		userAgent = DefaultUserAgent
+	}
 	return &Client{
 		inputURL:          url,
-		requestUserAgent:  DefaultUserAgent,
+		requestUserAgent:  userAgent,
 		ClientTimeout:     opts.HTTPClientTimeout(),
 		ClientMaxBodySize: opts.HTTPClientMaxBodySize(),
 		ClientProxyURL:    opts.HTTPClientProxy(),

--- a/http/client/client_test.go
+++ b/http/client/client_test.go
@@ -62,7 +62,7 @@ func TestClientRequestUserAgent(t *testing.T) {
 	}
 
 	userAgent := "Custom User Agent"
-	os.Setenv("USER_AGENT", userAgent)
+	os.Setenv("HTTP_CLIENT_USER_AGENT", userAgent)
 	opts, err := config.NewParser().ParseEnvironmentVariables()
 	if err != nil {
 		t.Fatalf(`Parsing config failed: %v`, err)

--- a/http/client/client_test.go
+++ b/http/client/client_test.go
@@ -4,7 +4,12 @@
 
 package client // import "miniflux.app/http/client"
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"miniflux.app/config"
+)
 
 func TestClientWithDelay(t *testing.T) {
 	clt := New("http://httpbin.org/delay/5")
@@ -47,5 +52,23 @@ func TestClientWithBasicAuth(t *testing.T) {
 	_, err := clt.Get()
 	if err != nil {
 		t.Fatalf(`The client should be authenticated successfully: %v`, err)
+	}
+}
+
+func TestClientRequestUserAgent(t *testing.T) {
+	clt := New("http://httpbin.org")
+	if clt.requestUserAgent != DefaultUserAgent {
+		t.Errorf(`The client had default User-Agent %q, wanted %q`, clt.requestUserAgent, DefaultUserAgent)
+	}
+
+	userAgent := "Custom User Agent"
+	os.Setenv("USER_AGENT", userAgent)
+	opts, err := config.NewParser().ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing config failed: %v`, err)
+	}
+	clt = NewClientWithConfig("http://httpbin.org", opts)
+	if clt.requestUserAgent != userAgent {
+		t.Errorf(`The client had User-Agent %q, wanted %q`, clt.requestUserAgent, userAgent)
 	}
 }

--- a/miniflux.1
+++ b/miniflux.1
@@ -277,6 +277,11 @@ Proxy URL for HTTP client\&.
 .br
 Default is empty\&.
 .TP
+.B HTTP_CLIENT_USER_AGENT
+The default User-Agent header to use for the HTTP client. Can be overridden in per-feed settings\&.
+.br
+Default is empty. When empty, Miniflux uses a default User-Agent that includes the Miniflux version\&.
+.TP
 .B AUTH_PROXY_HEADER
 Proxy authentication HTTP header\&.
 .TP


### PR DESCRIPTION
Addresses #880. 

Creates a new USER_AGENT config setting, which is used by the miniflux http client in the place of the default user agent, if set.