### PR TITLE
Let's Encrypt improvements

### DIFF
--- a/packaging/systemd/miniflux.service
+++ b/packaging/systemd/miniflux.service
@@ -43,5 +43,13 @@ RestrictRealtime=true
 # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWritePaths=
 ReadWritePaths=/run
 
+# Allow miniflux to bind to <1024 ports
+# https://www.freedesktop.org/software/systemd/man/systemd.exec.html#AmbientCapabilities=
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Provide a private /tmp for CERT_CACHE (required when using Let's Encrypt)
+# https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateTmp=
+PrivateTmp=true
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change makes it possible to `apt-get install miniflux`, `echo CERT_DOMAIN=fqdn >>/etc/miniflux.conf`, and immediately start accepting HTTPS traffic with Let's Encrypt and without any reverse proxies.


Currently, Miniflux's documentation is a little conflicted and suggests to either;
1. [Remove systemd directives](https://miniflux.app/docs/howto.html#privileged-ports) such as `NoNewPrivileges` to let the process bind to <1024 ports.
2. [Use a reverse proxy](https://miniflux.app/docs/howto.html#reverse-proxy) such as NGINX. Doing so requires additional complexity to use Let's Encrypt (i.e. certbot).
3. [Use an experimental Systemd Socket Activation](https://miniflux.app/docs/howto.html#systemd-socket-activation) - without clear options for using Let's Encrypt.

This pull request adds two directives to Miniflux's systemd unit service file;

- [AmbientCapabilities](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#AmbientCapabilities=) to give the `CAP_NET_BIND_SERVICE` capability without having to use `setcap` on `/usr/bin/miniflux` (on each update!) and without having to drop `NoNewPrivileges`, etc. directives. [AmbientCapabilities](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#AmbientCapabilities=) was introduced in [systemd v229](https://github.com/systemd/systemd/blob/d514454446dd233c6b03b1c84fabb813fbab593e/NEWS#L5999) which shipped with [Ubuntu 16.04 LTS](https://packages.ubuntu.com/xenial/systemd) in Apr 2016.
- [PrivateTmp](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateTmp=) to provide a private `/tmp` and `/var/tmp` to the miniflux process, which allows it to write to the default `CERT_CACHE` path which is required by Let's Encrypt and which defaults to `/tmp/cert_cache`.