### PR TITLE
Improve the query way of pagination builder

### DIFF
--- a/storage/entry_pagination_builder.go
+++ b/storage/entry_pagination_builder.go
@@ -112,6 +112,7 @@ func (e *EntryPaginationBuilder) getPrevNextID(tx *sql.Tx) (prevID int64, nextID
 	`
 
 	subCondition := strings.Join(e.conditions, " AND ")
+	subCondition += fmt.Sprintf(" OR e.id = $%d", len(e.args)+1)
 	finalCondition := fmt.Sprintf("ep.id = $%d", len(e.args)+1)
 	query := fmt.Sprintf(cte, subCondition, finalCondition)
 	e.args = append(e.args, e.entryID)


### PR DESCRIPTION
Hello, I'm working on keeping track of unread/all entries for entry pagination from inner of feeds/categories pages for my own needs, but the way `EntryPaginationBuilder` works really confused me a lot. Looks like it is not working well with unread/read status, so instead of to make trading like `showUnreadEntryPage` I tried to make the query method better, but I'm NOT sure if it is really better for this cause It looks too simple(just one line add), Please check it. Thank you!

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
