### PR TITLE
client: expose comments_url entry field

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -187,6 +187,7 @@ type Entry struct {
 	Hash        string     `json:"hash"`
 	Title       string     `json:"title"`
 	URL         string     `json:"url"`
+	CommentsURL string     `json:"comments_url"`
 	Date        time.Time  `json:"published_at"`
 	CreatedAt   time.Time  `json:"created_at"`
 	ChangedAt   time.Time  `json:"changed_at"`


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Comments URL for entries is returned by API, but has not avaliable in
the Go client. This PR fixes this.
