### PR TITLE
Avoid showing a broken image when there is no feed icon

### DIFF
--- a/template/templates/common/feed_list.html
+++ b/template/templates/common/feed_list.html
@@ -4,7 +4,7 @@
         <article class="item {{ if ne .ParsingErrorCount 0 }}feed-parsing-error{{ end }}">
             <div class="item-header" dir="auto">
                 <span class="item-title">
-                    {{ if .Icon }}
+                    {{ if and (.Icon) (gt .Icon.IconID 0) }}
                         <img src="{{ route "icon" "iconID" .Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Title }}">
                     {{ end }}
                     {{ if .Disabled }} 🚫 {{ end }}


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
