### PR TITLE
Improve entry pagination: backtracking and tracking of unread status

### DIFF
--- a/database/migrations.go
+++ b/database/migrations.go
@@ -534,4 +534,9 @@ var migrations = []func(tx *sql.Tx) error{
 		_, err = tx.Exec(sql)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		sql := `ALTER TABLE entries ADD COLUMN read_at timestamp with time zone`
+		_, err = tx.Exec(sql)
+		return err
+	},
 }

--- a/http/request/params.go
+++ b/http/request/params.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -107,6 +108,18 @@ func QueryBooleanParam(r *http.Request, param string) bool {
 	}
 
 	return val
+}
+
+// QueryTimestampParam returns a query string (unix seconds) parameter as timestamp.
+func QueryTimestampParam(r *http.Request, param string) *time.Time {
+	value, err := strconv.ParseInt(r.URL.Query().Get(param), 10, 64)
+	if err != nil {
+		return nil
+	}
+
+	t := time.Unix(value, 0)
+
+	return &t
 }
 
 // HasQueryParam checks if the query string contains the given parameter.

--- a/http/request/params.go
+++ b/http/request/params.go
@@ -94,6 +94,21 @@ func QueryInt64Param(r *http.Request, param string, defaultValue int64) int64 {
 	return val
 }
 
+// QueryBooleanParam returns a query string parameter as boolean.
+func QueryBooleanParam(r *http.Request, param string) bool {
+	value := r.URL.Query().Get(param)
+	if value == "" {
+		return false
+	}
+
+	val, err := strconv.ParseBool(value)
+	if err != nil {
+		return true
+	}
+
+	return val
+}
+
 // HasQueryParam checks if the query string contains the given parameter.
 func HasQueryParam(r *http.Request, param string) bool {
 	values := r.URL.Query()

--- a/http/request/params_test.go
+++ b/http/request/params_test.go
@@ -5,10 +5,12 @@
 package request // import "miniflux.app/http/request"
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -211,6 +213,24 @@ func TestQueryBooleanParam(t *testing.T) {
 
 	if result != expected {
 		t.Errorf(`Unexpected result, got %t instead of %t`, result, expected)
+	}
+}
+
+func TestQueryTimestampParam(t *testing.T) {
+	anyTime := time.Now()
+	u, _ := url.Parse(fmt.Sprintf("http://example.org/?t=%d&invalid=invalidformat", anyTime.Unix()))
+	r := &http.Request{URL: u}
+
+	result := QueryTimestampParam(r, "t")
+
+	if result.Unix() != anyTime.Unix() {
+		t.Errorf(`Unexpected result, got %v instead of %v`, result, anyTime)
+	}
+
+	result = QueryTimestampParam(r, "invalid")
+
+	if result != nil {
+		t.Errorf(`Unexpected result, got %v instead of %v`, result, nil)
 	}
 }
 

--- a/http/request/params_test.go
+++ b/http/request/params_test.go
@@ -195,6 +195,25 @@ func TestQueryInt64Param(t *testing.T) {
 	}
 }
 
