### PR TITLE
Change -config-dump to use KEY=VALUE format

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1431,3 +1431,38 @@ func TestFetchYouTubeWatchTime(t *testing.T) {
 		t.Fatalf(`Unexpected FETCH_YOUTUBE_WATCH_TIME value, got %v instead of %v`, result, expected)
 	}
 }
+
+func TestParseConfigDumpOutput(t *testing.T) {
+	os.Clearenv()
+
+	wantOpts := NewOptions()
+	wantOpts.adminUsername = "my-username"
+
+	serialized := wantOpts.String()
+	tmpfile, err := os.CreateTemp(".", "miniflux.*.unit_test.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tmpfile.Write([]byte(serialized)); err != nil {
+		t.Fatal(err)
+	}
+
+	parser := NewParser()
+	parsedOpts, err := parser.ParseFile(tmpfile.Name())
+	if err != nil {
+		t.Errorf(`Parsing failure: %v`, err)
+	}
+
+	if parsedOpts.AdminUsername() != wantOpts.AdminUsername() {
+		t.Fatalf(`Unexpected ADMIN_USERNAME value, got %q instead of %q`, parsedOpts.AdminUsername(), wantOpts.AdminUsername())
+	}
+
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(tmpfile.Name()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/config/options.go
+++ b/config/options.go
@@ -559,7 +559,7 @@ func (o *Options) String() string {
 	var builder strings.Builder
 
 	for _, option := range o.SortedOptions() {
-		builder.WriteString(fmt.Sprintf("%s: %v\n", option.Key, option.Value))
+		fmt.Fprintf(&builder, "%s=%v\n", option.Key, option.Value)
 	}
 
 	return builder.String()


### PR DESCRIPTION
Addresses #1224. Changes `-config-dump` to use `KEY=VALUE` format, so that the output of `-config-dump` is compatible to be used as the input to `-config-file`.

Example:
```sh
$ ./miniflux-darwin-arm64 -config-dump
ADMIN_PASSWORD=
ADMIN_USERNAME=
AUTH_PROXY_HEADER=
AUTH_PROXY_USER_CREATION=false
BASE_PATH=
BASE_URL=http://localhost
BATCH_SIZE=100
CERT_DOMAIN=
CERT_FILE=
CLEANUP_ARCHIVE_BATCH_SIZE=10000
CLEANUP_ARCHIVE_READ_DAYS=60
CLEANUP_ARCHIVE_UNREAD_DAYS=180
CLEANUP_FREQUENCY_HOURS=24
CLEANUP_REMOVE_SESSIONS_DAYS=30
CREATE_ADMIN=false
...
```

Technically, this is a breaking change, since if a user has a script that relies on `KEY: VALUE`, this change will break that.

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
