### PR TITLE
Fix templates being visible on old browsers

### DIFF
--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -544,6 +544,10 @@ a.button {
 }
 
 /* Modals */
+template {
+    display: none;
+}
+
 #modal-left {
     position: fixed;
     top: 0;


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

---

This fixes the `<template>` elements being visible on older browsers, specifically the PlayStation Vita browser in my case, though it looks anything pre-2015 or so is probably affected. It shouldn't have any impact in modern browsers as the CSS is identical to Safari and Chrome at least's default for templates, just `display: none;`.

Apologies if I didn't put it in a good place in the CSS file, the modals are what the templates are and it seems the element selectors are usually being done first so I put it right below the `/* Modals */` comment since that seemed like the best place to me.

I would have just used custom CSS to fix this, but custom CSS is broken in the Vita browser and I can't figure out why, so since it's a minor change with no downsides besides 33 extra bytes in the CSS file and might actually help out other people I figured I'd just do a pull request for it.

---

Here are before and after comparison images:
<details><summary>Before:</summary>

![before](https://user-images.githubusercontent.com/41608708/134458013-b429dc09-656b-4fc7-bbe9-8747bf4a6b60.png)

</details>
<details><summary>After:</summary>

![after](https://user-images.githubusercontent.com/41608708/134458012-64f8a0f8-819f-4f83-90da-45f11e5bfd42.png)

</details>