### PR TITLE
Expose `changed_at` time through the API

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -189,6 +189,7 @@ type Entry struct {
 	URL         string     `json:"url"`
 	Date        time.Time  `json:"published_at"`
 	CreatedAt   time.Time  `json:"created_at"`
+	ChangedAt   time.Time  `json:"changed_at"`
 	Content     string     `json:"content"`
 	Author      string     `json:"author"`
 	ShareCode   string     `json:"share_code"`

--- a/model/entry.go
+++ b/model/entry.go
@@ -29,6 +29,7 @@ type Entry struct {
 	CommentsURL string        `json:"comments_url"`
 	Date        time.Time     `json:"published_at"`
 	CreatedAt   time.Time     `json:"created_at"`
+	ChangedAt   time.Time     `json:"changed_at"`
 	Content     string        `json:"content"`
 	Author      string        `json:"author"`
 	ShareCode   string        `json:"share_code"`

--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -233,6 +233,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 			e.starred,
 			e.reading_time,
 			e.created_at,
+			e.changed_at,
 			f.title as feed_title,
 			f.feed_url,
 			f.site_url,
@@ -294,6 +295,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 			&entry.Starred,
 			&entry.ReadingTime,
 			&entry.CreatedAt,
+			&entry.ChangedAt,
 			&entry.Feed.Title,
 			&entry.Feed.FeedURL,
 			&entry.Feed.SiteURL,
@@ -322,6 +324,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 		// Make sure that timestamp fields contains timezone information (API)
 		entry.Date = timezone.Convert(tz, entry.Date)
 		entry.CreatedAt = timezone.Convert(tz, entry.CreatedAt)
+		entry.ChangedAt = timezone.Convert(tz, entry.ChangedAt)
 		entry.Feed.CheckedAt = timezone.Convert(tz, entry.Feed.CheckedAt)
 
 		entry.Feed.ID = entry.FeedID


### PR DESCRIPTION
No issue

This is already stored and updated in the DB to render the History page but is currently not exposed through the API

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
