### PR TITLE
Use an appropriate color for visited links on dark theme

### DIFF
--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -881,7 +881,7 @@ article.feed-parsing-error {
 }
 
 .entry-content a:visited {
-    color: purple;
+    color: var(--link-visited-color);
 }
 
 .entry-content dt {

--- a/ui/static/css/dark.css
+++ b/ui/static/css/dark.css
@@ -7,6 +7,7 @@
     --link-color: #aaa;
     --link-focus-color: #ddd;
     --link-hover-color: #ddd;
+    --link-visited-color: #f083e4;
 
     --header-list-border-color: #333;
     --header-link-color: #ddd;

--- a/ui/static/css/light.css
+++ b/ui/static/css/light.css
@@ -7,6 +7,7 @@
     --link-color: #3366CC;
     --link-focus-color: red;
     --link-hover-color: #333;
+    --link-visited-color: purple;
 
     --header-list-border-color: #ddd;
     --header-link-color: #444;

--- a/ui/static/css/system.css
+++ b/ui/static/css/system.css
@@ -7,6 +7,7 @@
     --link-color: #3366CC;
     --link-focus-color: red;
     --link-hover-color: #333;
+    --link-visited-color: purple;
 
     --header-list-border-color: #ddd;
     --header-link-color: #444;
@@ -114,6 +115,7 @@
         --link-color: #aaa;
         --link-focus-color: #ddd;
         --link-hover-color: #ddd;
+        --link-visited-color: #f083e4;
 
         --header-list-border-color: #333;
         --header-link-color: #ddd;


### PR DESCRIPTION
The contrast between background and purple for visited links was too
low (1.69). Use a brighter purple for the dark theme (contrast 6.87).

Do you follow the guidelines?

- [x] I have tested my changes (tested on the live site, not really after compiling)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
