### PR TITLE
Display Go version on /about

### DIFF
--- a/locale/translations/de_DE.json
+++ b/locale/translations/de_DE.json
@@ -116,6 +116,7 @@
     "page.about.license": "Lizenz:",
     "page.about.global_config_options": "Globale Konfigurationsoptionen",
     "page.about.postgres_version": "Postgres Version:",
+    "page.about.go_version": "Go Version:",
     "page.add_feed.title": "Neues Abonnement",
     "page.add_feed.no_category": "Es ist keine Kategorie vorhanden. Wenigstens eine Kategorie muss angelegt sein.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/el_EL.json
+++ b/locale/translations/el_EL.json
@@ -116,6 +116,7 @@
     "page.about.license": "Άδεια:",
     "page.about.global_config_options": "Γενικές ρυθμίσεις",
     "page.about.postgres_version": "Έκδοση Postgres:",
+    "page.about.go_version": "Έκδοση Go:",
     "page.add_feed.title": "Νέα Συνδρομή",
     "page.add_feed.no_category": "Δεν υπάρχει κατηγορία. Πρέπει να έχετε τουλάχιστον μία κατηγορία.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -116,6 +116,7 @@
     "page.about.license": "License:",
     "page.about.global_config_options": "Global configuration options",
     "page.about.postgres_version": "Postgres version:",
+    "page.about.go_version": "Go version:",
     "page.add_feed.title": "New Subscription",
     "page.add_feed.no_category": "There is no category. You must have at least one category.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/es_ES.json
+++ b/locale/translations/es_ES.json
@@ -116,6 +116,7 @@
     "page.about.license": "Licencia:",
     "page.about.global_config_options": "Opciones de configuración global",
     "page.about.postgres_version": "Postgres versión:",
+    "page.about.go_version": "Go versión:",
     "page.add_feed.title": "Nueva suscripción",
     "page.add_feed.no_category": "No hay categoría. Debe tener al menos una categoría.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/fi_FI.json
+++ b/locale/translations/fi_FI.json
@@ -116,6 +116,7 @@
     "page.about.license": "Lisenssi:",
     "page.about.global_config_options": "Yleiset asetukset",
     "page.about.postgres_version": "Postgres-versio:",
+    "page.about.go_version": "Go-versio:",
     "page.add_feed.title": "Uusi tilaus",
     "page.add_feed.no_category": "Ei ole ketegoriaa. Sinulla on oltava vähintään yksi ketegoria.",
     "page.add_feed.label.url": "URL-osoite",

--- a/locale/translations/fr_FR.json
+++ b/locale/translations/fr_FR.json
@@ -116,6 +116,7 @@
     "page.about.license": "Licence :",
     "page.about.global_config_options": "Options de configuration globales",
     "page.about.postgres_version": "Version de Postgresql :",
+    "page.about.go_version": "Version de Go :",
     "page.add_feed.title": "Nouvel Abonnement",
     "page.add_feed.no_category": "Il n'y a aucune catégorie. Vous devez avoir au moins une catégorie.",
     "page.add_feed.label.url": "Lien",

--- a/locale/translations/it_IT.json
+++ b/locale/translations/it_IT.json
@@ -116,6 +116,7 @@
     "page.about.license": "Licenza:",
     "page.about.global_config_options": "Opzioni di configurazione globali",
     "page.about.postgres_version": "Postgres versione:",
+    "page.about.go_version": "Go versione:",
     "page.add_feed.title": "Nuovo feed",
     "page.add_feed.no_category": "Nessuna categoria selezionata. Devi scegliere almeno una categoria.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/ja_JP.json
+++ b/locale/translations/ja_JP.json
@@ -116,6 +116,7 @@
     "page.about.license": "ライセンス:",
     "page.about.global_config_options": "グローバル構成オプション",
     "page.about.postgres_version": "Postgres バージョン:",
+    "page.about.go_version": "Go バージョン:",
     "page.add_feed.title": "新規購読",
     "page.add_feed.no_category": "カテゴリが存在しません。 少なくとも1つのカテゴリが必要です。",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/nl_NL.json
+++ b/locale/translations/nl_NL.json
@@ -117,6 +117,7 @@
     "page.about.license": "Licentie:",
     "page.about.global_config_options": "globale configuratie-opties",
     "page.about.postgres_version": "Postgres versie:",
+    "page.about.go_version": "Go versie:",
     "page.add_feed.title": "Nieuwe feed",
     "page.add_feed.no_category": "Er zijn geen categorieën. Je moet op zijn minst één caterogie hebben.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/pl_PL.json
