### PR TITLE
Update date parser to fix another time zone issue

### DIFF
--- a/reader/date/parser.go
+++ b/reader/date/parser.go
@@ -340,5 +340,9 @@ func parseLocalTimeDates(layout, ds string) (t time.Time, err error) {
 		loc, _ = time.LoadLocation("America/Los_Angeles")
 	}
 
+	if strings.HasSuffix(ds, "EST") || strings.HasSuffix(ds, "EDT") {
+		loc, _ = time.LoadLocation("America/New_York")
+	}
+
 	return time.ParseInLocation(layout, ds, loc)
 }

--- a/reader/date/parser_test.go
+++ b/reader/date/parser_test.go
@@ -96,6 +96,34 @@ func TestParseRSSDatePST(t *testing.T) {
 	}
 }
 
+func TestParseRSSDateEST(t *testing.T) {
+	date, err := Parse("Wed, 10 Feb 2021 22:46:00 EST")
+	if err != nil {
+		t.Fatalf(`RSS dates with EST timezone should be parsed correctly: %v`, err)
+	}
+
+	expectedTS := int64(1613015160)
+	if date.Unix() != expectedTS {
+		t.Errorf(`The Unix timestamp should be %v instead of %v`, expectedTS, date.Unix())
+	}
+
+	expectedLocation := "America/New_York"
+	if date.Location().String() != expectedLocation {
+		t.Errorf(`The location should be %q instead of %q`, expectedLocation, date.Location())
+	}
+
+	name, offset := date.Zone()
+
+	expectedName := "EST"
+	if name != expectedName {
+		t.Errorf(`The zone name should be %q instead of %q`, expectedName, name)
+	}
+
+	expectedOffset := -18000
+	if offset != expectedOffset {
+		t.Errorf(`The offset should be %v instead of %v`, expectedOffset, offset)
+	}
+}
 func TestParseRSSDateOffset(t *testing.T) {
 	date, err := Parse("Sun, 28 Oct 2018 13:48:00 +0100")
 	if err != nil {


### PR DESCRIPTION
The Washington Post has its feeds with EST, which is getting parsed by miniflux as UTC, and showing up as 8 hours off.
See http://feeds.washingtonpost.com/rss/politics for an example.
This fix applies a similar workaround for EST/EDT as was done for PST/PDT.