### PR TITLE
Fixed regression: reset touch-item if not in /unread

### DIFF
--- a/ui/static/js/touch_handler.js
+++ b/ui/static/js/touch_handler.js
@@ -75,10 +75,13 @@ class TouchHandler {
 
             if (distance > 75) {
                 toggleEntryStatus(this.touch.element);
-	    } else {
+            } 
+
+            // If not on the unread page, undo transform of the dragged element.
+            if (document.URL.split("/").indexOf("unread") == -1 || distance <= 75) {
                 this.touch.element.style.opacity = 1;
                 this.touch.element.style.transform = "none";
-	    }
+            }
         }
 
         this.reset();

--- a/ui/static/js/touch_handler.js
+++ b/ui/static/js/touch_handler.js
@@ -75,10 +75,10 @@ class TouchHandler {
 
             if (distance > 75) {
                 toggleEntryStatus(this.touch.element);
-			} else {
-            	this.touch.element.style.opacity = 1;
-            	this.touch.element.style.transform = "none";
-			}
+	    } else {
+                this.touch.element.style.opacity = 1;
+                this.touch.element.style.transform = "none";
+	    }
         }
 
         this.reset();

--- a/ui/static/js/touch_handler.js
+++ b/ui/static/js/touch_handler.js
@@ -75,10 +75,10 @@ class TouchHandler {
 
             if (distance > 75) {
                 toggleEntryStatus(this.touch.element);
-            }
-
-            this.touch.element.style.opacity = 1;
-            this.touch.element.style.transform = "none";
+			} else {
+            	this.touch.element.style.opacity = 1;
+            	this.touch.element.style.transform = "none";
+			}
         }
 
         this.reset();


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request

In my previous pull request, I accidentally introduced a regression where swiping an article not in unread (where swiping does not delete) leaves the article transformed. This pull request resets touch item if the page is not /unread or the distance was less than or equal to 75.