### PR TITLE
Add support for theme color based on preferred color scheme of OS

### DIFF
--- a/model/theme.go
+++ b/model/theme.go
@@ -19,10 +19,17 @@ func Themes() map[string]string {
 // ThemeColor returns the color for the address bar or/and the browser color.
 // https://developer.mozilla.org/en-US/docs/Web/Manifest#theme_color
 // https://developers.google.com/web/tools/lighthouse/audits/address-bar
-func ThemeColor(theme string) string {
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
+func ThemeColor(theme, colorScheme string) string {
 	switch theme {
 	case "dark_serif", "dark_sans_serif":
 		return "#222"
+	case "system_serif", "system_sans_serif":
+		if colorScheme == "dark" {
+			return "#222"
+		}
+
+		return "#fff"
 	default:
 		return "#fff"
 	}

--- a/template/functions.go
+++ b/template/functions.go
@@ -87,8 +87,8 @@ func (f *funcMap) Map() template.FuncMap {
 		"isodate": func(ts time.Time) string {
 			return ts.Format("2006-01-02 15:04:05")
 		},
-		"theme_color": func(theme string) string {
-			return model.ThemeColor(theme)
+		"theme_color": func(theme, colorScheme string) string {
+			return model.ThemeColor(theme, colorScheme)
 		},
 		"icon": func(iconName string) template.HTML {
 			return template.HTML(fmt.Sprintf(

--- a/template/templates/common/layout.html
+++ b/template/templates/common/layout.html
@@ -29,7 +29,9 @@
     <link rel="apple-touch-icon" sizes="167x167" href="{{ route "appIcon" "filename" "icon-167.png" }}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ route "appIcon" "filename" "icon-180.png" }}">
 
-    <meta name="theme-color" content="{{ theme_color .theme }}">
+    <meta name="theme-color" content="{{ theme_color .theme "light" }}" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="{{ theme_color .theme "dark" }}" media="(prefers-color-scheme: dark)">
+
     <link rel="stylesheet" type="text/css" href="{{ route "stylesheet" "name" .theme "checksum" .theme_checksum }}">
 
     {{ if and .user .user.Stylesheet }}

--- a/ui/static_manifest.go
+++ b/ui/static_manifest.go
@@ -53,7 +53,7 @@ func (h *handler) showWebManifest(w http.ResponseWriter, r *http.Request) {
 		}
 		displayMode = user.DisplayMode
 	}
-	themeColor := model.ThemeColor(request.UserTheme(r))
+	themeColor := model.ThemeColor(request.UserTheme(r), "light")
 	manifest := &webManifest{
 		Name:            "Miniflux",
 		ShortName:       "Miniflux",


### PR DESCRIPTION
Hey folks,

as Apple introduced with iOS 15 and Safari 15 support for the "theme-color" property, I noticed that the theme color is always the value for the light theme, when you select a "system" theme:

![iOS theme color for system theme](https://user-images.githubusercontent.com/1100180/143774926-5383b105-03ee-452c-89b3-38247015b742.PNG)

I introduced a color scheme parameter, and added a second meta-tag with the correct media.

As there is no official way to set the theme color for the dark mode in the [web manifest yet](https://github.com/w3c/manifest/issues/975), I just passed there the parameter "light", as this will not change the current behavior.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
