### PR TITLE
Add Content-Security-Policy header to feed icon url

### DIFF
--- a/ui/feed_icon.go
+++ b/ui/feed_icon.go
@@ -27,6 +27,7 @@ func (h *handler) showIcon(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.New(w, r).WithCaching(icon.Hash, 72*time.Hour, func(b *response.Builder) {
+		b.WithHeader("Content-Security-Policy", `default-src 'self'`)
 		b.WithHeader("Content-Type", icon.MimeType)
 		b.WithBody(icon.Content)
 		b.WithoutCompression()

--- a/ui/proxy.go
+++ b/ui/proxy.go
@@ -67,6 +67,7 @@ func (h *handler) imageProxy(w http.ResponseWriter, r *http.Request) {
 	etag := crypto.HashFromBytes(decodedURL)
 
 	response.New(w, r).WithCaching(etag, 72*time.Hour, func(b *response.Builder) {
+		b.WithHeader("Content-Security-Policy", `default-src 'self'`)
 		b.WithHeader("Content-Type", resp.Header.Get("Content-Type"))
 		b.WithBody(resp.Body)
 		b.WithoutCompression()


### PR DESCRIPTION
- SVG images could contains Javascript. This CSP blocks inline script.
- Feed icons are served using `<img>` tag and Javascript is not interpreted.

See https://developer.mozilla.org/en-US/docs/Web/SVG/SVG_as_an_Image#restrictions

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
