### PR TITLE
packaging: remove SystemCallFilter from miniflux.service

### DIFF
--- a/packaging/systemd/miniflux.service
+++ b/packaging/systemd/miniflux.service
@@ -77,10 +77,6 @@ ProtectClock=yes
 # Filter dangerous system calls. The following is listed as safe basic
 # choice in systemd.exec(5).
 SystemCallArchitectures=native
-SystemCallFilter=@system-service
-SystemCallFilter=~@privileged
-SystemCallFilter=~@resources
-SystemCallErrorNumber=EPERM
 
 # Deny kernel execution domain changing.
 LockPersonality=yes


### PR DESCRIPTION
`SystemCallFilter=@system-service` is not supported on older systemd versions and causes crashes on them.

Fixes #1297.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
