### PR TITLE
add proxy arg in scraper.Fetch

### DIFF
--- a/reader/processor/processor.go
+++ b/reader/processor/processor.go
@@ -56,6 +56,7 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed) {
 				feed.UserAgent,
 				feed.Cookie,
 				feed.AllowSelfSignedCertificates,
+				feed.FetchViaProxy,
 			)
 
 			if config.Opts.HasMetricsCollector() {
@@ -118,6 +119,7 @@ func ProcessEntryWebPage(feed *model.Feed, entry *model.Entry) error {
 		entry.Feed.UserAgent,
 		entry.Feed.Cookie,
 		feed.AllowSelfSignedCertificates,
+		feed.FetchViaProxy,
 	)
 
 	if config.Opts.HasMetricsCollector() {

--- a/reader/scraper/scraper.go
+++ b/reader/scraper/scraper.go
@@ -20,10 +20,13 @@ import (
 )
 
 // Fetch downloads a web page and returns relevant contents.
-func Fetch(websiteURL, rules, userAgent string, cookie string, allowSelfSignedCertificates bool) (string, error) {
+func Fetch(websiteURL, rules, userAgent string, cookie string, allowSelfSignedCertificates, useProxy bool) (string, error) {
 	clt := client.NewClientWithConfig(websiteURL, config.Opts)
 	clt.WithUserAgent(userAgent)
 	clt.WithCookie(cookie)
+	if useProxy {
+		clt.WithProxy()
+	}
 	clt.AllowSelfSignedCertificates = allowSelfSignedCertificates
 
 	response, err := clt.Get()


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

The scraper doesn't use proxy event I choose "Fetch via proxy" when create a subscription.