### PR TITLE
Avoid custom stylesheet to be cached by third-party CDN

### DIFF
--- a/template/functions.go
+++ b/template/functions.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"miniflux.app/config"
+	"miniflux.app/crypto"
 	"miniflux.app/http/route"
 	"miniflux.app/locale"
 	"miniflux.app/model"
@@ -86,6 +87,9 @@ func (f *funcMap) Map() template.FuncMap {
 				route.Path(f.router, "appIcon", "filename", "sprite.svg"),
 				iconName,
 			))
+		},
+		"rand": func() string {
+			return crypto.GenerateRandomStringHex(10)
 		},
 
 		// These functions are overrode at runtime after the parsing.

--- a/template/templates/common/layout.html
+++ b/template/templates/common/layout.html
@@ -36,7 +36,7 @@
     <meta name="theme-color" content="{{ theme_color .theme }}">
     <link rel="stylesheet" type="text/css" href="{{ route "stylesheet" "name" .theme }}?{{ .theme_checksum }}">
     {{ if and .user .user.Stylesheet }}
-    <link rel="stylesheet" type="text/css" href="{{ route "stylesheet" "name" "custom_css" }}">
+    <link rel="stylesheet" type="text/css" href="{{ route "stylesheet" "name" "custom_css" }}?{{ rand }}">
     {{ end }}
 
     <script type="text/javascript" src="{{ route "javascript" "name" "app" }}?{{ .app_js_checksum }}" defer></script>


### PR DESCRIPTION
If the application is hosted behind a CDN like Cloudflare,
then all custom stylesheets is be the same for all users.

The random query string prevent the CDN to cache this.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
