### PR TITLE
update help on CLEANUP_ARCHIVE_READ_DAYS and CLEANUP_ARCHIVE_UNREAD_DAYS

### DIFF
--- a/miniflux.1
+++ b/miniflux.1
@@ -161,12 +161,16 @@ Cleanup job frequency. Remove old sessions and archive entries\&.
 Default is 24 hours\&.
 .TP
 .B CLEANUP_ARCHIVE_READ_DAYS
-Number of days after marking read items as removed\&.
+Number of days after marking read entries as removed\&.
+.br
+Set to -1 to keep all read entries.
 .br
 Default is 60 days\&.
 .TP
 .B CLEANUP_ARCHIVE_UNREAD_DAYS
-Number of days after marking unread items as removed\&.
+Number of days after marking unread entries as removed\&.
+.br
+Set to -1 to keep all unread entries.
 .br
 Default is 180 days\&.
 .TP


### PR DESCRIPTION
Tell user they can use -1 to keep all entries.