### PR TITLE
add option to hide categories from the global unread list

### DIFF
--- a/database/migrations.go
+++ b/database/migrations.go
@@ -534,4 +534,10 @@ var migrations = []func(tx *sql.Tx) error{
 		_, err = tx.Exec(sql)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		_, err = tx.Exec(`
+			ALTER TABLE categories ADD COLUMN hide_globally boolean not null default false
+		`)
+		return err
+	},
 }

--- a/locale/translations/de_DE.json
+++ b/locale/translations/de_DE.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Über Proxy abrufen",
     "form.feed.label.disabled": "Dieses Abonnement nicht aktualisieren",
     "form.category.label.title": "Titel",
+    "form.category.hide_globally": "Einträge in der globalen Ungelesen-Liste ausblenden",
     "form.user.label.username": "Benutzername",
     "form.user.label.password": "Passwort",
     "form.user.label.confirmation": "Passwort Bestätigung",

--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Fetch via proxy",
     "form.feed.label.disabled": "Do not refresh this feed",
     "form.category.label.title": "Title",
+    "form.category.hide_globally": "Hide entries in global unread list",
     "form.user.label.username": "Username",
     "form.user.label.password": "Password",
     "form.user.label.confirmation": "Password Confirmation",

--- a/locale/translations/es_ES.json
+++ b/locale/translations/es_ES.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Buscar a través de proxy",
     "form.feed.label.disabled": "No actualice este feed",
     "form.category.label.title": "Título",
+    "form.category.hide_globally": "Ocultar entradas en la lista global de no leídos",
     "form.user.label.username": "Nombre de usuario",
     "form.user.label.password": "Contraseña",
     "form.user.label.confirmation": "Confirmación de contraseña",

--- a/locale/translations/fr_FR.json
+++ b/locale/translations/fr_FR.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Récupérer via proxy",
     "form.feed.label.disabled": "Ne pas actualiser ce flux",
     "form.category.label.title": "Titre",
+    "form.category.hide_globally": "Masquer les entrées dans la liste globale non lue",
     "form.user.label.username": "Nom d'utilisateur",
     "form.user.label.password": "Mot de passe",
     "form.user.label.confirmation": "Confirmation du mot de passe",

--- a/locale/translations/it_IT.json
+++ b/locale/translations/it_IT.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Recuperare tramite proxy",
     "form.feed.label.disabled": "Non aggiornare questo feed",
     "form.category.label.title": "Titolo",
+    "form.category.hide_globally": "Nascondere le voci nella lista globale dei non letti",
     "form.user.label.username": "Nome utente",
     "form.user.label.password": "Password",
     "form.user.label.confirmation": "Conferma password",

--- a/locale/translations/ja_JP.json
+++ b/locale/translations/ja_JP.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "プロキシ経由でフェッチ",
     "form.feed.label.disabled": "このフィードを更新しない",
     "form.category.label.title": "タイトル",
+    "form.category.hide_globally": "グローバル未読リストのエントリーを隠す",
     "form.user.label.username": "ユーザー名",
     "form.user.label.password": "パスワード",
     "form.user.label.confirmation": "パスワード確認",

--- a/locale/translations/nl_NL.json
+++ b/locale/translations/nl_NL.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Ophalen via proxy",
     "form.feed.label.disabled": "Vernieuw deze feed niet",
     "form.category.label.title": "Naam",
+    "form.category.hide_globally": "Verberg items in de globale ongelezen lijst",
     "form.user.label.username": "Gebruikersnaam",
     "form.user.label.password": "Wachtwoord",
     "form.user.label.confirmation": "Bevestig wachtwoord",

--- a/locale/translations/pl_PL.json
+++ b/locale/translations/pl_PL.json
@@ -279,6 +279,7 @@
     "form.feed.label.fetch_via_proxy": "Pobierz przez proxy",
     "form.feed.label.disabled": "Не обновлять этот канал",
     "form.category.label.title": "Tytuł",
+    "form.category.hide_globally": "Ukryj wpisy na globalnej liście nieprzeczytanych",
     "form.user.label.username": "Nazwa użytkownika",
     "form.user.label.password": "Hasło",
     "form.user.label.confirmation": "Potwierdzenie hasła",

--- a/locale/translations/pt_BR.json
+++ b/locale/translations/pt_BR.json
@@ -277,6 +277,7 @@
     "form.feed.label.disabled": "Não atualizar esta fonte",
     "form.feed.label.fetch_via_proxy": "Buscar via proxy",
     "form.category.label.title": "Título",
+    "form.category.hide_globally": "Ocultar entradas na lista global não lida",
     "form.user.label.username": "Nome de usuário",
     "form.user.label.password": "Senha",
     "form.user.label.confirmation": "Confirmação de senha",

--- a/locale/translations/ru_RU.json
+++ b/locale/translations/ru_RU.json
@@ -279,6 +279,7 @@
     "form.feed.label.fetch_via_proxy": "Получить через прокси",
     "form.feed.label.disabled": "Не обновлять этот канал",
     "form.category.label.title": "Название",
