### PR TITLE
only show pagination on needed

### DIFF
--- a/template/templates/common/pagination.html
+++ b/template/templates/common/pagination.html
@@ -1,6 +1,6 @@
 {{ define "pagination" }}
 <div class="pagination">
-    <div class="pagination-prev">
+    <div class="pagination-prev {{ if not .ShowPrev }}invisible{{end}}">
         {{ if .ShowPrev }}
             <a href="{{ .Route }}{{ if gt .PrevOffset 0 }}?offset={{ .PrevOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}{{ else }}{{ if .SearchQuery }}?q={{ .SearchQuery }}{{ end }}{{ end }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
         {{ else }}
@@ -8,7 +8,7 @@
         {{ end }}
     </div>
 
-    <div class="pagination-next">
+    <div class="pagination-next {{ if not .ShowNext }}invisible{{end}}">
         {{ if .ShowNext }}
             <a href="{{ .Route }}?offset={{ .NextOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
         {{ else }}

--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -1040,3 +1040,7 @@ details.entry-enclosures {
     text-decoration: none;
     font-size: 1.2em;
 }
+
+.invisible {
+    visibility: hidden;
+}


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

I found it confusing to have pagination buttons(text) that seem to be clickable when It is actually not clickable. Especially when I have scrolled down and the entry count is not visible. 

This pr only show those text when it is clickable. 