### PR TITLE
add systemd-tmpfiles config file

### DIFF
--- a/packaging/systemd/miniflux.service
+++ b/packaging/systemd/miniflux.service
@@ -55,6 +55,10 @@ RestrictRealtime=true
 # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWritePaths=
 ReadWritePaths=/run
 
+# Create /run/miniflux as 0755, for the Unix socket.
+# https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=
+RuntimeDirectory=miniflux
+
 # Allow miniflux to bind to privileged ports
 # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#AmbientCapabilities=
 AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
These changes will add a `/run/miniflux` directory for the Unix socket bind.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

I've only tested the Debian package generation on amd64. I don't have different hardware.

The Fedora package needs more work, `nginx` on Fedora uses the `nginx` group, which isn't present without `nginx` installed. I'm not well versed on RedHat systems, so I'll open this as a draft for now, to figure out whether to not add this file at all or use some other group, or some other solution.