### PR TITLE
Reformat some Go files

### DIFF
--- a/model/feed.go
+++ b/model/feed.go
@@ -15,8 +15,8 @@ import (
 
 // List of supported schedulers.
 const (
-	SchedulerRoundRobin         = "round_robin"
-	SchedulerEntryFrequency     = "entry_frequency"
+	SchedulerRoundRobin     = "round_robin"
+	SchedulerEntryFrequency = "entry_frequency"
 	// Default settings for the feed query builder
 	DefaultFeedSorting          = "parsing_error_count"
 	DefaultFeedSortingDirection = "desc"

--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -229,4 +229,3 @@ func replaceCustom(entryContent string, searchTerm string, replaceTerm string) s
 	}
 	return entryContent
 }
-

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -5,8 +5,8 @@
 package rewrite // import "miniflux.app/reader/rewrite"
 
 import (
-	"strings"
 	"regexp"
+	"strings"
 
 	"miniflux.app/logger"
 	"miniflux.app/url"

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -125,7 +125,7 @@ func (s *Storage) FeedsWithCounters(userID int64) (model.Feeds, error) {
 	builder.WithCounters()
 	builder.WithOrder(model.DefaultFeedSorting)
 	builder.WithDirection(model.DefaultFeedSortingDirection)
-	return  builder.GetFeeds()
+	return builder.GetFeeds()
 }
 
 // FeedsByCategoryWithCounters returns all feeds of the given user/category with counters of read and unread entries.
@@ -176,7 +176,7 @@ func (s *Storage) FeedByID(userID, feedID int64) (*model.Feed, error) {
 	case err != nil:
 		return nil, fmt.Errorf(`store: unable to fetch feed #%d: %v`, feedID, err)
 	}
-	
+
 	return feed, nil
 }
 

--- a/storage/feed_query_builder.go
+++ b/storage/feed_query_builder.go
@@ -15,17 +15,17 @@ import (
 
 // FeedQueryBuilder builds a SQL query to fetch feeds.
 type FeedQueryBuilder struct {
-	store              *Storage
-	args               []interface{}
-	conditions         []string
-	order              string
-	direction          string
-	limit              int
-	offset             int
-	withCounters       bool
-	counterJoinFeeds    bool
-	counterArgs        []interface{}
-	counterConditions  []string
+	store             *Storage
+	args              []interface{}
+	conditions        []string
+	order             string
+	direction         string
+	limit             int
+	offset            int
+	withCounters      bool
+	counterJoinFeeds  bool
+	counterArgs       []interface{}
+	counterConditions []string
 }
 
 // NewFeedQueryBuilder returns a new FeedQueryBuilder.

--- a/ui/login_show.go
+++ b/ui/login_show.go
@@ -7,8 +7,8 @@ package ui // import "miniflux.app/ui"
 import (
 	"net/http"
 
-	"miniflux.app/http/response/html"
 	"miniflux.app/http/request"
+	"miniflux.app/http/response/html"
 	"miniflux.app/http/route"
 	"miniflux.app/ui/session"
 	"miniflux.app/ui/view"

--- a/ui/oauth2.go
+++ b/ui/oauth2.go
@@ -6,6 +6,7 @@ package ui // import "miniflux.app/ui"
 
 import (
 	"context"
+
 	"miniflux.app/config"
 	"miniflux.app/oauth2"
 )


### PR DESCRIPTION
When working on #994 I noticed that some Go files are not formatted with
`gofmt`.

This PR fixes this.