### PR TITLE
Fix finding JSON feeds with new MIME type

### DIFF
--- a/reader/subscription/finder.go
+++ b/reader/subscription/finder.go
@@ -69,9 +69,10 @@ func FindSubscriptions(websiteURL, userAgent, cookie, username, password string,
 func parseWebPage(websiteURL string, data io.Reader) (Subscriptions, *errors.LocalizedError) {
 	var subscriptions Subscriptions
 	queries := map[string]string{
-		"link[type='application/rss+xml']":  "rss",
-		"link[type='application/atom+xml']": "atom",
-		"link[type='application/json']":     "json",
+		"link[type='application/rss+xml']":   "rss",
+		"link[type='application/atom+xml']":  "atom",
+		"link[type='application/json']":      "json",
+		"link[type='application/feed+json']": "json",
 	}
 
 	doc, err := goquery.NewDocumentFromReader(data)


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

The 1.1 version (https://jsonfeed.org/version/1.1) for JSON feeds defines that feeds should have a MIME type of `application/feed+json` which Miniflux wasn't searching for. I've tested this on a few sites that have JSON feeds and Miniflux now finds them when scraping the page for meta tags.