### PR TITLE
Reset scroll position on mark page as read

### DIFF
--- a/ui/static/js/app.js
+++ b/ui/static/js/app.js
@@ -106,7 +106,7 @@ function markPageAsRead() {
             }
 
             if (showOnlyUnread) {
-                window.location.reload();
+                window.location.href = window.location.href;
             } else {
                 goToPage("next", true);
             }


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

This pull request is aimed at resetting scroll position to top when marking a page as read with "Show only unread entries" enabled.

Without this change, when marking a page as read the user must scroll to top in order to see the first items of the page just loaded. This is caused by the default behavior of the user agent of restoring scroll position[1].

[1]: https://www.w3.org/TR/html52/browsers.html#scroll-restoration-mode