### PR TITLE
Add "in" in "logged in" for en_US tooltip.logged_user

### DIFF
--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -16,7 +16,7 @@
     "action.login": "Login",
     "action.home_screen": "Add to home screen",
     "tooltip.keyboard_shortcuts": "Keyboard Shortcut: %s",
-    "tooltip.logged_user": "Logged as %s",
+    "tooltip.logged_user": "Logged in as %s",
     "menu.unread": "Unread",
     "menu.starred": "Starred",
     "menu.history": "History",


### PR DESCRIPTION
Fix a typo, by adding the "in" part of the phrasal verb as the intent is
to notify the user that they are "logged" in in the system as user X and
not to notify them that they are "recorded"

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
