### PR TITLE
Implement readiness notification for systemd

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -44,6 +44,11 @@ func startDaemon(store *storage.Storage) {
 		go collector.GatherStorageMetrics()
 	}
 
+	// Notify systemd that we are ready.
+	if err := sdNotify(sdNotifyReady); err != nil {
+		logger.Error("Unable to send readiness notification to systemd: %v", err)
+	}
+
 	<-stop
 	logger.Info("Shutting down the process...")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cli/sd_notify.go
+++ b/cli/sd_notify.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Frédéric Guillot. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package cli // import "miniflux.app/cli"
+
+import (
+	"net"
+	"os"
+)
+
+const (
+	// sdNotifyReady tells the service manager that service startup is
+	// finished, or the service finished loading its configuration.
+	sdNotifyReady = "READY=1"
+)
+
+// sdNotify sends a message to systemd using the sd_notify protocol.
+// See https://www.freedesktop.org/software/systemd/man/sd_notify.html.
+func sdNotify(state string) error {
+	addr := &net.UnixAddr{
+		Net:  "unixgram",
+		Name: os.Getenv("NOTIFY_SOCKET"),
+	}
+
+	if addr.Name == "" {
+		// We're not running under systemd (NOTIFY_SOCKET has not set).
+		return nil
+	}
+
+	conn, err := net.DialUnix(addr.Net, nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if _, err = conn.Write([]byte(state)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
-github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=

--- a/packaging/systemd/miniflux.service
+++ b/packaging/systemd/miniflux.service
@@ -9,11 +9,12 @@ Description=Miniflux Feed Reader
 After=network.target postgresql.service
 
 [Service]
-Type=simple
-EnvironmentFile=/etc/miniflux.conf
-User=miniflux
+Type=notify
 ExecStart=/usr/bin/miniflux
 Restart=always
+
+EnvironmentFile=/etc/miniflux.conf
+User=miniflux
 
 # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#NoNewPrivileges=
 NoNewPrivileges=true


### PR DESCRIPTION
Set the systemd startup type to `notify`, so that startup of followup units is delayed until Miniflux signals readiness. 

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request