+func TestQueryBooleanParam(t *testing.T) {
+	u, _ := url.Parse("http://example.org/?t=t")
+	r := &http.Request{URL: u}
+
+	result := QueryBooleanParam(r, "t")
+	expected := true
+
+	if result != expected {
+		t.Errorf(`Unexpected result, got %t instead of %t`, result, expected)
+	}
+
+	result = QueryBooleanParam(r, "f")
+	expected = false
+
+	if result != expected {
+		t.Errorf(`Unexpected result, got %t instead of %t`, result, expected)
+	}
+}
+
 func TestHasQueryParam(t *testing.T) {
 	u, _ := url.Parse("http://example.org/?key=42")
 	r := &http.Request{URL: u}

--- a/http/response/html/html.go
+++ b/http/response/html/html.go
@@ -72,3 +72,14 @@ func NotFound(w http.ResponseWriter, r *http.Request) {
 func Redirect(w http.ResponseWriter, r *http.Request, uri string) {
 	http.Redirect(w, r, uri, http.StatusFound)
 }
+
+// RedirectWithQueries redirects the user to current location with given query string pairs.
+func RedirectWithQueries(w http.ResponseWriter, r *http.Request, qs ...string) {
+	u := r.URL
+	query := u.Query()
+	for i := 0; i < len(qs)-1; i += 2 {
+		query.Set(qs[i], qs[i+1])
+	}
+	u.RawQuery = query.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}

--- a/model/entry.go
+++ b/model/entry.go
@@ -29,6 +29,7 @@ type Entry struct {
 	CommentsURL string        `json:"comments_url"`
 	Date        time.Time     `json:"published_at"`
 	CreatedAt   time.Time     `json:"created_at"`
+	ReadAt      time.Time     `json:"read_at"`
 	Content     string        `json:"content"`
 	Author      string        `json:"author"`
 	ShareCode   string        `json:"share_code"`

--- a/storage/entry_pagination_builder.go
+++ b/storage/entry_pagination_builder.go
@@ -112,6 +112,7 @@ func (e *EntryPaginationBuilder) getPrevNextID(tx *sql.Tx) (prevID int64, nextID
 	`
 
 	subCondition := strings.Join(e.conditions, " AND ")
+	subCondition += fmt.Sprintf(" OR e.id = $%d", len(e.args)+1)
 	finalCondition := fmt.Sprintf("ep.id = $%d", len(e.args)+1)
 	query := fmt.Sprintf(cte, subCondition, finalCondition)
 	e.args = append(e.args, e.entryID)

--- a/storage/entry_pagination_builder.go
+++ b/storage/entry_pagination_builder.go
@@ -60,6 +60,13 @@ func (e *EntryPaginationBuilder) WithStatus(status string) {
 	}
 }
 
+// WithStatus adds (unread/unread before specific time) status to the condition.
+func (e *EntryPaginationBuilder) WithUnreadBefore(before time.Time) {
+	e.conditions = append(e.conditions, fmt.Sprintf("(e.status = $%d OR e.read_at > $%d)", len(e.args)+1, len(e.args)+2))
+	e.args = append(e.args, model.EntryStatusUnread)
+	e.args = append(e.args, before)
+}
+
 // Entries returns previous and next entries.
 func (e *EntryPaginationBuilder) Entries() (*model.Entry, *model.Entry, error) {
 	tx, err := e.store.db.Begin()

--- a/template/functions.go
+++ b/template/functions.go
@@ -214,6 +214,10 @@ func buildQuery(args ...interface{}) string {
 			if v {
 				vals.Set(key, "t")
 			}
+		case *time.Time:
+			if v != nil {
+				vals.Set(key, fmt.Sprintf("%d", v.Unix()))
+			}
 		}
 	}
 

--- a/template/functions.go
+++ b/template/functions.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	netUrl "net/url"
+
 	"miniflux.app/config"
 	"miniflux.app/http/route"
 	"miniflux.app/locale"
@@ -35,6 +37,7 @@ func (f *funcMap) Map() template.FuncMap {
 		"hasKey":         hasKey,
 		"truncate":       truncate,
 		"isEmail":        isEmail,
+		"buildQuery":     buildQuery,
 		"baseURL": func() string {
 			return config.Opts.BaseURL()
 		},
@@ -192,4 +195,31 @@ func formatFileSize(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %ciB",
 		float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func buildQuery(args ...interface{}) string {
+	vals := netUrl.Values{}
+	for i := 0; i < len(args)-1; i += 2 {
+		key := args[i].(string)
+		switch v := args[i+1].(type) {
+		case int, int64:
+			if v != 0 {
+				vals.Set(key, fmt.Sprintf("%v", v))
+			}
+		case string:
+			if v != "" {
+				vals.Set(key, v)
+			}
+		case bool:
+			if v {
+				vals.Set(key, "t")
+			}
+		}
+	}
+
+	qs := vals.Encode()
+	if qs == "" {
+		return ""
+	}
+	return "?" + qs
 }

--- a/template/functions_test.go
+++ b/template/functions_test.go
@@ -144,3 +144,25 @@ func TestFormatFileSize(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildQuery(t *testing.T) {
+	scenarios := []struct {
+		input    []interface{}
+		expected string
+	}{
+		{[]interface{}{"foo", "bar"}, "?foo=bar"},
+		{[]interface{}{"foo", "bar", "foo2", "bar2"}, "?foo=bar&foo2=bar2"},
+		{[]interface{}{"foo", ""}, ""},
+		{[]interface{}{"foo", nil}, ""},
+		{[]interface{}{"foo", 0}, ""},
+		{[]interface{}{"foo", false}, ""},
+		{[]interface{}{"foo", true}, "?foo=t"},
+	}
+
+	for _, scenario := range scenarios {
+		result := buildQuery(scenario.input...)
+		if result != scenario.expected {
+			t.Errorf(`Unexpected result, got %q instead of %q for %v`, result, scenario.expected, scenario.input)
+		}
+	}
+}

--- a/template/functions_test.go
+++ b/template/functions_test.go
@@ -5,6 +5,7 @@
 package template // import "miniflux.app/template"
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -146,6 +147,8 @@ func TestFormatFileSize(t *testing.T) {
 }
 
 func TestBuildQuery(t *testing.T) {
+	anyTime := time.Now()
+
 	scenarios := []struct {
 		input    []interface{}
 		expected string
@@ -157,6 +160,7 @@ func TestBuildQuery(t *testing.T) {
 		{[]interface{}{"foo", 0}, ""},
 		{[]interface{}{"foo", false}, ""},
 		{[]interface{}{"foo", true}, "?foo=t"},
+		{[]interface{}{"foo", &anyTime}, fmt.Sprintf("?foo=%d", anyTime.Unix())},
 	}
 
 	for _, scenario := range scenarios {

--- a/template/templates/common/entry_pagination.html
+++ b/template/templates/common/entry_pagination.html
@@ -2,7 +2,7 @@
 <div class="pagination">
     <div class="pagination-prev">
         {{ if .prevEntry }}
-            <a href="{{ .prevEntryRoute }}{{ if .searchQuery }}?q={{ .searchQuery }}{{ end }}" title="{{ .prevEntry.Title }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
+            <a href="{{ .prevEntryRoute }}{{ buildQuery "q" .searchQuery "unread" $.showOnlyUnreadEntries }}" title="{{ .prevEntry.Title }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
         {{ else }}
             {{ t "pagination.previous" }}
         {{ end }}
@@ -10,7 +10,7 @@
 
     <div class="pagination-next">
         {{ if .nextEntry }}
-            <a href="{{ .nextEntryRoute }}{{ if .searchQuery }}?q={{ .searchQuery }}{{ end }}" title="{{ .nextEntry.Title }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
+            <a href="{{ .nextEntryRoute }}{{ buildQuery "q" .searchQuery "unread" $.showOnlyUnreadEntries }}" title="{{ .nextEntry.Title }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
         {{ else }}
             {{ t "pagination.next" }}
         {{ end }}

--- a/template/templates/common/entry_pagination.html
+++ b/template/templates/common/entry_pagination.html
@@ -2,7 +2,7 @@
 <div class="pagination">
     <div class="pagination-prev">
         {{ if .prevEntry }}
-            <a href="{{ .prevEntryRoute }}{{ buildQuery "q" .searchQuery "unread" $.showOnlyUnreadEntries }}" title="{{ .prevEntry.Title }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
+            <a href="{{ .prevEntryRoute }}{{ buildQuery "q" .searchQuery "unread" $.showOnlyUnreadEntries "unreadBefore" $.unreadBefore }}" title="{{ .prevEntry.Title }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
         {{ else }}
             {{ t "pagination.previous" }}
         {{ end }}
@@ -10,7 +10,7 @@
 
     <div class="pagination-next">
         {{ if .nextEntry }}
-            <a href="{{ .nextEntryRoute }}{{ buildQuery "q" .searchQuery "unread" $.showOnlyUnreadEntries }}" title="{{ .nextEntry.Title }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
+            <a href="{{ .nextEntryRoute }}{{ buildQuery "q" .searchQuery "unread" $.showOnlyUnreadEntries "unreadBefore" $.unreadBefore }}" title="{{ .nextEntry.Title }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
         {{ else }}
             {{ t "pagination.next" }}
         {{ end }}

--- a/template/templates/views/category_entries.html
+++ b/template/templates/views/category_entries.html
@@ -41,7 +41,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "categoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}">{{ .Title }}</a>
+                    <a href="{{ route "categoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}{{ buildQuery "unread" $.showOnlyUnreadEntries }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/template/templates/views/feed_entries.html
+++ b/template/templates/views/feed_entries.html
@@ -78,7 +78,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "feedEntry" "feedID" .Feed.ID "entryID" .ID }}">{{ .Title }}</a>
+                    <a href="{{ route "feedEntry" "feedID" .Feed.ID "entryID" .ID }}{{ buildQuery "unread" $.showOnlyUnreadEntries }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/ui/entry_category.go
+++ b/ui/entry_category.go
@@ -88,6 +88,7 @@ func (h *handler) showCategoryEntryPage(w http.ResponseWriter, r *http.Request) 
 	view.Set("countUnread", h.store.CountUnreadEntries(user.ID))
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
 	view.Set("hasSaveEntry", h.store.HasSaveEntry(user.ID))
+	view.Set("showOnlyUnreadEntries", showOnlyUnread)
 
 	html.OK(w, r, view.Render("entry"))
 }

--- a/ui/entry_category.go
+++ b/ui/entry_category.go
@@ -52,8 +52,14 @@ func (h *handler) showCategoryEntryPage(w http.ResponseWriter, r *http.Request) 
 		entry.Status = model.EntryStatusRead
 	}
 
+	showOnlyUnread := request.QueryBooleanParam(r, "unread")
+
 	entryPaginationBuilder := storage.NewEntryPaginationBuilder(h.store, user.ID, entry.ID, user.EntryDirection)
 	entryPaginationBuilder.WithCategoryID(categoryID)
+	if showOnlyUnread {
+		entryPaginationBuilder.WithStatus(model.EntryStatusUnread)
+	}
+
 	prevEntry, nextEntry, err := entryPaginationBuilder.Entries()
 	if err != nil {
 		html.ServerError(w, r, err)

--- a/ui/entry_feed.go
+++ b/ui/entry_feed.go
@@ -88,6 +88,7 @@ func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
 	view.Set("countUnread", h.store.CountUnreadEntries(user.ID))
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
 	view.Set("hasSaveEntry", h.store.HasSaveEntry(user.ID))
+	view.Set("showOnlyUnreadEntries", showOnlyUnread)
 
 	html.OK(w, r, view.Render("entry"))
 }

--- a/ui/entry_feed.go
+++ b/ui/entry_feed.go
@@ -5,7 +5,9 @@
 package ui // import "miniflux.app/ui"
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"miniflux.app/http/request"
 	"miniflux.app/http/response/html"
@@ -52,12 +54,18 @@ func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
 		entry.Status = model.EntryStatusRead
 	}
 
+	var unreadBefore *time.Time
 	showOnlyUnread := request.QueryBooleanParam(r, "unread")
 
 	entryPaginationBuilder := storage.NewEntryPaginationBuilder(h.store, user.ID, entry.ID, user.EntryDirection)
 	entryPaginationBuilder.WithFeedID(feedID)
 	if showOnlyUnread {
-		entryPaginationBuilder.WithStatus(model.EntryStatusUnread)
+		unreadBefore = request.QueryTimestampParam(r, "unreadBefore")
+		if unreadBefore == nil {
+			html.RedirectWithQueries(w, r, "unreadBefore", fmt.Sprint(time.Now().Unix()))
+			return
+		}
+		entryPaginationBuilder.WithUnreadBefore(*unreadBefore)
 	}
 
 	prevEntry, nextEntry, err := entryPaginationBuilder.Entries()
@@ -89,6 +97,7 @@ func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
 	view.Set("hasSaveEntry", h.store.HasSaveEntry(user.ID))
 	view.Set("showOnlyUnreadEntries", showOnlyUnread)
+	view.Set("unreadBefore", unreadBefore)
 
 	html.OK(w, r, view.Render("entry"))
 }

--- a/ui/entry_feed.go
+++ b/ui/entry_feed.go
@@ -52,8 +52,14 @@ func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
 		entry.Status = model.EntryStatusRead
 	}
 
+	showOnlyUnread := request.QueryBooleanParam(r, "unread")
+
 	entryPaginationBuilder := storage.NewEntryPaginationBuilder(h.store, user.ID, entry.ID, user.EntryDirection)
 	entryPaginationBuilder.WithFeedID(feedID)
+	if showOnlyUnread {
+		entryPaginationBuilder.WithStatus(model.EntryStatusUnread)
+	}
+
 	prevEntry, nextEntry, err := entryPaginationBuilder.Entries()
 	if err != nil {
 		html.ServerError(w, r, err)


### PR DESCRIPTION
This pull request adds a few states of some entry pagination pages to get a more intuitive navigation. For example, you can only navigate through unread items in feeds/categories pages, and  `category/8/entry/19153` would be `category/8/entry/19153?unread=t` with the track of `unread` status. ~~But this is not getting the ability to "backtracking" previous read  #items.~~


Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
