### PR TITLE
order disabled feeds to last

### DIFF
--- a/storage/feed.go
+++ b/storage/feed.go
@@ -21,17 +21,20 @@ type byStateAndName struct{ f model.Feeds }
 func (l byStateAndName) Len() int      { return len(l.f) }
 func (l byStateAndName) Swap(i, j int) { l.f[i], l.f[j] = l.f[j], l.f[i] }
 func (l byStateAndName) Less(i, j int) bool {
-	if l.f[i].ParsingErrorCount > 0 && l.f[j].ParsingErrorCount == 0 {
+	// Disabled test first, since if disabled, we don't care the errors
+	if l.f[i].Disabled != l.f[j].Disabled {
+		if l.f[i].Disabled {
+			return false
+		}
 		return true
-	} else if l.f[i].ParsingErrorCount == 0 && l.f[j].ParsingErrorCount > 0 {
-		return false
-	} else if l.f[i].UnreadCount > 0 && l.f[j].UnreadCount == 0 {
-		return true
-	} else if l.f[i].UnreadCount == 0 && l.f[j].UnreadCount > 0 {
-		return false
-	} else {
-		return l.f[i].Title < l.f[j].Title
 	}
+	if l.f[i].ParsingErrorCount != l.f[j].ParsingErrorCount {
+		return l.f[i].ParsingErrorCount > l.f[j].ParsingErrorCount
+	}
+	if l.f[i].UnreadCount != l.f[j].UnreadCount {
+		return l.f[i].UnreadCount > l.f[j].UnreadCount
+	}
+	return l.f[i].Title < l.f[j].Title
 }
 
 // FeedExists checks if the given feed exists.

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -21,12 +21,9 @@ type byStateAndName struct{ f model.Feeds }
 func (l byStateAndName) Len() int      { return len(l.f) }
 func (l byStateAndName) Swap(i, j int) { l.f[i], l.f[j] = l.f[j], l.f[i] }
 func (l byStateAndName) Less(i, j int) bool {
-	// Disabled test first, since if disabled, we don't care the errors
+	// disabled test first, since we don't care about errors if disabled
 	if l.f[i].Disabled != l.f[j].Disabled {
-		if l.f[i].Disabled {
-			return false
-		}
-		return true
+		return l.f[j].Disabled
 	}
 	if l.f[i].ParsingErrorCount != l.f[j].ParsingErrorCount {
 		return l.f[i].ParsingErrorCount > l.f[j].ParsingErrorCount


### PR DESCRIPTION
This PR orders disabled feeds to last, which:
- disabled feeds last, even if they have errors.
- in disabled feeds section, the error feeds are still first
- simplify the order codes, but introduced slightly change that feeds who has more errors are first

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