+    "form.category.hide_globally": "Скрыть записи в глобальном списке непрочитанных",
     "form.user.label.username": "Имя пользователя",
     "form.user.label.password": "Пароль",
     "form.user.label.confirmation": "Подтверждение пароля",

--- a/locale/translations/tr_TR.json
+++ b/locale/translations/tr_TR.json
@@ -277,6 +277,7 @@
     "form.feed.label.fetch_via_proxy": "Proxy ile çek",
     "form.feed.label.disabled": "Bu beslemeyi yenileme",
     "form.category.label.title": "Başlık",
+    "form.category.hide_globally": "Genel okunmamış listesindeki girişleri gizle",
     "form.user.label.username": "Kullanıcı Adı",
     "form.user.label.password": "Parola",
     "form.user.label.confirmation": "Parola Doğrulama",

--- a/locale/translations/zh_CN.json
+++ b/locale/translations/zh_CN.json
@@ -275,6 +275,7 @@
     "form.feed.label.fetch_via_proxy": "通过代理获取",
     "form.feed.label.disabled": "请勿刷新此Feed",
     "form.category.label.title": "标题",
+    "form.category.hide_globally": "隐藏全局未读列表中的条目",
     "form.user.label.username": "用户名",
     "form.user.label.password": "密码",
     "form.user.label.confirmation": "确认",

