### PR TITLE
Rename storage certificate cache

### DIFF
--- a/service/httpd/httpd.go
+++ b/service/httpd/httpd.go
@@ -121,7 +121,7 @@ func tlsConfig() *tls.Config {
 func startAutoCertTLSServer(server *http.Server, certDomain string, store *storage.Storage) {
 	server.Addr = ":https"
 	certManager := autocert.Manager{
-		Cache:      storage.NewCache(store),
+		Cache:      storage.NewCertificateCache(store),
 		Prompt:     autocert.AcceptTOS,
 		HostPolicy: autocert.HostWhitelist(certDomain),
 	}

--- a/storage/certificate_cache.go
+++ b/storage/certificate_cache.go
@@ -12,24 +12,24 @@ import (
 )
 
 // Making sure that we're adhering to the autocert.Cache interface.
-var _ autocert.Cache = (*Cache)(nil)
+var _ autocert.Cache = (*CertificateCache)(nil)
 
-// Cache provides a SQL backend to the autocert cache.
-type Cache struct {
+// CertificateCache provides a SQL backend to the autocert cache.
+type CertificateCache struct {
 	storage *Storage
 }
 
-// NewCache creates an cache instance that can be used with autocert.Cache.
+// NewCertificateCache creates an cache instance that can be used with autocert.Cache.
 // It returns any errors that could happen while connecting to SQL.
-func NewCache(storage *Storage) *Cache {
-	return &Cache{
+func NewCertificateCache(storage *Storage) *CertificateCache {
+	return &CertificateCache{
 		storage: storage,
 	}
 }
 
 // Get returns a certificate data for the specified key.
 // If there's no such key, Get returns ErrCacheMiss.
-func (c *Cache) Get(ctx context.Context, key string) ([]byte, error) {
+func (c *CertificateCache) Get(ctx context.Context, key string) ([]byte, error) {
 	query := `SELECT data::bytea FROM acme_cache WHERE key = $1`
 	var data []byte
 	err := c.storage.db.QueryRowContext(ctx, query, key).Scan(&data)
@@ -41,7 +41,7 @@ func (c *Cache) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 // Put stores the data in the cache under the specified key.
-func (c *Cache) Put(ctx context.Context, key string, data []byte) error {
+func (c *CertificateCache) Put(ctx context.Context, key string, data []byte) error {
 	query := `INSERT INTO acme_cache (key, data, updated_at) VALUES($1, $2::bytea, now())
 	          ON CONFLICT (key) DO UPDATE SET data = $2::bytea, updated_at = now()`
 	_, err := c.storage.db.ExecContext(ctx, query, key, data)
@@ -53,7 +53,7 @@ func (c *Cache) Put(ctx context.Context, key string, data []byte) error {
 
 // Delete removes a certificate data from the cache under the specified key.
 // If there's no such key in the cache, Delete returns nil.
-func (c *Cache) Delete(ctx context.Context, key string) error {
+func (c *CertificateCache) Delete(ctx context.Context, key string) error {
 	query := `DELETE FROM acme_cache WHERE key = $1`
 	_, err := c.storage.db.ExecContext(ctx, query, key)
 	if err != nil {


### PR DESCRIPTION
This cache is used only for ACME certificates.

Being explicit is always better.