### PR TITLE
Remove deprecated io/ioutil package

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -20,7 +20,7 @@ package main
 
 import (
 	"fmt"
-    "io/ioutil"
+	"os"
 
 	miniflux "miniflux.app/client"
 )
@@ -47,7 +47,7 @@ func main() {
         return
     }
 
-    err = ioutil.WriteFile("opml.xml", opml, 0644)
+    err = os.WriteFile("opml.xml", opml, 0644)
     if err != nil {
         fmt.Println(err)
         return

--- a/client/client.go
+++ b/client/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strconv"
 )
@@ -270,7 +269,7 @@ func (c *Client) Export() ([]byte, error) {
 	}
 	defer body.Close()
 
-	opml, err := ioutil.ReadAll(body)
+	opml, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -87,7 +86,7 @@ func (r *request) execute(method, path string, data interface{}) (io.ReadCloser,
 		case io.ReadCloser:
 			request.Body = data.(io.ReadCloser)
 		default:
-			request.Body = ioutil.NopCloser(bytes.NewBuffer(r.toJSON(data)))
+			request.Body = io.NopCloser(bytes.NewBuffer(r.toJSON(data)))
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,7 +5,6 @@
 package config // import "miniflux.app/config"
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -1309,7 +1308,7 @@ DEBUG = yes
 Invalid text
 `)
 
-	tmpfile, err := ioutil.TempFile(".", "miniflux.*.unit_test.conf")
+	tmpfile, err := os.CreateTemp(".", "miniflux.*.unit_test.conf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/parser.go
+++ b/config/parser.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	url_parser "net/url"
 	"os"
 	"strconv"
@@ -269,7 +268,7 @@ func parseStringList(value string, fallback []string) []string {
 }
 
 func readSecretFile(filename, fallback string) string {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return fallback
 	}

--- a/generate.go
+++ b/generate.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func NewBundle(pkg, mapName, importPath string) *Bundle {
 }
 
 func readFile(filename string) []byte {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -219,7 +218,7 @@ func (c *Client) executeRequest(request *http.Request) (*Response, error) {
 		return nil, fmt.Errorf("client: response too large (%d bytes)", resp.ContentLength)
 	}
 
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("client: error while reading body %v", err)
 	}

--- a/http/client/response.go
+++ b/http/client/response.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -87,7 +86,7 @@ func (r *Response) IsModified(etag, lastModified string) bool {
 // - Feeds with encoding specified only in XML document and not in HTTP header
 // - Feeds with wrong encoding defined and already in UTF-8
 func (r *Response) EnsureUnicodeBody() (err error) {
-	buffer, err := ioutil.ReadAll(r.Body)
+	buffer, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}
@@ -116,6 +115,6 @@ func (r *Response) EnsureUnicodeBody() (err error) {
 
 // BodyAsString returns the response body as string.
 func (r *Response) BodyAsString() string {
-	bytes, _ := ioutil.ReadAll(r.Body)
+	bytes, _ := io.ReadAll(r.Body)
 	return string(bytes)
 }

--- a/http/client/response_test.go
+++ b/http/client/response_test.go
@@ -6,7 +6,7 @@ package client // import "miniflux.app/http/client"
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -129,7 +129,7 @@ func TestEnsureUnicodeWithHTMLDocuments(t *testing.T) {
 	}
 
 	for _, tc := range unicodeTestCases {
-		content, err := ioutil.ReadFile("testdata/" + tc.filename)
+		content, err := os.ReadFile("testdata/" + tc.filename)
 		if err != nil {
 			t.Fatalf(`Unable to read file %q: %v`, tc.filename, err)
 		}

--- a/integration/pocket/connector.go
+++ b/integration/pocket/connector.go
@@ -7,7 +7,7 @@ package pocket // import "miniflux.app/integration/pocket"
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 
 	"miniflux.app/http/client"
@@ -35,7 +35,7 @@ func (c *Connector) RequestToken(redirectURL string) (string, error) {
 		return "", fmt.Errorf("pocket: unable to fetch request token, status=%d", response.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("pocket: unable to read response body: %v", err)
 	}
@@ -70,7 +70,7 @@ func (c *Connector) AccessToken(requestToken string) (string, error) {
 		return "", fmt.Errorf("pocket: unable to fetch access token, status=%d", response.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("pocket: unable to read response body: %v", err)
 	}

--- a/reader/encoding/encoding.go
+++ b/reader/encoding/encoding.go
@@ -7,7 +7,6 @@ package encoding // import "miniflux.app/reader/encoding"
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"unicode/utf8"
 
 	"golang.org/x/net/html/charset"
@@ -25,7 +24,7 @@ import (
 // - Feeds with encoding specified only in XML document and not in HTTP header
 // - Feeds with wrong encoding defined and already in UTF-8
 func CharsetReader(label string, input io.Reader) (io.Reader, error) {
-	buffer, _ := ioutil.ReadAll(input)
+	buffer, _ := io.ReadAll(input)
 	r := bytes.NewReader(buffer)
 
 	// The document is already UTF-8, do not do anything (avoid double-encoding).

--- a/reader/icon/finder.go
+++ b/reader/icon/finder.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"miniflux.app/config"
@@ -104,7 +103,7 @@ func downloadIcon(iconURL string, fetchViaProxy bool) (*model.Icon, error) {
 		return nil, fmt.Errorf("unable to download icon: status=%d", response.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read downloaded icon: %v", err)
 	}

--- a/reader/parser/parser_test.go
+++ b/reader/parser/parser_test.go
@@ -6,7 +6,7 @@ package parser // import "miniflux.app/reader/parser"
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"miniflux.app/http/client"
@@ -329,7 +329,7 @@ func TestDifferentEncodingWithResponse(t *testing.T) {
 	}
 
 	for _, tc := range unicodeTestCases {
-		content, err := ioutil.ReadFile("testdata/" + tc.filename)
+		content, err := os.ReadFile("testdata/" + tc.filename)
 		if err != nil {
 			t.Fatalf(`Unable to read file %q: %v`, tc.filename, err)
 		}

--- a/reader/scraper/scraper_test.go
+++ b/reader/scraper/scraper_test.go
@@ -6,7 +6,7 @@ package scraper // import "miniflux.app/reader/scraper"
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -54,7 +54,7 @@ func TestSelectorRules(t *testing.T) {
 	}
 
 	for filename, rule := range ruleTestCases {
-		html, err := ioutil.ReadFile("testdata/" + filename)
+		html, err := os.ReadFile("testdata/" + filename)
 		if err != nil {
 			t.Fatalf(`Unable to read file %q: %v`, filename, err)
 		}
@@ -64,7 +64,7 @@ func TestSelectorRules(t *testing.T) {
 			t.Fatalf(`Scraping error for %q - %q: %v`, filename, rule, err)
 		}
 
-		expectedResult, err := ioutil.ReadFile("testdata/" + filename + "-result")
+		expectedResult, err := os.ReadFile("testdata/" + filename + "-result")
 		if err != nil {
 			t.Fatalf(`Unable to read file %q: %v`, filename, err)
 		}

--- a/reader/xml/decoder.go
+++ b/reader/xml/decoder.go
@@ -9,7 +9,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"miniflux.app/reader/encoding"
@@ -18,7 +17,7 @@ import (
 // NewDecoder returns a XML decoder that filters illegal characters.
 func NewDecoder(data io.Reader) *xml.Decoder {
 	var decoder *xml.Decoder
-	buffer, _ := ioutil.ReadAll(data)
+	buffer, _ := io.ReadAll(data)
 	enc := procInst("encoding", string(buffer))
 	if enc != "" && enc != "utf-8" && enc != "UTF-8" && !strings.EqualFold(enc, "utf-8") {
 		// filter invalid chars later within decoder.CharsetReader
@@ -36,7 +35,7 @@ func NewDecoder(data io.Reader) *xml.Decoder {
 		if err != nil {
 			return nil, err
 		}
-		rawData, err := ioutil.ReadAll(utf8Reader)
+		rawData, err := io.ReadAll(utf8Reader)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to read data: %q", err)
 		}

--- a/tests/import_export_test.go
+++ b/tests/import_export_test.go
@@ -8,7 +8,7 @@ package tests
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 )
@@ -39,7 +39,7 @@ func TestImport(t *testing.T) {
 	</opml>`
 
 	b := bytes.NewReader([]byte(data))
-	err := client.Import(ioutil.NopCloser(b))
+	err := client.Import(io.NopCloser(b))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Miniflux now requires at least Go 1.16 and io/util is deprecated.

https://golang.org/doc/go1.16#ioutil