### PR TITLE
Fix password reset via CLI

### DIFF
--- a/cli/reset_password.go
+++ b/cli/reset_password.go
@@ -34,6 +34,7 @@ func resetPassword(store *storage.Storage) {
 		os.Exit(1)
 	}
 
+	user.Password = password
 	if err := store.UpdateUser(user); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
User has been stored in CLI command, but the new password has never been assigned to user model. Kinda obvious bug/fix, but maybe not.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
