### PR TITLE
Remove RequestURI() hack

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -21,7 +21,6 @@ import (
 	"miniflux.app/errors"
 	"miniflux.app/logger"
 	"miniflux.app/timer"
-	url_helper "miniflux.app/url"
 )
 
 const (
@@ -40,7 +39,6 @@ var (
 type Client struct {
 	inputURL string
 
-	requestURL                 string
 	requestEtagHeader          string
 	requestLastModifiedHeader  string
 	requestAuthorizationHeader string
@@ -90,9 +88,8 @@ func (c *Client) String() string {
 	}
 
 	return fmt.Sprintf(
-		`InputURL=%q RequestURL=%q ETag=%s LastMod=%s Auth=%v UserAgent=%q Verify=%v`,
+		`InputURL=%q ETag=%s LastMod=%s Auth=%v UserAgent=%q Verify=%v`,
 		c.inputURL,
-		c.requestURL,
 		etagHeader,
 		lastModifiedHeader,
 		c.requestAuthorizationHeader != "" || (c.requestUsername != "" && c.requestPassword != ""),
@@ -263,8 +260,7 @@ func (c *Client) executeRequest(request *http.Request) (*Response, error) {
 }
 
 func (c *Client) buildRequest(method string, body io.Reader) (*http.Request, error) {
-	c.requestURL = url_helper.RequestURI(c.inputURL)
-	request, err := http.NewRequest(method, c.requestURL, body)
+	request, err := http.NewRequest(method, c.inputURL, body)
 	if err != nil {
 		return nil, err
 	}

--- a/url/url.go
+++ b/url/url.go
@@ -7,7 +7,6 @@ package url // import "miniflux.app/url"
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"strings"
 )
 
@@ -80,52 +79,4 @@ func Domain(websiteURL string) string {
 	}
 
 	return parsedURL.Host
-}
-
-// RequestURI returns the encoded URI to be used in HTTP requests.
-func RequestURI(websiteURL string) string {
-	u, err := url.Parse(websiteURL)
-	if err != nil {
-		return websiteURL
-	}
-
-	queryValues := u.Query()
-	u.RawQuery = "" // Clear RawQuery to make sure it's encoded properly.
-	u.Fragment = "" // Clear fragment because Web browsers strip #fragment before sending the URL to a web server.
-
-	var buf strings.Builder
-	buf.WriteString(u.String())
-
-	if len(queryValues) > 0 {
-		buf.WriteByte('?')
-
-		// Sort keys.
-		keys := make([]string, 0, len(queryValues))
-		for k := range queryValues {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		i := 0
-		for _, key := range keys {
-			keyEscaped := url.QueryEscape(key)
-			values := queryValues[key]
-			for _, value := range values {
-				if i > 0 {
-					buf.WriteByte('&')
-				}
-				buf.WriteString(keyEscaped)
-
-				// As opposed to the standard library, we append the = only if the value is not empty.
-				if value != "" {
-					buf.WriteByte('=')
-					buf.WriteString(url.QueryEscape(value))
-				}
-
-				i++
-			}
-		}
-	}
-
-	return buf.String()
 }

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -88,25 +88,3 @@ func TestDomain(t *testing.T) {
 		}
 	}
 }
-
-func TestRequestURI(t *testing.T) {
-	scenarios := map[string]string{
-		"https://www.example.org":                                                   "https://www.example.org",
-		"https://user:password@www.example.org":                                     "https://user:password@www.example.org",
-		"https://www.example.org/path with spaces":                                  "https://www.example.org/path%20with%20spaces",
-		"https://www.example.org/path#test":                                         "https://www.example.org/path",
-		"https://www.example.org/path?abc#test":                                     "https://www.example.org/path?abc",
-		"https://www.example.org/path?a=b&a=c":                                      "https://www.example.org/path?a=b&a=c",
-		"https://www.example.org/path?a=b&a=c&d":                                    "https://www.example.org/path?a=b&a=c&d",
-		"https://www.example.org/path?atom":                                         "https://www.example.org/path?atom",
-		"https://www.example.org/path?测试=测试":                                        "https://www.example.org/path?%E6%B5%8B%E8%AF%95=%E6%B5%8B%E8%AF%95",
-		"https://www.example.org/url=http%3A%2F%2Fwww.example.com%2Ffeed%2F&max=20": "https://www.example.org/url=http%3A%2F%2Fwww.example.com%2Ffeed%2F&max=20",
-	}
-
-	for input, expected := range scenarios {
-		actual := RequestURI(input)
-		if actual != expected {
-			t.Errorf(`Unexpected result, got %q instead of %q`, actual, expected)
-		}
-	}
-}


### PR DESCRIPTION
I can't remember why this change was done.

Let's use only the standard lib.

It seems to break URL like this one: https://www.deimeke.net/dirk/blog/index.php?/feeds/index.rss2

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
