### PR TITLE
Do not reset touch-item if successfully swiped

### DIFF
--- a/ui/static/js/touch_handler.js
+++ b/ui/static/js/touch_handler.js
@@ -75,10 +75,10 @@ class TouchHandler {
 
             if (distance > 75) {
                 toggleEntryStatus(this.touch.element);
-			} else {
-            	this.touch.element.style.opacity = 1;
-            	this.touch.element.style.transform = "none";
-			}
+	    } else {
+                this.touch.element.style.opacity = 1;
+                this.touch.element.style.transform = "none";
+	    }
         }
 
         this.reset();

--- a/ui/static/js/touch_handler.js
+++ b/ui/static/js/touch_handler.js
@@ -75,10 +75,10 @@ class TouchHandler {
 
             if (distance > 75) {
                 toggleEntryStatus(this.touch.element);
-            }
-
-            this.touch.element.style.opacity = 1;
-            this.touch.element.style.transform = "none";
+			} else {
+            	this.touch.element.style.opacity = 1;
+            	this.touch.element.style.transform = "none";
+			}
         }
 
         this.reset();


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request

After swiping an article, code will reset the style.opacity and style.transform properties to cancel the swipe. This is not necessary to do this if the user swipes far enough to toggle entry status. This creates a jarring effect on slower mobile connections.

https://user-images.githubusercontent.com/11655457/149604464-d46d1485-a232-4473-8811-df84415dc57c.mp4

With the PR the code won't execute when the user dismisses the article.

https://user-images.githubusercontent.com/11655457/149604540-ef882408-5fbb-4238-bc49-ba531dce413b.mp4