### PR TITLE
contrib: Add support for a $MINIFLUX_IMAGE env var in docker-compose

### DIFF
--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   miniflux:
-    image: miniflux/miniflux:latest
+    image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     restart: always
     ports:

--- a/contrib/docker-compose/caddy.yml
+++ b/contrib/docker-compose/caddy.yml
@@ -13,7 +13,7 @@ services:
       - caddy_data:/data
       - caddy_config:/config
   miniflux:
-    image: miniflux/miniflux:latest
+    image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     depends_on:
       db:

--- a/contrib/docker-compose/traefik.yml
+++ b/contrib/docker-compose/traefik.yml
@@ -18,7 +18,7 @@ services:
       - "./letsencrypt:/letsencrypt"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
   miniflux:
-    image: miniflux/miniflux:latest
+    image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     depends_on:
       db:


### PR DESCRIPTION
Allowing to override the image used in docker-compose files can allow
for richer and more easy local development/debugging sessions. The
docker image building process is already using the latest tag anyway,
making it really easy to build an image with a (set of) specific
commits. Using the above built image with the provided docker-compose
files isn't doable without modifications though. Add that support via
environmental variables.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
