### PR TITLE
Scrape and rewrite rules for quantamagazine.org

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	youtubeRegex  = regexp.MustCompile(`youtube\.com/watch\?v=(.*)`)
-	invidioRegex  = regexp.MustCompile(`https?:\/\/(.*)\/watch\?v=(.*)`)
-	imgRegex      = regexp.MustCompile(`<img [^>]+>`)
-	textLinkRegex = regexp.MustCompile(`(?mi)(\bhttps?:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])`)
+	youtubeRegex   = regexp.MustCompile(`youtube\.com/watch\?v=(.*)`)
+	youtubeIdRegex = regexp.MustCompile(`youtube_id"?\s*[:=]\s*"([a-zA-Z0-9_-]{11})"`)
+	invidioRegex   = regexp.MustCompile(`https?:\/\/(.*)\/watch\?v=(.*)`)
+	imgRegex       = regexp.MustCompile(`<img [^>]+>`)
+	textLinkRegex  = regexp.MustCompile(`(?mi)(\bhttps?:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])`)
 )
 
 func addImageTitle(entryURL, entryContent string) string {
@@ -217,6 +218,23 @@ func addYoutubeVideoUsingInvidiousPlayer(entryURL, entryContent string) string {
 		return video + `<br>` + entryContent
 	}
 	return entryContent
+}
+
+func addYoutubeVideoFromId(entryContent string) string {
+	matches := youtubeIdRegex.FindAllStringSubmatch(entryContent, -1)
+	if matches == nil {
+		return entryContent
+	}
+	sb := strings.Builder{}
+	for _, match := range matches {
+		if len(match) == 2 {
+			sb.WriteString(`<iframe width="650" height="350" frameborder="0" src="https://www.youtube-nocookie.com/embed/`)
+			sb.WriteString(match[1])
+			sb.WriteString(`" allowfullscreen></iframe><br>`)
+		}
+	}
+	sb.WriteString(entryContent)
+	return sb.String()
 }
 
 func addInvidiousVideo(entryURL, entryContent string) string {

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -74,6 +74,8 @@ func applyRule(entryURL, entryContent string, rule rule) string {
 		entryContent = addInvidiousVideo(entryURL, entryContent)
 	case "add_youtube_video_using_invidious_player":
 		entryContent = addYoutubeVideoUsingInvidiousPlayer(entryURL, entryContent)
+	case "add_youtube_video_from_id":
+		entryContent = addYoutubeVideoFromId(entryContent)
 	case "add_pdf_download_link":
 		entryContent = addPDFLink(entryURL, entryContent)
 	case "nl2br":

--- a/reader/rewrite/rules.go
+++ b/reader/rewrite/rules.go
@@ -26,7 +26,7 @@ var predefinedRules = map[string]string{
 	"oglaf.com":              "add_image_title",
 	"optipess.com":           "add_image_title",
 	"peebleslab.com":         "add_image_title",
-	"quantamagazine.org":     `remove("h6:not(.byline,.post__title__kicker), #comments, .next-post__content, .footer__section, figure .outer--content")`,
+	"quantamagazine.org":     `add_youtube_video_from_id, remove("h6:not(.byline,.post__title__kicker), #comments, .next-post__content, .footer__section, figure .outer--content, script")`,
 	"sentfromthemoon.com":    "add_image_title",
 	"thedoghousediaries.com": "add_image_title",
 	"treelobsters.com":       "add_image_title",

--- a/reader/rewrite/rules.go
+++ b/reader/rewrite/rules.go
@@ -26,6 +26,7 @@ var predefinedRules = map[string]string{
 	"oglaf.com":              "add_image_title",
 	"optipess.com":           "add_image_title",
 	"peebleslab.com":         "add_image_title",
+	"quantamagazine.org":     `remove("h6:not(.byline,.post__title__kicker), #comments, .next-post__content, .footer__section, figure .outer--content")`,
 	"sentfromthemoon.com":    "add_image_title",
 	"thedoghousediaries.com": "add_image_title",
 	"treelobsters.com":       "add_image_title",

--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -33,7 +33,7 @@ var predefinedRules = map[string]string{
 	"osnews.com":           "div.newscontent1",
 	"phoronix.com":         "div.content",
 	"pseudo-sciences.org":  "#art_main",
-	"quantamagazine.org":   ".outer--content, figure",
+	"quantamagazine.org":   ".outer--content, figure, script",
 	"raywenderlich.com":    "article",
 	"slate.fr":             ".field-items",
 	"techcrunch.com":       "div.article-entry",

--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -33,6 +33,7 @@ var predefinedRules = map[string]string{
 	"osnews.com":           "div.newscontent1",
 	"phoronix.com":         "div.content",
 	"pseudo-sciences.org":  "#art_main",
+	"quantamagazine.org":   ".outer--content, figure",
 	"raywenderlich.com":    "article",
 	"slate.fr":             ".field-items",
 	"techcrunch.com":       "div.article-entry",


### PR DESCRIPTION
Quantamagazine.org is a somewhat complex React site, but with these changes I can see the text, images and videos in all the stories that are currently visible in the rss feed. This adds a heuristic rule for detecting Youtube ids in JavaScript and enables it for quantamagazine.org.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