+++ b/locale/translations/pl_PL.json
@@ -117,6 +117,7 @@
     "page.about.author": "Autor:",
     "page.about.license": "Licencja:",
     "page.about.postgres_version": "Postgres wersja:",
+    "page.about.go_version": "Go wersja:",
     "page.about.global_config_options": "globalne opcje konfiguracji",
     "page.add_feed.title": "Nowa subskrypcja",
     "page.add_feed.no_category": "Nie ma żadnej kategorii. Musisz mieć co najmniej jedną kategorię.",

--- a/locale/translations/pt_BR.json
+++ b/locale/translations/pt_BR.json
@@ -116,6 +116,7 @@
     "page.about.license": "Licença:",
     "page.about.global_config_options": "opções de configuração global",
     "page.about.postgres_version": "Postgres versão:",
+    "page.about.go_version": "Go versão:",
     "page.add_feed.title": "Nova inscrição",
     "page.add_feed.no_category": "Não existe uma categoria. Deve existir pelo menos uma categoria.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/ru_RU.json
+++ b/locale/translations/ru_RU.json
@@ -117,6 +117,7 @@
     "page.about.author": "Автор:",
     "page.about.license": "Лицензия:",
     "page.about.postgres_version": "Postgres bерсия:",
+    "page.about.go_version": "Go bерсия:",
     "page.about.global_config_options": "глобальные параметры конфигурации",
     "page.add_feed.title": "Новая подписка",
     "page.add_feed.no_category": "Категории отсутствуют. У вас должна быть хотя бы одна категория.",

--- a/locale/translations/tr_TR.json
+++ b/locale/translations/tr_TR.json
@@ -116,6 +116,7 @@
     "page.about.license": "Lisans:",
     "page.about.global_config_options": "Global yapılandırma seçenekleri",
     "page.about.postgres_version": "Postgres sürümü:",
+    "page.about.go_version": "Go sürümü:",
     "page.add_feed.title": "Yeni Abonelik",
     "page.add_feed.no_category": "Kategori yok. En az bir kategoriye sahip olmalısınız.",
     "page.add_feed.label.url": "URL",

--- a/locale/translations/zh_CN.json
+++ b/locale/translations/zh_CN.json
@@ -113,6 +113,7 @@
     "page.about.author": "作者：",
     "page.about.license": "协议：",
     "page.about.postgres_version": "Postgres 版本号：",
+    "page.about.go_version": "Go 版本号：",
     "page.about.global_config_options": "全局配置选项",
     "page.add_feed.title": "新增源",
     "page.add_feed.no_category": "没有类别，至少需要有一个类别",

--- a/template/templates/views/about.html
+++ b/template/templates/views/about.html
@@ -13,6 +13,7 @@
         <li><strong>Git Commit</strong> {{ .commit }}</li>
         <li><strong>{{ t "page.about.build_date" }}</strong> {{ .build_date }}</li>
         {{ if .user.IsAdmin }}<li><strong>{{ t "page.about.postgres_version" }}</strong> {{ .postgres_version }}</li>{{ end }}
+	<li><strong>{{t "page.about.go_version" }}</strong> {{ .go_version }}</li>
     </ul>
 </div>
 

--- a/ui/about.go
+++ b/ui/about.go
@@ -6,6 +6,7 @@ package ui // import "miniflux.app/ui"
 
 import (
 	"net/http"
+	"runtime"
 
 	"miniflux.app/config"
 	"miniflux.app/http/request"
@@ -33,6 +34,7 @@ func (h *handler) showAboutPage(w http.ResponseWriter, r *http.Request) {
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
 	view.Set("globalConfigOptions", config.Opts.SortedOptions(true))
 	view.Set("postgres_version", h.store.DatabaseVersion())
+	view.Set("go_version", runtime.Version())
 
 	html.OK(w, r, view.Render("about"))
 }


### PR DESCRIPTION
There seems to be a steady trickle of minor security bugs in the Golang crypto/x509, crypto/tls, and net/http packages, and every time another one drops I wonder if I need to rebuild Miniflux to update the Go standard library. I know I can retrieve the Go version from a miniflux binary by calling it with the -info flag, but I'm not always in a position to SSH into the box that's running my copy of miniflux, so it would be nice to find the Go version on the /about page.

Please let me know if you think the Go version should be hidden behind the IsAdmin flag (as the Postgres version is). 

Translations are copy-paste from the equivalent Postgres version string, and might not account for grammatical gender, etc.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