--- a/model/category.go
+++ b/model/category.go
@@ -8,11 +8,12 @@ import "fmt"
 
 // Category represents a feed category.
 type Category struct {
-	ID          int64  `json:"id"`
-	Title       string `json:"title"`
-	UserID      int64  `json:"user_id"`
-	FeedCount   int    `json:"-"`
-	TotalUnread int    `json:"-"`
+	ID           int64  `json:"id"`
+	Title        string `json:"title"`
+	UserID       int64  `json:"user_id"`
+	HideGlobally bool   `json:"hide_globally"`
+	FeedCount    int    `json:"-"`
+	TotalUnread  int    `json:"-"`
 }
 
 func (c *Category) String() string {
@@ -21,12 +22,14 @@ func (c *Category) String() string {
 
 // CategoryRequest represents the request to create or update a category.
 type CategoryRequest struct {
-	Title string `json:"title"`
+	Title        string `json:"title"`
+	HideGlobally string `json:"hide_globally"`
 }
 
 // Patch updates category fields.
 func (cr *CategoryRequest) Patch(category *Category) {
 	category.Title = cr.Title
+	category.HideGlobally = cr.HideGlobally != ""
 }
 
 // Categories represents a list of categories.

--- a/storage/entry.go
+++ b/storage/entry.go
@@ -49,6 +49,7 @@ func (s *Storage) CountAllEntries() map[string]int64 {
 func (s *Storage) CountUnreadEntries(userID int64) int {
 	builder := s.NewEntryQueryBuilder(userID)
 	builder.WithStatus(model.EntryStatusUnread)
+	builder.WithGloballyVisible()
 
 	n, err := builder.CountEntries()
 	if err != nil {
@@ -344,6 +345,27 @@ func (s *Storage) SetEntriesStatus(userID int64, entryIDs []int64, status string
 	}
 
 	return nil
+}
+
+func (s *Storage) SetEntriesStatusCount(userID int64, entryIDs []int64, status string) (int, error) {
+	if err := s.SetEntriesStatus(userID, entryIDs, status); err != nil {
+		return 0, err
+	}
+
+	query := `
+		SELECT count(*)
+		FROM entries e
+		    JOIN feeds f ON (f.id = e.feed_id)
+		    JOIN categories c ON (c.id = f.category_id)
+		WHERE e.user_id = $1 AND e.id = ANY($2) AND NOT c.hide_globally
+	`
+	row := s.db.QueryRow(query, userID, pq.Array(entryIDs))
+	visible := 0
+	if err := row.Scan(&visible); err != nil {
+		return 0, fmt.Errorf(`store: unable to query entries visibility %v: %v`, entryIDs, err)
+	}
+
+	return visible, nil
 }
 
 // ToggleBookmark toggles entry bookmark value.

--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -181,9 +181,20 @@ func (e *EntryQueryBuilder) WithOffset(offset int) *EntryQueryBuilder {
 	return e
 }
 
+func (e *EntryQueryBuilder) WithGloballyVisible() *EntryQueryBuilder {
+	e.conditions = append(e.conditions, "not c.hide_globally")
+	return e
+}
+
 // CountEntries count the number of entries that match the condition.
 func (e *EntryQueryBuilder) CountEntries() (count int, err error) {
-	query := `SELECT count(*) FROM entries e LEFT JOIN feeds f ON f.id=e.feed_id WHERE %s`
+	query := `
+		SELECT count(*)
+		FROM entries e
+			JOIN feeds f ON f.id = e.feed_id
+			JOIN categories c ON c.id = f.category_id
+		WHERE %s
+	`
 	condition := e.buildCondition()
 
 	err = e.store.db.QueryRow(fmt.Sprintf(query, condition), e.args...).Scan(&count)

--- a/template/templates/views/edit_category.html
+++ b/template/templates/views/edit_category.html
@@ -26,6 +26,11 @@
     <label for="form-title">{{ t "form.category.label.title" }}</label>
     <input type="text" name="title" id="form-title" value="{{ .form.Title }}" required autofocus>
 
+    <label>
+        <input type="checkbox" name="hide_globally" {{ if .form.HideGlobally }}checked{{ end }}>
+        {{ t "form.category.hide_globally" }}
+    </label>
+
     <div class="buttons">
         <button type="submit" class="button button-primary" data-label-loading="{{ t "form.submit.saving" }}">{{ t "action.update" }}</button>
     </div>

--- a/ui/category_edit.go
+++ b/ui/category_edit.go
@@ -37,7 +37,11 @@ func (h *handler) showEditCategoryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	categoryForm := form.CategoryForm{
-		Title: category.Title,
+		Title:        category.Title,
+		HideGlobally: "",
+	}
+	if category.HideGlobally {
+		categoryForm.HideGlobally = "checked"
 	}
 
 	view.Set("form", categoryForm)

--- a/ui/category_update.go
+++ b/ui/category_update.go
@@ -48,7 +48,10 @@ func (h *handler) updateCategory(w http.ResponseWriter, r *http.Request) {
 	view.Set("countUnread", h.store.CountUnreadEntries(loggedUser.ID))
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(loggedUser.ID))
 
-	categoryRequest := &model.CategoryRequest{Title: categoryForm.Title}
+	categoryRequest := &model.CategoryRequest{
+		Title:        categoryForm.Title,
+		HideGlobally: categoryForm.HideGlobally,
+	}
 
 	if validationErr := validator.ValidateCategoryModification(h.store, loggedUser.ID, category.ID, categoryRequest); validationErr != nil {
 		view.Set("errorMessage", validationErr.TranslationKey)

--- a/ui/entry_update_status.go
+++ b/ui/entry_update_status.go
@@ -26,10 +26,11 @@ func (h *handler) updateEntriesStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.store.SetEntriesStatus(request.UserID(r), entriesStatusUpdateRequest.EntryIDs, entriesStatusUpdateRequest.Status); err != nil {
+	count, err := h.store.SetEntriesStatusCount(request.UserID(r), entriesStatusUpdateRequest.EntryIDs, entriesStatusUpdateRequest.Status)
+	if err != nil {
 		json.ServerError(w, r, err)
 		return
 	}
 
-	json.OK(w, r, "OK")
+	json.OK(w, r, count)
 }

--- a/ui/form/category.go
+++ b/ui/form/category.go
@@ -10,12 +10,14 @@ import (
 
 // CategoryForm represents a feed form in the UI
 type CategoryForm struct {
-	Title string
+	Title        string
+	HideGlobally string
 }
 
 // NewCategoryForm returns a new CategoryForm.
 func NewCategoryForm(r *http.Request) *CategoryForm {
 	return &CategoryForm{
-		Title: r.FormValue("title"),
+		Title:        r.FormValue("title"),
+		HideGlobally: r.FormValue("hide_globally"),
 	}
 }

--- a/ui/static/js/app.js
+++ b/ui/static/js/app.js
@@ -205,14 +205,20 @@ function updateEntriesStatus(entryIDs, status, callback) {
     let url = document.body.dataset.entriesStatusUrl;
     let request = new RequestBuilder(url);
     request.withBody({entry_ids: entryIDs, status: status});
-    request.withCallback(callback);
-    request.execute();
+    request.withCallback((resp) => {
+        resp.json().then(count => {
+        if (callback) {
+            callback(resp);
+        }
 
-    if (status === "read") {
-        decrementUnreadCounter(1);
-    } else {
-        incrementUnreadCounter(1);
-    }
+            if (status === "read") {
+                decrementUnreadCounter(count);
+            } else {
+                incrementUnreadCounter(count);
+            }
+        });
+    });
+    request.execute();
 }
 
 // Handle save entry from list view and entry view.

--- a/ui/unread_entries.go
+++ b/ui/unread_entries.go
@@ -34,6 +34,7 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 	offset := request.QueryIntParam(r, "offset", 0)
 	builder := h.store.NewEntryQueryBuilder(user.ID)
 	builder.WithStatus(model.EntryStatusUnread)
+	builder.WithGloballyVisible()
 	countUnread, err := builder.CountEntries()
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -52,6 +53,7 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 	builder.WithDirection(user.EntryDirection)
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
+	builder.WithGloballyVisible()
 	entries, err := builder.GetEntries()
 	if err != nil {
 		html.ServerError(w, r, err)


### PR DESCRIPTION
implement #447 

`SetEntriesStatusCount` could be folded into `SetEntriesStatus` as an `update ... returning`, but there's enough places in the code that don't need the extra info that it seemed like a good idea to keep them separate. translations from english to other languages by DeepL.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
