### PR TITLE
ui: Expose markCategoryAsRead

### DIFF
--- a/template/templates/views/categories.html
+++ b/template/templates/views/categories.html
@@ -49,6 +49,17 @@
                             data-url="{{ route "removeCategory" "categoryID" .ID }}">{{ icon "delete" }}<span class="icon-label">{{ t "action.remove" }}</span></a>
                     </li>
                     {{ end }}
+                    {{ if gt .TotalUnread 0 }}
+                      <li>
+                        <a href="#"
+                            data-confirm="true"
+                            data-label-question="{{ t "confirm.question" }}"
+                            data-label-yes="{{ t "confirm.yes" }}"
+                            data-label-no="{{ t "confirm.no" }}"
+                            data-label-loading="{{ t "confirm.loading" }}"
+                            data-url="{{ route "markCategoryAsRead" "categoryID" .ID }}">{{ icon "read" }}<span class="icon-label">{{ t "menu.mark_all_as_read" }}</span></a>
+                      </li>
+                    {{ end }}
                 </ul>
             </div>
         </article>

--- a/template/templates/views/category_entries.html
+++ b/template/templates/views/category_entries.html
@@ -14,6 +14,15 @@
                 data-label-loading="{{ t "confirm.loading" }}"
                 data-show-only-unread="{{ if .showOnlyUnreadEntries }}1{{ end }}">{{ t "menu.mark_page_as_read" }}</a>
         </li>
+        <li>
+            <a href="#"
+                data-confirm="true"
+                data-label-question="{{ t "confirm.question" }}"
+                data-label-yes="{{ t "confirm.yes" }}"
+                data-label-no="{{ t "confirm.no" }}"
+                data-label-loading="{{ t "confirm.loading" }}"
+                data-url="{{ route "markCategoryAsRead" "categoryID" .category.ID }}">{{ t "menu.mark_all_as_read" }}</a>
+        </li>
     {{ end }}
     {{ if .showOnlyUnreadEntries }}
         <li>

--- a/ui/category_mark_as_read.go
+++ b/ui/category_mark_as_read.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Frédéric Guillot. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package ui // import "miniflux.app/ui"
+
+import (
+	"net/http"
+	"time"
+
+	"miniflux.app/http/request"
+	"miniflux.app/http/response/html"
+	"miniflux.app/http/route"
+)
+
+func (h *handler) markCategoryAsRead(w http.ResponseWriter, r *http.Request) {
+	userID := request.UserID(r)
+	categoryID := request.RouteInt64Param(r, "categoryID")
+
+	category, err := h.store.Category(userID, categoryID)
+	if err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
+	if category == nil {
+		html.NotFound(w, r)
+		return
+	}
+
+	if err = h.store.MarkCategoryAsRead(userID, categoryID, time.Now()); err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
+	html.Redirect(w, r, route.Path(h.router, "categories"))
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -93,6 +93,7 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	uiRouter.HandleFunc("/category/{categoryID}/edit", handler.showEditCategoryPage).Name("editCategory").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/category/{categoryID}/update", handler.updateCategory).Name("updateCategory").Methods(http.MethodPost)
 	uiRouter.HandleFunc("/category/{categoryID}/remove", handler.removeCategory).Name("removeCategory").Methods(http.MethodPost)
+	uiRouter.HandleFunc("/category/{categoryID}/mark-all-as-read", handler.markCategoryAsRead).Name("markCategoryAsRead").Methods(http.MethodPost)
 
 	// Entry pages.
 	uiRouter.HandleFunc("/entry/status", handler.updateEntriesStatus).Name("updateEntriesStatus").Methods(http.MethodPost)


### PR DESCRIPTION
Why:
It is nice to have the ability to mark an entire category as read in the
UI. The API already exposes that functionality anyway, so for
consistency reasons, expose it in the UI as well

What:
Add a new handler in the UI to markCategoryAsRead() and amend views and
router to expose the functionality in the UI

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
