### PR TITLE
Add scraper rule for ikiwiki.iki.fi

### DIFF
--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -17,6 +17,7 @@ var predefinedRules = map[string]string{
 	"github.com":           "article.entry-content",
 	"heise.de":             "header .article-content__lead, header .article-image, div.article-layout__content.article-content",
 	"igen.fr":              "section.corps",
+	"ikiwiki.iki.fi":       ".page.group",
 	"ing.dk":               "section.body",
 	"lapresse.ca":          ".amorce, .entry",
 	"lemonde.fr":           "article",


### PR DESCRIPTION
Feed: https://ikiwiki.iki.fi/feed.php?linkto=current&ns=uutiset%3Ablog&num=5

Example page: https://ikiwiki.iki.fi/uutiset/blog/20210923100421viiveita

(To clarify, I'm not a representative of iki.fi although I have an email address in the domain. This is a nonprofit association that offers email forwarding addresses, and the rss feed in question contains news for their members.)

I try to follow the guidelines:

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
