### PR TITLE
[wip] Support marking feed entries older than one day

### DIFF
--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -34,6 +34,7 @@
     "menu.create_category": "Create a category",
     "menu.mark_page_as_read": "Mark this page as read",
     "menu.mark_all_as_read": "Mark all as read",
+    "menu.mark_all_as_read_one_day": "Mark all as read older than 1 day",
     "menu.show_all_entries": "Show all entries",
     "menu.show_only_unread_entries": "Show only unread entries",
     "menu.refresh_feed": "Refresh",

--- a/template/templates/views/feed_entries.html
+++ b/template/templates/views/feed_entries.html
@@ -26,6 +26,15 @@
                 data-label-loading="{{ t "confirm.loading" }}"
                 data-url="{{ route "markFeedAsRead" "feedID" .feed.ID }}">{{ t "menu.mark_all_as_read" }}</a>
         </li>
+        <li>
+            <a href="#"
+               data-confirm="true"
+               data-label-question="{{ t "confirm.question" }}"
+            data-label-yes="{{ t "confirm.yes" }}"
+            data-label-no="{{ t "confirm.no" }}"
+            data-label-loading="{{ t "confirm.loading" }}"
+            data-url="{{ route "markFeedAsRead" "feedID" .feed.ID }}?before={{ .before }}">{{ t "menu.mark_all_as_read_one_day" }}</a>
+        </li>
         {{ end }}
         {{ if .showOnlyUnreadEntries }}
         <li>

--- a/ui/feed_entries.go
+++ b/ui/feed_entries.go
@@ -6,6 +6,7 @@ package ui // import "miniflux.app/ui"
 
 import (
 	"net/http"
+	"time"
 
 	"miniflux.app/http/request"
 	"miniflux.app/http/response/html"
@@ -67,6 +68,7 @@ func (h *handler) showFeedEntriesPage(w http.ResponseWriter, r *http.Request) {
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
 	view.Set("hasSaveEntry", h.store.HasSaveEntry(user.ID))
 	view.Set("showOnlyUnreadEntries", true)
+	view.Set("before", time.Now().Add(time.Duration(-24) * time.Hour).Unix())
 
 	html.OK(w, r, view.Render("feed_entries"))
 }

--- a/ui/feed_mark_as_read.go
+++ b/ui/feed_mark_as_read.go
@@ -5,11 +5,11 @@
 package ui // import "miniflux.app/ui"
 
 import (
-	"net/http"
-
 	"miniflux.app/http/request"
 	"miniflux.app/http/response/html"
 	"miniflux.app/http/route"
+	"net/http"
+	"time"
 )
 
 func (h *handler) markFeedAsRead(w http.ResponseWriter, r *http.Request) {
@@ -17,6 +17,12 @@ func (h *handler) markFeedAsRead(w http.ResponseWriter, r *http.Request) {
 	userID := request.UserID(r)
 
 	feed, err := h.store.FeedByID(userID, feedID)
+
+	before := feed.CheckedAt
+
+	if request.HasQueryParam(r, "before") {
+		before = time.Unix(request.QueryInt64Param(r, "before", 0), 0)
+	}
 
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -28,7 +34,7 @@ func (h *handler) markFeedAsRead(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = h.store.MarkFeedAsRead(userID, feedID, feed.CheckedAt); err != nil {
+	if err = h.store.MarkFeedAsRead(userID, feedID, before); err != nil {
 		html.ServerError(w, r, err)
 		return
 	}


### PR DESCRIPTION
One of the features I miss from Tiny Tiny RSS is the ability to mark all items in a feed as read older than a certain duration ago. It has a dropdown with 1 day / 7 day / 30 days options for each view, regardless of a single feed or a collection of feeds.

<img width="794" alt="Screen Shot 2021-03-28 at 2 21 05 PM" src="https://user-images.githubusercontent.com/255023/112763043-d84fa580-8fd0-11eb-94c1-d000b8018b63.png">

This is a very rough first take at supporting marking entries older than one day. In particular, this is useful for high-traffic feeds where the content becomes invalid after a period of time, such as those from forums such as RedFlagDeals.com.

I have a few questions I'd like feedback on:

1. As a new contributor, I was a little confused when I started by reading https://miniflux.app/docs/api.html and then discovered that the UI has an entirely separate set of routes it uses. Should new work go against the `/v1/` API, or should those docs be updated to indicate they're for the "public" API of miniflux only?
2. I didn't see any examples of POSTs with parameters used by the UI. If there's one, I'd appreciate a pointer, as I'm not sure if I should be using query parameters or a JSON object in the POST body.
3. I'm open to suggestions on wording / positioning / etc of the new link. I feel like it doesn't scale well if we wanted to support multiple "time ago" options. I thought about setting the link text to just `(than 1 day)`, but I think that isn't good from an accessibility perspective.

Do you follow the guidelines?

- [ ] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
