### PR TITLE
Add links to scraper/rewrite/filtering docs when editing feeds

### DIFF
--- a/template/templates/views/add_subscription.html
+++ b/template/templates/views/add_subscription.html
@@ -55,16 +55,47 @@
                 -->
                 <input type="text" name="feed_password" id="form-feed-password" value="{{ .form.Password }}" spellcheck="false">
 
-                <label for="form-scraper-rules">{{ t "form.feed.label.scraper_rules" }}</label>
+                <div class="rules-entry">
+                    <label for="form-scraper-rules">
+                        {{ t "form.feed.label.scraper_rules" }}
+                    </label>
+                    &nbsp;
+                    <a href="https://miniflux.app/docs/rules.html#scraper-rules" target="_blank">
+                        {{ icon "external-link" }}
+                    </a>
+                </div>
                 <input type="text" name="scraper_rules" id="form-scraper-rules" value="{{ .form.ScraperRules }}" spellcheck="false">
 
-                <label for="form-rewrite-rules">{{ t "form.feed.label.rewrite_rules" }}</label>
+                <div class="rules-entry">
+                    <label for="form-rewrite-rules">
+                        {{ t "form.feed.label.rewrite_rules" }}
+                    </label>
+                    &nbsp;
+                    <a href="https://miniflux.app/docs/rules.html#rewrite-rules" target="_blank">
+                        {{ icon "external-link" }}
+                    </a>
+                </div>
                 <input type="text" name="rewrite_rules" id="form-rewrite-rules" value="{{ .form.RewriteRules }}" spellcheck="false">
-
-                <label for="form-blocklist-rules">{{ t "form.feed.label.blocklist_rules" }}</label>
+                <div class="rules-entry">
+                    <label for="form-blocklist-rules">
+                        {{ t "form.feed.label.blocklist_rules" }}
+                    </label>
+                    &nbsp;
+                    <a href=" https://miniflux.app/docs/rules.html#filtering-rules" target="_blank">
+                        {{ icon "external-link" }}
+                    </a>
+                </div>
                 <input type="text" name="blocklist_rules" id="form-blocklist-rules" value="{{ .form.BlocklistRules }}" spellcheck="false">
- 
-                <label for="form-keeplist-rules">{{ t "form.feed.label.keeplist_rules" }}</label>
+
+                <div class="rules-entry">
+                    <label for="form-keeplist-rules">
+                        {{ t "form.feed.label.keeplist_rules" }}
+                    </label>
+                    &nbsp;
+                    <a href=" https://miniflux.app/docs/rules.html#filtering-rules" target="_blank">
+                        {{ icon "external-link" }}
+                    </a>
+                </div>
                 <input type="text" name="keeplist_rules" id="form-keeplist-rules" value="{{ .form.KeeplistRules }}" spellcheck="false">
             </div>
         </details>

--- a/template/templates/views/edit_feed.html
+++ b/template/templates/views/edit_feed.html
@@ -61,16 +61,47 @@
         <label for="form-cookie">{{ t "form.feed.label.cookie" }}</label>
         <input type="text" name="cookie" id="form-cookie" value="{{ .form.Cookie }}" spellcheck="false">
 
-        <label for="form-scraper-rules">{{ t "form.feed.label.scraper_rules" }}</label>
+        <div class="rules-entry">
+            <label for="form-scraper-rules">
+                {{ t "form.feed.label.scraper_rules" }}
+            </label>
+            &nbsp;
+            <a href="https://miniflux.app/docs/rules.html#scraper-rules" target="_blank">
+                {{ icon "external-link" }}
+            </a>
+        </div>
         <input type="text" name="scraper_rules" id="form-scraper-rules" value="{{ .form.ScraperRules }}" spellcheck="false">
 
-        <label for="form-rewrite-rules">{{ t "form.feed.label.rewrite_rules" }}</label>
+        <div class="rules-entry">
+            <label for="form-rewrite-rules">
+                {{ t "form.feed.label.rewrite_rules" }}
+            </label>
+            &nbsp;
+            <a href="https://miniflux.app/docs/rules.html#rewrite-rules" target="_blank">
+                {{ icon "external-link" }}
+            </a>
+        </div>
         <input type="text" name="rewrite_rules" id="form-rewrite-rules" value="{{ .form.RewriteRules }}" spellcheck="false">
-
-        <label for="form-blocklist-rules">{{ t "form.feed.label.blocklist_rules" }}</label>
+        <div class="rules-entry">
+            <label for="form-blocklist-rules">
+                {{ t "form.feed.label.blocklist_rules" }}
+            </label>
+            &nbsp;
+            <a href=" https://miniflux.app/docs/rules.html#filtering-rules" target="_blank">
+                {{ icon "external-link" }}
+            </a>
+        </div>
         <input type="text" name="blocklist_rules" id="form-blocklist-rules" value="{{ .form.BlocklistRules }}" spellcheck="false">
 
-        <label for="form-keeplist-rules">{{ t "form.feed.label.keeplist_rules" }}</label>
+        <div class="rules-entry">
+            <label for="form-keeplist-rules">
+                {{ t "form.feed.label.keeplist_rules" }}
+            </label>
+            &nbsp;
+            <a href=" https://miniflux.app/docs/rules.html#filtering-rules" target="_blank">
+                {{ icon "external-link" }}
+            </a>
+        </div>
         <input type="text" name="keeplist_rules" id="form-keeplist-rules" value="{{ .form.KeeplistRules }}" spellcheck="false">
 
         <label for="form-category">{{ t "form.feed.label.category" }}</label>

--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -1052,3 +1052,7 @@ details.entry-enclosures {
     text-decoration: none;
     font-size: 1.2em;
 }
+
+.rules-entry {
+    display: flex;
+}


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request

Preview: 
![127 0 0 1_8080_subscribe](https://user-images.githubusercontent.com/2840106/150664133-ecaf598d-7c09-41f2-b2df-10382f12a92a.png)

We could optionally extract those URLs to a template for reuse, but I figured it's cleaner not to since they're only used in two places.
