### PR TITLE
contrib: Bump docker-compose version to 3.4

### DIFF
--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.4'
 services:
   miniflux:
     image: miniflux/miniflux:latest

--- a/contrib/docker-compose/caddy.yml
+++ b/contrib/docker-compose/caddy.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.4'
 services:
   caddy:
     image: caddy:2

--- a/contrib/docker-compose/traefik.yml
+++ b/contrib/docker-compose/traefik.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.4'
 services:
   traefik:
     image: "traefik:v2.3"


### PR DESCRIPTION
'start_period' for 'healthchecks' was added in Compose file version 3.4,

https://docs.docker.com/compose/compose-file/compose-versioning/#version-34

Bump docker-compose files' versions from 3.3 to 3.4

Without this, docker-compose (1.25 at least) returns

```
ERROR: The Compose file './contrib/docker-compose/caddy.yml' is invalid because:
services.db.healthcheck value Additional properties are not allowed ('start_period' was unexpected)
```

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
