### PR TITLE
Display the number of total entries in UI

### DIFF
--- a/locale/translations.go
+++ b/locale/translations.go
@@ -104,7 +104,7 @@ var translations = map[string]string{
     "page.feeds.title": "Abonnements",
     "page.feeds.last_check": "Letzte Aktualisierung:",
     "page.feeds.unread_counter": "Anzahl der ungelesenen Artikel",
-    "page.feeds.read_counter": "Anzahl der gelesenen Artikel",
+    "page.feeds.total_counter": "Anzahl der Einträge insgesamt",
     "page.feeds.error_count": [
         "%d Fehler",
         "%d Fehler"
@@ -468,7 +468,7 @@ var translations = map[string]string{
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "Last check:",
     "page.feeds.unread_counter": "Number of unread entries",
-    "page.feeds.read_counter": "Number of read entries",
+    "page.feeds.total_counter": "Number of total entries",
     "page.feeds.error_count": [
         "%d error",
         "%d errors"
@@ -812,7 +812,7 @@ var translations = map[string]string{
     "page.feeds.title": "Fuentes",
     "page.feeds.last_check": "Última verificación:",
     "page.feeds.unread_counter": "Número de entradas no leídas",
-    "page.feeds.read_counter": "Número de entradas leídas",
+    "page.feeds.total_counter": "Número de entradas total",
     "page.feeds.error_count": [
         "%d error",
         "%d errores"
@@ -1156,7 +1156,7 @@ var translations = map[string]string{
     "page.feeds.title": "Abonnements",
     "page.feeds.last_check": "Dernière vérification :",
     "page.feeds.unread_counter": "Nombre d'entrées non lues",
-    "page.feeds.read_counter": "Nombre d'entrées lues",
+    "page.feeds.total_counter": "Nombre total d'entrées",
     "page.feeds.error_count": [
         "%d erreur",
         "%d erreurs"
@@ -1520,7 +1520,7 @@ var translations = map[string]string{
     "page.feeds.title": "Feed",
     "page.feeds.last_check": "Ultimo controllo:",
     "page.feeds.unread_counter": "Numero di voci non lette",
-    "page.feeds.read_counter": "Numero di voci lette",
+    "page.feeds.total_counter": "Numero di voci totali",
     "page.feeds.error_count": [
         "%d errore",
         "%d errori"
@@ -1864,7 +1864,7 @@ var translations = map[string]string{
     "page.feeds.title": "フィード一覧",
     "page.feeds.last_check": "最終チェック:",
     "page.feeds.unread_counter": "未読記事の数",
-    "page.feeds.read_counter": "既読記事の数",
+    "page.feeds.total_counter": "総エントリ数",
     "page.feeds.error_count": [
         "%d 個のエラー",
         "%d 個のエラー"
@@ -2208,7 +2208,7 @@ var translations = map[string]string{
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "Laatste update:",
     "page.feeds.unread_counter": "Aantal ongelezen vermeldingen",
-    "page.feeds.read_counter": "Aantal gelezen vermeldingen",
+    "page.feeds.total_counter": "Totaal aantal inzendingen",
     "page.feeds.error_count": [
         "%d error",
         "%d errors"
@@ -2571,7 +2571,7 @@ var translations = map[string]string{
     "page.feeds.title": "Kanały",
     "page.feeds.last_check": "Ostatnia aktualizacja:",
     "page.feeds.unread_counter": "Liczba nieprzeczytanych wpisów",
-    "page.feeds.read_counter": "Liczba przeczytanych wpisów",
+    "page.feeds.total_counter": "Liczba wszystkich wpisów",
     "page.feeds.error_count": [
         "%d błąd",
         "%d błąd",
@@ -2940,7 +2940,7 @@ var translations = map[string]string{
     "page.feeds.title": "Fontes",
     "page.feeds.last_check": "Última verificação:",
     "page.feeds.unread_counter": "Numero de itens não lidos",
-    "page.feeds.read_counter": "Número de itens lidos",
+    "page.feeds.total_counter": "Número de entradas totais",
     "page.feeds.error_count": [
         "%d erro",
         "%d erros"
@@ -3285,7 +3285,7 @@ var translations = map[string]string{
     "page.feeds.title": "Подписки",
     "page.feeds.last_check": "Последняя проверка:",
     "page.feeds.unread_counter": "Количество непрочитанных записей",
-    "page.feeds.read_counter": "Количество прочитанных записей",
+    "page.feeds.total_counter": "Количество полных записей",
     "page.feeds.error_count": [
         "%d ошибка",
         "%d ошибки",
@@ -3635,7 +3635,7 @@ var translations = map[string]string{
     "page.feeds.title": "源",
     "page.feeds.last_check": "最后检查时间：",
     "page.feeds.unread_counter": "未读条目数",
-    "page.feeds.read_counter": "读取条目数",
+    "page.feeds.total_counter": "总条目数",
     "page.feeds.error_count": [
         "%d 错误"
     ],
@@ -3893,15 +3893,15 @@ var translations = map[string]string{
 }
 
 var translationsChecksums = map[string]string{
-	"de_DE": "83df0b00c06a4a96a806456048cf61962aa1218acbd24d14b95bfedda8274797",
-	"en_US": "0f71c28287716454c8f1c191899e93adbe2410a109e06f17892ec9710389ac88",
-	"es_ES": "cfaf7d66f0ddf544492ae89c32b501bb687aaf3f65e08d09d1a6aa44bc0f55a6",
-	"fr_FR": "1d94f93c89c209ca0041f1c74a5e6ac0234fd8ddae900e41c312a326521f096b",
-	"it_IT": "6b33e802ac2bdf412c89a2de616fc162c1d98052bf92d2c81da0501809a223d3",
-	"ja_JP": "81e64953889c637a14695881cecafdef8fdcc9e0b5934281999ca23b0aee6037",
-	"nl_NL": "1532538d071ca8097a1e02c6a0f803598126f6d4bb3bb9409e20d9f8fc957a73",
-	"pl_PL": "2b4cb51082be142c6a5cf32d681348ff0224b60a052be318c99efe1d6fa269dc",
-	"pt_BR": "0dd731b01e2453453548818ba0539e54da7722d0c0cd931bf160cb32fd691fee",
-	"ru_RU": "8b482f58720668d325ce16c9e4399e01f22db5afe79558b10b2e782779678ec8",
-	"zh_CN": "193195d7609b7fb07386b0c56c4c85ecf370e6e17295a18c36a6e28289336a0e",
+	"de_DE": "cfc615af391cdf9b5a6bfcab8500825e86df0a587aa85a33c8c58f4a425262f5",
+	"en_US": "e834a576abed60f259c628f9d2a66652b54f541d3cd505d1059f34cd2eade9ee",
+	"es_ES": "b4bbd1689279efb07c90294a410001a94593f680077afba8f0633929ecd0a5cd",
+	"fr_FR": "e751458f0ea4b6bf91e8f3aa7d250295d6e1c10718b7bc23503a18dd78be9565",
+	"it_IT": "dd1a21140f41741a2002d0ca9da39a09efd4f2174117a29e5ea56d2f33224f63",
+	"ja_JP": "7e501f5b3b98c2ac4ed88fca0994f8e9f9864c03b9f3be3c647e408dd821ada5",
+	"nl_NL": "3021365e63e851a57c53f2484277a588ffff2efd4ca8c65cd85db7ea682bdd6e",
+	"pl_PL": "bd46491b7d3bd28b616b154f10ed7307eea5abdf2c9a32bbb80f90d588732a64",
+	"pt_BR": "4effc433057250bc2c509e7e82281abcee00d07d8e2983f7985c7d730d5f0e83",
+	"ru_RU": "c8b663850c4e7ee6ba67d8fa28055c2c7e5ead83913ae7ad6249f7d0f70b3cc6",
+	"zh_CN": "81ffba19c3f5cd5b8ee804e39ad3c232bf22bafd6ab9a649fee03195266ffd76",
 }

--- a/locale/translations/de_DE.json
+++ b/locale/translations/de_DE.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Abonnements",
     "page.feeds.last_check": "Letzte Aktualisierung:",
     "page.feeds.unread_counter": "Anzahl der ungelesenen Artikel",
-    "page.feeds.read_counter": "Anzahl der gelesenen Artikel",
+    "page.feeds.total_counter": "Anzahl der Einträge insgesamt",
     "page.feeds.error_count": [
         "%d Fehler",
         "%d Fehler"

--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "Last check:",
     "page.feeds.unread_counter": "Number of unread entries",
-    "page.feeds.read_counter": "Number of read entries",
+    "page.feeds.total_counter": "Number of total entries",
     "page.feeds.error_count": [
         "%d error",
         "%d errors"

--- a/locale/translations/es_ES.json
+++ b/locale/translations/es_ES.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Fuentes",
     "page.feeds.last_check": "Última verificación:",
     "page.feeds.unread_counter": "Número de entradas no leídas",
-    "page.feeds.read_counter": "Número de entradas leídas",
+    "page.feeds.total_counter": "Número de entradas total",
     "page.feeds.error_count": [
         "%d error",
         "%d errores"

--- a/locale/translations/fr_FR.json
+++ b/locale/translations/fr_FR.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Abonnements",
     "page.feeds.last_check": "Dernière vérification :",
     "page.feeds.unread_counter": "Nombre d'entrées non lues",
-    "page.feeds.read_counter": "Nombre d'entrées lues",
+    "page.feeds.total_counter": "Nombre total d'entrées",
     "page.feeds.error_count": [
         "%d erreur",
         "%d erreurs"

--- a/locale/translations/it_IT.json
+++ b/locale/translations/it_IT.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Feed",
     "page.feeds.last_check": "Ultimo controllo:",
     "page.feeds.unread_counter": "Numero di voci non lette",
-    "page.feeds.read_counter": "Numero di voci lette",
+    "page.feeds.total_counter": "Numero di voci totali",
     "page.feeds.error_count": [
         "%d errore",
         "%d errori"

--- a/locale/translations/ja_JP.json
+++ b/locale/translations/ja_JP.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "フィード一覧",
     "page.feeds.last_check": "最終チェック:",
     "page.feeds.unread_counter": "未読記事の数",
-    "page.feeds.read_counter": "既読記事の数",
+    "page.feeds.total_counter": "総エントリ数",
     "page.feeds.error_count": [
         "%d 個のエラー",
         "%d 個のエラー"

--- a/locale/translations/nl_NL.json
+++ b/locale/translations/nl_NL.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "Laatste update:",
     "page.feeds.unread_counter": "Aantal ongelezen vermeldingen",
-    "page.feeds.read_counter": "Aantal gelezen vermeldingen",
+    "page.feeds.total_counter": "Totaal aantal inzendingen",
     "page.feeds.error_count": [
         "%d error",
         "%d errors"

--- a/locale/translations/pl_PL.json
+++ b/locale/translations/pl_PL.json
@@ -100,7 +100,7 @@
     "page.feeds.title": "Kanały",
     "page.feeds.last_check": "Ostatnia aktualizacja:",
     "page.feeds.unread_counter": "Liczba nieprzeczytanych wpisów",
-    "page.feeds.read_counter": "Liczba przeczytanych wpisów",
+    "page.feeds.total_counter": "Liczba wszystkich wpisów",
     "page.feeds.error_count": [
         "%d błąd",
         "%d błąd",

--- a/locale/translations/pt_BR.json
+++ b/locale/translations/pt_BR.json
@@ -99,7 +99,7 @@
     "page.feeds.title": "Fontes",
     "page.feeds.last_check": "Última verificação:",
     "page.feeds.unread_counter": "Numero de itens não lidos",
-    "page.feeds.read_counter": "Número de itens lidos",
+    "page.feeds.total_counter": "Número de entradas totais",
     "page.feeds.error_count": [
         "%d erro",
         "%d erros"

--- a/locale/translations/ru_RU.json
+++ b/locale/translations/ru_RU.json
@@ -100,7 +100,7 @@
     "page.feeds.title": "Подписки",
     "page.feeds.last_check": "Последняя проверка:",
     "page.feeds.unread_counter": "Количество непрочитанных записей",
-    "page.feeds.read_counter": "Количество прочитанных записей",
+    "page.feeds.total_counter": "Количество полных записей",
     "page.feeds.error_count": [
         "%d ошибка",
         "%d ошибки",

--- a/locale/translations/zh_CN.json
+++ b/locale/translations/zh_CN.json
@@ -98,7 +98,7 @@
     "page.feeds.title": "源",
     "page.feeds.last_check": "最后检查时间：",
     "page.feeds.unread_counter": "未读条目数",
-    "page.feeds.read_counter": "读取条目数",
+    "page.feeds.total_counter": "总条目数",
     "page.feeds.error_count": [
         "%d 错误"
     ],

--- a/model/feed.go
+++ b/model/feed.go
@@ -51,6 +51,7 @@ type Feed struct {
 	Icon               *FeedIcon `json:"icon"`
 	UnreadCount        int       `json:"-"`
 	ReadCount          int       `json:"-"`
+	TotalCount         int       `json:"-"`
 }
 
 func (f *Feed) String() string {

--- a/storage/feed_query_builder.go
+++ b/storage/feed_query_builder.go
@@ -201,6 +201,7 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			c.title as category_title,
 			COALESCE(entries_count.read_count, 0) as read_count,
 			COALESCE(entries_count.unread_count, 0) as unread_count,
+			COALESCE(read_count + unread_count, 0) as total_count,
 			fi.icon_id,
 			u.timezone
 		FROM
@@ -258,6 +259,7 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			&feed.Category.Title,
 			&feed.ReadCount,
 			&feed.UnreadCount,
+			&feed.TotalCount,
 			&iconID,
 			&tz,
 		)

--- a/storage/feed_query_builder.go
+++ b/storage/feed_query_builder.go
@@ -24,7 +24,6 @@ type FeedQueryBuilder struct {
 	offset            int
 	withCounters      bool
 	counterJoinFeeds  bool
-	counterArgs       []interface{}
 	counterConditions []string
 }
 
@@ -34,18 +33,16 @@ func NewFeedQueryBuilder(store *Storage, userID int64) *FeedQueryBuilder {
 		store:             store,
 		args:              []interface{}{userID},
 		conditions:        []string{"f.user_id = $1"},
-		counterArgs:       []interface{}{userID, model.EntryStatusRead, model.EntryStatusUnread},
-		counterConditions: []string{"e.user_id = $1", "e.status IN ($2, $3)"},
+		counterConditions: []string{fmt.Sprintf("e.user_id = %v", userID)},
 	}
 }
 
 // WithCategoryID filter by category ID.
 func (f *FeedQueryBuilder) WithCategoryID(categoryID int64) *FeedQueryBuilder {
 	if categoryID > 0 {
-		f.conditions = append(f.conditions, fmt.Sprintf("f.category_id = $%d", len(f.args)+1))
 		f.args = append(f.args, categoryID)
-		f.counterConditions = append(f.counterConditions, fmt.Sprintf("f.category_id = $%d", len(f.counterArgs)+1))
-		f.counterArgs = append(f.counterArgs, categoryID)
+		f.conditions = append(f.conditions, fmt.Sprintf("f.category_id = $%d", len(f.args)))
+		f.counterConditions = append(f.counterConditions, fmt.Sprintf("f.category_id = %v", categoryID))
 		f.counterJoinFeeds = true
 	}
 	return f
@@ -54,8 +51,8 @@ func (f *FeedQueryBuilder) WithCategoryID(categoryID int64) *FeedQueryBuilder {
 // WithFeedID filter by feed ID.
 func (f *FeedQueryBuilder) WithFeedID(feedID int64) *FeedQueryBuilder {
 	if feedID > 0 {
-		f.conditions = append(f.conditions, fmt.Sprintf("f.id = $%d", len(f.args)+1))
 		f.args = append(f.args, feedID)
+		f.conditions = append(f.conditions, fmt.Sprintf("f.id = $%d", len(f.args)))
 	}
 	return f
 }
@@ -91,11 +88,17 @@ func (f *FeedQueryBuilder) WithOffset(offset int) *FeedQueryBuilder {
 }
 
 func (f *FeedQueryBuilder) buildCondition() string {
-	return strings.Join(f.conditions, " AND ")
+	if len(f.conditions) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("WHERE %s", strings.Join(f.conditions, " AND "))
 }
 
 func (f *FeedQueryBuilder) buildCounterCondition() string {
-	return strings.Join(f.counterConditions, " AND ")
+	if len(f.counterConditions) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("WHERE %s", strings.Join(f.counterConditions, " AND "))
 }
 
 func (f *FeedQueryBuilder) buildSorting() string {
@@ -139,6 +142,36 @@ func (f *FeedQueryBuilder) GetFeed() (*model.Feed, error) {
 	return feeds[0], nil
 }
 
+func (f *FeedQueryBuilder) countQuery() string {
+	if f.withCounters {
+		joins := ""
+		if f.counterJoinFeeds {
+			joins = "LEFT JOIN feeds f ON f.id=e.feed_id"
+		}
+		countQuery := `
+			SELECT
+				e.feed_id as feed_id,
+				count(*) filter (where e.status='%s') as read_count,
+				count(*) filter (where e.status='%s') as unread_count
+			FROM
+				entries e
+			%s 
+			%s 
+			GROUP BY
+				e.feed_id
+		`
+		return fmt.Sprintf(countQuery, model.EntryStatusRead, model.EntryStatusUnread, joins, f.buildCounterCondition())
+	}
+	return `
+		SELECT 
+			f.id as feed_id,
+			0 as read_count,
+			0 as unread_count
+		FROM
+			feeds f
+	`
+}
+
 // GetFeeds returns a list of feeds that match the condition.
 func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 	var query = `
@@ -166,6 +199,8 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			f.disabled,
 			f.category_id,
 			c.title as category_title,
+			COALESCE(entries_count.read_count, 0) as read_count,
+			COALESCE(entries_count.unread_count, 0) as unread_count,
 			fi.icon_id,
 			u.timezone
 		FROM
@@ -176,22 +211,19 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			feed_icons fi ON fi.feed_id=f.id
 		LEFT JOIN
 			users u ON u.id=f.user_id
-		WHERE %s 
-		%s
+		LEFT JOIN 
+			(%s) entries_count on entries_count.feed_id=f.id
+		%s 
+		%s 
 	`
 
-	query = fmt.Sprintf(query, f.buildCondition(), f.buildSorting())
+	query = fmt.Sprintf(query, f.countQuery(), f.buildCondition(), f.buildSorting())
 
 	rows, err := f.store.db.Query(query, f.args...)
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch feeds: %w`, err)
 	}
 	defer rows.Close()
-
-	readCounters, unreadCounters, err := f.fetchFeedCounter()
-	if err != nil {
-		return nil, err
-	}
 
 	feeds := make(model.Feeds, 0)
 	for rows.Next() {
@@ -224,6 +256,8 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			&feed.Disabled,
 			&feed.Category.ID,
 			&feed.Category.Title,
+			&feed.ReadCount,
+			&feed.UnreadCount,
 			&iconID,
 			&tz,
 		)
@@ -238,70 +272,10 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			feed.Icon = &model.FeedIcon{FeedID: feed.ID, IconID: 0}
 		}
 
-		if readCounters != nil {
-			if count, found := readCounters[feed.ID]; found {
-				feed.ReadCount = count
-			}
-		}
-		if unreadCounters != nil {
-			if count, found := unreadCounters[feed.ID]; found {
-				feed.UnreadCount = count
-			}
-		}
-
 		feed.CheckedAt = timezone.Convert(tz, feed.CheckedAt)
 		feed.Category.UserID = feed.UserID
 		feeds = append(feeds, &feed)
 	}
 
 	return feeds, nil
-}
-
-func (f *FeedQueryBuilder) fetchFeedCounter() (unreadCounters map[int64]int, readCounters map[int64]int, err error) {
-	if !f.withCounters {
-		return nil, nil, nil
-	}
-	query := `
-		SELECT
-			e.feed_id,
-			e.status,
-			count(*)
-		FROM
-			entries e
-		%s 
-		WHERE
-			%s 
-		GROUP BY
-			e.feed_id, e.status
-	`
-	join := ""
-	if f.counterJoinFeeds {
-		join = "LEFT JOIN feeds f ON f.id=e.feed_id"
-	}
-	query = fmt.Sprintf(query, join, f.buildCounterCondition())
-
-	rows, err := f.store.db.Query(query, f.counterArgs...)
-	if err != nil {
-		return nil, nil, fmt.Errorf(`store: unable to fetch feed counts: %w`, err)
-	}
-	defer rows.Close()
-
-	readCounters = make(map[int64]int)
-	unreadCounters = make(map[int64]int)
-	for rows.Next() {
-		var feedID int64
-		var status string
-		var count int
-		if err := rows.Scan(&feedID, &status, &count); err != nil {
-			return nil, nil, fmt.Errorf(`store: unable to fetch feed counter row: %w`, err)
-		}
-
-		if status == model.EntryStatusRead {
-			readCounters[feedID] = count
-		} else if status == model.EntryStatusUnread {
-			unreadCounters[feedID] = count
-		}
-	}
-
-	return readCounters, unreadCounters, nil
 }

--- a/template/common.go
+++ b/template/common.go
@@ -36,7 +36,7 @@ var templateCommonMap = map[string]string{
                     <a href="{{ route "feedEntries" "feedID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="feed-entries-counter">
-                    (<span title="{{ t "page.feeds.unread_counter" }}">{{ .UnreadCount }}</span>/<span title="{{ t "page.feeds.read_counter" }}">{{ .ReadCount }}</span>)
+                    (<span title="{{ t "page.feeds.unread_counter" }}">{{ .UnreadCount }}</span>/<span title="{{ t "page.feeds.total_counter" }}">{{ .TotalCount }}</span>)
                 </span>
                 <span class="category">
                     <a href="{{ route "categoryEntries" "categoryID" .Category.ID }}">{{ .Category.Title }}</a>
@@ -538,7 +538,7 @@ SOFTWARE.
 
 var templateCommonMapChecksums = map[string]string{
 	"entry_pagination": "cdca9cf12586e41e5355190b06d9168f57f77b85924d1e63b13524bc15abcbf6",
-	"feed_list":        "931e43d328a116318c510de5658c688cd940b934c86b6ec82a472e1f81e020ae",
+	"feed_list":        "3071310eb9fbe7dbdacb5cd5cdb0636177d8954021620fac4bcb1f399f005f91",
 	"feed_menu":        "318d8662dda5ca9dfc75b909c8461e79c86fb5082df1428f67aaf856f19f4b50",
 	"icons":            "7161afa4cce46245a99cb1e49a605d3ff30e907c3f568ef9c17218718d20e042",
 	"item_meta":        "fefa219c8296f0370632336ed59a2c8b0c2146ee77f3b10de1d9b87982219dc5",

--- a/template/html/common/feed_list.html
+++ b/template/html/common/feed_list.html
@@ -11,7 +11,7 @@
                     <a href="{{ route "feedEntries" "feedID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="feed-entries-counter">
-                    (<span title="{{ t "page.feeds.unread_counter" }}">{{ .UnreadCount }}</span>/<span title="{{ t "page.feeds.read_counter" }}">{{ .ReadCount }}</span>)
+                    (<span title="{{ t "page.feeds.unread_counter" }}">{{ .UnreadCount }}</span>/<span title="{{ t "page.feeds.total_counter" }}">{{ .TotalCount }}</span>)
                 </span>
                 <span class="category">
                     <a href="{{ route "categoryEntries" "categoryID" .Category.ID }}">{{ .Category.Title }}</a>


### PR DESCRIPTION
Display the number of total entries in UI, instead of the read entries.

I think the number of total entries is more useful than the number of read entries.
The UI could be read as, for example. "you have 789 unread articles out of 123456 articles."

When we sort we are also more interested in total articles instead of read articles, especially considering that we cannot distinguish between "mark-as-read" and "opened" articles today.
The number of total entries will indicate how many articles the feed generates.
The number of "opened entries " will indicate how often we interact with that feed, whether those articles are interested to us.
What does the number of "read" article (including both "mark-as-read" and "opened") tell us?

Depends on #988