### PR TITLE
Firefox on Windows does not show the active link as bold

### DIFF
--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -82,7 +82,8 @@ a:hover {
 
 .header .active a {
     color: var(--header-active-link-color);
-    font-weight: 500;
+    /* Note: Firefox on Windows does not show the link as bold if the value is under 600 */
+    font-weight: 600;
 }
 
 .header a:hover {


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
