### PR TITLE
Add lang attribute to root html tag

### DIFF
--- a/template/engine.go
+++ b/template/engine.go
@@ -98,13 +98,13 @@ func (e *Engine) ParseTemplates() error {
 }
 
 // Render process a template.
-func (e *Engine) Render(name, language string, data interface{}) []byte {
+func (e *Engine) Render(name string, data map[string]interface{}) []byte {
 	tpl, ok := e.templates[name]
 	if !ok {
 		logger.Fatal("[Template] The template %s does not exists", name)
 	}
 
-	printer := locale.NewPrinter(language)
+	printer := locale.NewPrinter(data["language"].(string))
 
 	// Functions that need to be declared at runtime.
 	tpl.Funcs(template.FuncMap{

--- a/template/functions.go
+++ b/template/functions.go
@@ -74,6 +74,9 @@ func (f *funcMap) Map() template.FuncMap {
 		"contains": func(str, substr string) bool {
 			return strings.Contains(str, substr)
 		},
+		"replace": func(str, old string, new string) string {
+			return strings.Replace(str, old, new, 1)
+		},
 		"isodate": func(ts time.Time) string {
 			return ts.Format("2006-01-02 15:04:05")
 		},

--- a/template/templates/common/layout.html
+++ b/template/templates/common/layout.html
@@ -1,6 +1,6 @@
 {{ define "base" }}
 <!DOCTYPE html>
-<html>
+<html lang="{{replace .user.Language "_" "-"}}">
 <head>
     <meta charset="utf-8">
     <title>{{template "title" .}} - Miniflux</title>

--- a/template/templates/common/layout.html
+++ b/template/templates/common/layout.html
@@ -1,6 +1,6 @@
 {{ define "base" }}
 <!DOCTYPE html>
-<html lang="{{replace .user.Language "_" "-"}}">
+<html lang="{{ replace .language "_" "-"}}">
 <head>
     <meta charset="utf-8">
     <title>{{template "title" .}} - Miniflux</title>

--- a/ui/view/view.go
+++ b/ui/view/view.go
@@ -28,7 +28,7 @@ func (v *View) Set(param string, value interface{}) *View {
 
 // Render executes the template with arguments.
 func (v *View) Render(template string) []byte {
-	return v.tpl.Render(template+".html", request.UserLanguage(v.r), v.params)
+	return v.tpl.Render(template+".html", v.params)
 }
 
 // New returns a new view with default parameters.
@@ -40,6 +40,7 @@ func New(tpl *template.Engine, r *http.Request, sess *session.Session) *View {
 	b.params["flashMessage"] = sess.FlashMessage(request.FlashMessage(r))
 	b.params["flashErrorMessage"] = sess.FlashErrorMessage(request.FlashErrorMessage(r))
 	b.params["theme"] = theme
+	b.params["language"] = request.UserLanguage(r)
 	b.params["theme_checksum"] = static.StylesheetBundleChecksums[theme]
 	b.params["app_js_checksum"] = static.JavascriptBundleChecksums["app"]
 	b.params["sw_js_checksum"] = static.JavascriptBundleChecksums["service-worker"]


### PR DESCRIPTION
Allow `hyphens` CSS property to work correctly. Also may improve screen reader

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
