### PR TITLE
Expose entry unshare in the entry and list views

### DIFF
--- a/template/templates/common/item_meta.html
+++ b/template/templates/common/item_meta.html
@@ -42,6 +42,15 @@
                     title="{{ t "entry.shared_entry.title" }}"
                     target="_blank">{{ icon "share" }}<span class="icon-label">{{ t "entry.shared_entry.label" }}</span></a>
             </li>
+            <li>
+                <a href="#"
+                    data-confirm="true"
+                    data-url="{{ route "unshareEntry" "entryID" .entry.ID }}"
+                    data-label-question="{{ t "confirm.question" }}"
+                    data-label-yes="{{ t "confirm.yes" }}"
+                    data-label-no="{{ t "confirm.no" }}"
+                    data-label-loading="{{ t "confirm.loading" }}">{{ icon "delete" }}<span class="icon-label">{{ t "entry.unshare.label" }}</span></a>
+            </li>
         {{ end }}
         {{ if .hasSaveEntry }}
             <li>

--- a/template/templates/views/entry.html
+++ b/template/templates/views/entry.html
@@ -44,17 +44,28 @@
                             >{{ icon "save" }}<span class="icon-label">{{ t "entry.save.label" }}</span></a>
                     </li>
                 {{ end }}
-                <li>
-                    {{ if .entry.ShareCode }}
+                {{ if .entry.ShareCode }}
+                    <li>
                         <a href="{{ route "sharedEntry" "shareCode" .entry.ShareCode }}"
                             title="{{ t "entry.shared_entry.title" }}"
                             target="_blank">{{ icon "share" }}<span class="icon-label">{{ t "entry.shared_entry.label" }}</span></a>
-                    {{ else }}
+                    </li>
+                    <li>
+                        <a href="#"
+                            data-confirm="true"
+                            data-url="{{ route "unshareEntry" "entryID" .entry.ID }}"
+                            data-label-question="{{ t "confirm.question" }}"
+                            data-label-yes="{{ t "confirm.yes" }}"
+                            data-label-no="{{ t "confirm.no" }}"
+                            data-label-loading="{{ t "confirm.loading" }}">{{ icon "delete" }}<span class="icon-label">{{ t "entry.unshare.label" }}</span></a>
+                    </li>
+                {{ else }}
+                    <li>
                         <a href="{{ route "shareEntry" "entryID" .entry.ID }}"
                             title="{{ t "entry.share.title" }}"
                             target="_blank">{{ icon "share" }}<span class="icon-label">{{ t "entry.share.label" }}</span></a>
-                    {{ end }}
-                </li>
+                    </li>
+                {{ end }}
                 <li>
                     <a href="{{ .entry.URL | safeURL  }}"
                         target="_blank"


### PR DESCRIPTION
Why:

A user might want to unshare a specific entry. Navigating to the shared
entries page requires a mental context switch, whereas having the
ability right in the entry page makes it easier.

What:

Add an extra \<li> element to display the unshare icon and link in the
entry view as well as the item_meta template. The latter is shared for
multiple pages listing entries, e.g. bookmarks, feed entries, search,
history etc.

The functionality already exists for the shared entries page, we are
just expose it in a couple more places

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
