### PR TITLE
Fix docker compose example files compatibility to v3

### DIFF
--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -7,8 +7,7 @@ services:
     ports:
       - "80:8080"
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     environment:
       - DATABASE_URL=postgres://miniflux:secret@db/miniflux?sslmode=disable
       - RUN_MIGRATIONS=1

--- a/contrib/docker-compose/caddy.yml
+++ b/contrib/docker-compose/caddy.yml
@@ -16,8 +16,7 @@ services:
     image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     environment:
       - DATABASE_URL=postgres://miniflux:secret@db/miniflux?sslmode=disable
       - RUN_MIGRATIONS=1

--- a/contrib/docker-compose/traefik.yml
+++ b/contrib/docker-compose/traefik.yml
@@ -21,8 +21,7 @@ services:
     image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     expose:
       - "8080"
     environment:


### PR DESCRIPTION
As described in docker compose file reference: https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on
`depend_on` does not accept `condition` anymore.
Also the documentation example should  be modified.

---
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
