### PR TITLE
Fetch original article with api, fix #1114

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -62,4 +62,5 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	sr.HandleFunc("/entries", handler.setEntryStatus).Methods(http.MethodPut)
 	sr.HandleFunc("/entries/{entryID}", handler.getEntry).Methods(http.MethodGet)
 	sr.HandleFunc("/entries/{entryID}/bookmark", handler.toggleBookmark).Methods(http.MethodPut)
+	sr.HandleFunc("/entries/{entryID}/download", handler.fetchContent).Methods(http.MethodGet)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -62,5 +62,5 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	sr.HandleFunc("/entries", handler.setEntryStatus).Methods(http.MethodPut)
 	sr.HandleFunc("/entries/{entryID}", handler.getEntry).Methods(http.MethodGet)
 	sr.HandleFunc("/entries/{entryID}/bookmark", handler.toggleBookmark).Methods(http.MethodPut)
-	sr.HandleFunc("/entries/{entryID}/download", handler.fetchContent).Methods(http.MethodGet)
+	sr.HandleFunc("/entries/{entryID}/fetch-content", handler.fetchContent).Methods(http.MethodGet)
 }

--- a/api/entry.go
+++ b/api/entry.go
@@ -13,9 +13,9 @@ import (
 	"miniflux.app/http/request"
 	"miniflux.app/http/response/json"
 	"miniflux.app/model"
+	"miniflux.app/reader/processor"
 	"miniflux.app/storage"
 	"miniflux.app/validator"
-	"miniflux.app/reader/processor"
 )
 
 func getEntryFromBuilder(w http.ResponseWriter, r *http.Request, b *storage.EntryQueryBuilder) {

--- a/api/entry.go
+++ b/api/entry.go
@@ -15,6 +15,7 @@ import (
 	"miniflux.app/model"
 	"miniflux.app/storage"
 	"miniflux.app/validator"
+	"miniflux.app/reader/processor"
 )
 
 func getEntryFromBuilder(w http.ResponseWriter, r *http.Request, b *storage.EntryQueryBuilder) {
@@ -170,6 +171,46 @@ func (h *handler) toggleBookmark(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NoContent(w, r)
+}
+
+func (h *handler) fetchContent(w http.ResponseWriter, r *http.Request) {
+	loggedUserID := request.UserID(r)
+	entryID := request.RouteInt64Param(r, "entryID")
+
+	entryBuilder := h.store.NewEntryQueryBuilder(loggedUserID)
+	entryBuilder.WithEntryID(entryID)
+	entryBuilder.WithoutStatus(model.EntryStatusRemoved)
+
+	entry, err := entryBuilder.GetEntry()
+	if err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	if entry == nil {
+		json.NotFound(w, r)
+		return
+	}
+
+	feedBuilder := storage.NewFeedQueryBuilder(h.store, loggedUserID)
+	feedBuilder.WithFeedID(entry.FeedID)
+	feed, err := feedBuilder.GetFeed()
+	if err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	if feed == nil {
+		json.NotFound(w, r)
+		return
+	}
+
+	if err := processor.ProcessEntryWebPage(feed, entry); err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	json.OK(w, r, map[string]string{"content": entry.Content})
 }
 
 func configureFilters(builder *storage.EntryQueryBuilder, r *http.Request) {


### PR DESCRIPTION
Hi,

I needed to fetch the original article via API. I also came across #1114 so I have implemented it.
Of course a client API could fetch the article by itself, but the api is usefull (cors, apply feed rules, could also proxy image)

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Regards,
Pascal
