### PR TITLE
ETag value is not set correctly in HTTP client (regression)

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -115,7 +115,7 @@ func (c *Client) WithAuthorization(authorization string) *Client {
 
 // WithCacheHeaders defines caching headers.
 func (c *Client) WithCacheHeaders(etagHeader, lastModifiedHeader string) *Client {
-	c.requestLastModifiedHeader = etagHeader
+	c.requestEtagHeader = etagHeader
 	c.requestLastModifiedHeader = lastModifiedHeader
 	return c
 }


### PR DESCRIPTION
Bug introduced after refactoring.

See commit 16b7b3bc3e4237abbacdf8695a685ca9a03dc5bb.