### PR TITLE
show #unread per category in category list, not #feeds

### DIFF
--- a/locale/translations/de_DE.json
+++ b/locale/translations/de_DE.json
@@ -92,6 +92,7 @@
         "Es gibt %d Abonnement.",
         "Es gibt %d Abonnements."
     ],
+    "page.categories.unread_counter": "Anzahl der ungelesenen Artikel",
     "page.new_category.title": "Neue Kategorie",
     "page.new_user.title": "Neuer Benutzer",
     "page.edit_category.title": "Kategorie bearbeiten: %s",

--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -92,6 +92,7 @@
         "There is %d feed.",
         "There are %d feeds."
     ],
+    "page.categories.unread_counter": "Number of unread entries",
     "page.new_category.title": "New Category",
     "page.new_user.title": "New User",
     "page.edit_category.title": "Edit Category: %s",

--- a/locale/translations/es_ES.json
+++ b/locale/translations/es_ES.json
@@ -92,6 +92,7 @@
         "Hay %d fuente.",
         "Hay %d fuentes."
     ],
+    "page.categories.unread_counter": "Número de entradas no leídas",
     "page.new_category.title": "Nueva categoría",
     "page.new_user.title": "Nuevo usario",
     "page.edit_category.title": "Editar categoría: %s",

--- a/locale/translations/fr_FR.json
+++ b/locale/translations/fr_FR.json
@@ -92,6 +92,7 @@
         "Il y a %d abonnement.",
         "Il y a %d abonnements."
     ],
+    "page.categories.unread_counter": "Nombre d'entrées non lues",
     "page.new_category.title": "Nouvelle catégorie",
     "page.new_user.title": "Nouvel Utilisateur",
     "page.edit_category.title": "Modification de la catégorie : %s",

--- a/locale/translations/it_IT.json
+++ b/locale/translations/it_IT.json
@@ -92,6 +92,7 @@
         "C'è %d feed.",
         "Ci sono %d feed."
     ],
+    "page.categories.unread_counter": "Numero di voci non lette",
     "page.new_category.title": "Nuova categoria",
     "page.new_user.title": "Nuovo utente",
     "page.edit_category.title": "Modifica categoria: %s",

--- a/locale/translations/ja_JP.json
+++ b/locale/translations/ja_JP.json
@@ -92,6 +92,7 @@
         "%d 個の記事があります。",
         "%d 個の記事があります。"
     ],
+    "page.categories.unread_counter": "未読記事の数",
     "page.new_category.title": "新規カテゴリ",
     "page.new_user.title": "新規ユーザー",
     "page.edit_category.title": "カテゴリーを編集: %s",

--- a/locale/translations/nl_NL.json
+++ b/locale/translations/nl_NL.json
@@ -92,6 +92,7 @@
         "Er is %d feed.",
         "Er zijn %d feeds."
     ],
+    "page.categories.unread_counter": "Aantal ongelezen vermeldingen",
     "page.new_category.title": "Nieuwe categorie",
     "page.new_user.title": "Nieuwe gebruiker",
     "page.edit_category.title": "Bewerken van categorie: %s",

--- a/locale/translations/pl_PL.json
+++ b/locale/translations/pl_PL.json
@@ -93,6 +93,7 @@
         "Są %d kanały.",
         "Jest %d kanałów."
     ],
+    "page.categories.unread_counter": "Liczba nieprzeczytanych wpisów",
     "page.new_category.title": "Nowa kategoria",
     "page.new_user.title": "Nowy użytkownik",
     "page.edit_category.title": "Edycja Kategorii: %s",

--- a/locale/translations/pt_BR.json
+++ b/locale/translations/pt_BR.json
@@ -92,6 +92,7 @@
         "Existe %d fonte.",
         "Existem %d fontes."
     ],
+    "page.categories.unread_counter": "Numero de itens não lidos",
     "page.new_category.title": "Nova categoria",
     "page.new_user.title": "Novo usuário",
     "page.edit_category.title": "Editar categoria: %s",

--- a/locale/translations/ru_RU.json
+++ b/locale/translations/ru_RU.json
@@ -93,6 +93,7 @@
         "Есть %d подписки.",
         "Есть %d подписок."
     ],
+    "page.categories.unread_counter": "Количество непрочитанных записей",
     "page.new_category.title": "Новая категория",
     "page.new_user.title": "Новый пользователь",
     "page.edit_category.title": "Изменить категорию: %s",

--- a/locale/translations/tr_TR.json
+++ b/locale/translations/tr_TR.json
@@ -92,6 +92,7 @@
         "%d besleme var.",
         "%d besleme var."
     ],
+    "page.categories.unread_counter": "Okunmamış iletilerin sayısı",
     "page.new_category.title": "Yeni Kategori",
     "page.new_user.title": "Yeni Kullanıcı",
     "page.edit_category.title": "Kategoriyi Düzenle: %s",

--- a/locale/translations/zh_CN.json
+++ b/locale/translations/zh_CN.json
@@ -91,6 +91,7 @@
     "page.categories.feed_count": [
         "有 %d 个源"
     ],
+    "page.categories.unread_counter": "未读条目数",
     "page.new_category.title": "新分类",
     "page.new_user.title": "新用户",
     "page.edit_category.title": "编辑分类 : %s",

--- a/model/category.go
+++ b/model/category.go
@@ -8,10 +8,11 @@ import "fmt"
 
 // Category represents a feed category.
 type Category struct {
-	ID        int64  `json:"id"`
-	Title     string `json:"title"`
-	UserID    int64  `json:"user_id"`
-	FeedCount int    `json:"-"`
+	ID          int64  `json:"id"`
+	Title       string `json:"title"`
+	UserID      int64  `json:"user_id"`
+	FeedCount   int    `json:"-"`
+	TotalUnread int    `json:"-"`
 }
 
 func (c *Category) String() string {

--- a/template/templates/views/categories.html
+++ b/template/templates/views/categories.html
@@ -20,7 +20,7 @@
                 <span class="item-title">
                     <a href="{{ route "categoryEntries" "categoryID" .ID }}">{{ .Title }}</a>
                 </span>
-                (<span title="{{ if eq .FeedCount 0 }}{{ t "page.categories.no_feed" }}{{ else }}{{ plural "page.categories.feed_count" .FeedCount .FeedCount }}{{ end }}">{{ .FeedCount }}</span>)
+                (<span title="{{ t "page.categories.unread_counter" }}">{{ .TotalUnread }}</span>)
             </div>
             <div class="item-meta">
                 <ul class="item-meta-info">


### PR DESCRIPTION
the number of feeds in the category is currently displayed twice, and a lot less
useful than the number of unread items in the category.

implements #512 

tested to one million feed entries, where the query takes around 150ms average.

translations are all copied from the page.feeds.unread_counter, which seemed like a reasonable idea.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
