### PR TITLE
Add /rss/ in finder's wellKnownUrls

### DIFF
--- a/reader/subscription/finder.go
+++ b/reader/subscription/finder.go
@@ -146,6 +146,7 @@ func tryWellKnownUrls(websiteURL, userAgent, cookie, username, password string) 
 		"/feed.xml": "atom",
 		"/feed/":    "atom",
 		"/rss.xml":  "rss",
+		"/rss/":     "rss",
 	}
 
 	lastCharacter := websiteURL[len(websiteURL)-1:]


### PR DESCRIPTION
ATCOM netvolution WCM, probably alongside others, a CMS powering several
high profile and high traffic Greek news sites, among other sites,
publishes the RSS feed under /rss/. Add it to the list. It's generic
enough to allow us to assume other software might do it to

On a select set of 627 Greek news media sites (the infamous Petsas list),
adding this rule increased discoverability of RSS feeds by a factor of
2.61% (from 498 to 511).

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
