### PR TITLE
use authors entry for json 1.1 feeds

### DIFF
--- a/reader/json/json.go
+++ b/reader/json/json.go
@@ -16,12 +16,13 @@ import (
 )
 
 type jsonFeed struct {
-	Version string     `json:"version"`
-	Title   string     `json:"title"`
-	SiteURL string     `json:"home_page_url"`
-	FeedURL string     `json:"feed_url"`
-	Author  jsonAuthor `json:"author"`
-	Items   []jsonItem `json:"items"`
+	Version string       `json:"version"`
+	Title   string       `json:"title"`
+	SiteURL string       `json:"home_page_url"`
+	FeedURL string       `json:"feed_url"`
+	Authors []jsonAuthor `json:"authors"`
+	Author  jsonAuthor   `json:"author"`
+	Items   []jsonItem   `json:"items"`
 }
 
 type jsonAuthor struct {
@@ -38,6 +39,7 @@ type jsonItem struct {
 	HTML          string           `json:"content_html"`
 	DatePublished string           `json:"date_published"`
 	DateModified  string           `json:"date_modified"`
+	Authors       []jsonAuthor     `json:"authors"`
 	Author        jsonAuthor       `json:"author"`
 	Attachments   []jsonAttachment `json:"attachments"`
 }
@@ -51,6 +53,9 @@ type jsonAttachment struct {
 }
 
 func (j *jsonFeed) GetAuthor() string {
+	if len(j.Authors) > 0 {
+		return (getAuthor(j.Authors[0]))
+	}
 	return getAuthor(j.Author)
 }
 
@@ -108,6 +113,9 @@ func (j *jsonItem) GetDate() time.Time {
 }
 
 func (j *jsonItem) GetAuthor() string {
+	if len(j.Authors) > 0 {
+		return getAuthor(j.Authors[0])
+	}
 	return getAuthor(j.Author)
 }
 

--- a/reader/json/parser_test.go
+++ b/reader/json/parser_test.go
@@ -272,6 +272,49 @@ func TestParseAuthor(t *testing.T) {
 	}
 }
 
+func TestParseAuthors(t *testing.T) {
+	data := `{
+		"version": "https://jsonfeed.org/version/1.1",
+		"user_comment": "This is a microblog feed. You can add this to your feed reader using the following URL: https://example.org/feed.json",
+		"title": "Brent Simmons’s Microblog",
+		"home_page_url": "https://example.org/",
+		"feed_url": "https://example.org/feed.json",
+		"author": {
+			"name": "This field is deprecated, use authors",
+			"url": "http://example.org/",
+			"avatar": "https://example.org/avatar.png"
+		},
+		"authors": [ 
+			{
+				"name": "Brent Simmons",
+				"url": "http://example.org/",
+				"avatar": "https://example.org/avatar.png"
+			}
+		],
+		"items": [
+			{
+				"id": "2347259",
+				"url": "https://example.org/2347259",
+				"content_text": "Cats are neat. \n\nhttps://example.org/cats",
+				"date_published": "2016-02-09T14:22:00-07:00"
+			}
+		]
+	}`
+
+	feed, err := Parse("https://example.org/feed.json", bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(feed.Entries) != 1 {
+		t.Errorf("Incorrect number of entries, got: %d", len(feed.Entries))
+	}
+
+	if feed.Entries[0].Author != "Brent Simmons" {
+		t.Errorf("Incorrect entry author, got: %s", feed.Entries[0].Author)
+	}
+}
+
 func TestParseFeedWithoutTitle(t *testing.T) {
 	data := `{
 		"version": "https://jsonfeed.org/version/1",


### PR DESCRIPTION
The [JSON Feed 1.1 spec](https://jsonfeed.org/version/1.1) has deprecated the singular `author` field in favor an `authors` array. This PR checks for `authors` and uses that if present.
