### PR TITLE
feed_entries: Add mark feed as read option

### DIFF
--- a/template/templates/common/feed_list.html
+++ b/template/templates/common/feed_list.html
@@ -44,7 +44,13 @@
                     </li>
                     {{ if .UnreadCount }}
                       <li>
-                        <a href="{{ route "markFeedAsRead" "feedID" .ID }}">{{ template "icon_read" }}<span class="icon-label">{{ t "menu.mark_all_as_read" }}</span></a>
+                        <a href="#"
+                            data-confirm="true"
+                            data-label-question="{{ t "confirm.question" }}"
+                            data-label-yes="{{ t "confirm.yes" }}"
+                            data-label-no="{{ t "confirm.no" }}"
+                            data-label-loading="{{ t "confirm.loading" }}"
+                            data-url="{{ route "markFeedAsRead" "feedID" .ID }}">{{ template "icon_read" }}<span class="icon-label">{{ t "menu.mark_all_as_read" }}</span></a>
                       </li>
                     {{ end }}
                 </ul>

--- a/template/templates/views/feed_entries.html
+++ b/template/templates/views/feed_entries.html
@@ -17,6 +17,15 @@
                 data-label-loading="{{ t "confirm.loading" }}"
                 data-show-only-unread="{{ if .showOnlyUnreadEntries }}1{{ end }}">{{ t "menu.mark_page_as_read" }}</a>
         </li>
+        <li>
+            <a href="#"
+                data-confirm="true"
+                data-label-question="{{ t "confirm.question" }}"
+                data-label-yes="{{ t "confirm.yes" }}"
+                data-label-no="{{ t "confirm.no" }}"
+                data-label-loading="{{ t "confirm.loading" }}"
+                data-url="{{ route "markFeedAsRead" "feedID" .feed.ID }}">{{ t "menu.mark_all_as_read" }}</a>
+        </li>
         {{ end }}
         {{ if .showOnlyUnreadEntries }}
         <li>

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -80,7 +80,7 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	uiRouter.HandleFunc("/feed/{feedID}/entries/all", handler.showFeedEntriesAllPage).Name("feedEntriesAll").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/feed/{feedID}/entry/{entryID}", handler.showFeedEntryPage).Name("feedEntry").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/feed/icon/{iconID}", handler.showIcon).Name("icon").Methods(http.MethodGet)
-	uiRouter.HandleFunc("/feed/{feedID}/mark-all-as-read", handler.markFeedAsRead).Name("markFeedAsRead").Methods(http.MethodGet)
+	uiRouter.HandleFunc("/feed/{feedID}/mark-all-as-read", handler.markFeedAsRead).Name("markFeedAsRead").Methods(http.MethodPost)
 
 	// Category pages.
 	uiRouter.HandleFunc("/category/{categoryID}/entry/{entryID}", handler.showCategoryEntryPage).Name("categoryEntry").Methods(http.MethodGet)


### PR DESCRIPTION
Why:
e1c9e6ccb4607eeab2 added the support to mark a feed as read from views
showing a list of feeds. However, at times it can be useful to mark an
entire feed as read from within the feed entry views, e.g. when wanting
to mark as read a feed that is dominating a category after examining a
number of entries in that feed

What:
Add an li element in feed_entries.html to allow marking the feed as read
The code has been copy pasted from e1c9e6ccb4607eeab2

This closes #721

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
