### PR TITLE
Add a rewrite rule for castopod episodes

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -282,3 +282,9 @@ func removeCustom(entryContent string, selector string) string {
 	output, _ := doc.Find("body").First().Html()
 	return output
 }
+
+func addCastopodEpisode(entryURL, entryContent string) string {
+	player := `<iframe width="650" frameborder="0" src="` + entryURL + `/embed/light"></iframe>`
+
+	return player + `<br>` + entryContent
+}

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -100,6 +100,8 @@ func applyRule(entryURL, entryContent string, rule rule) string {
 		} else {
 			logger.Debug("[Rewrite] Cannot find selector for remove rule %s", rule)
 		}
+	case "add_castopod_episode":
+		entryContent = addCastopodEpisode(entryURL, entryContent)
 	}
 
 	return entryContent

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -286,3 +286,12 @@ func TestRewriteRemoveCustom(t *testing.T) {
 		t.Errorf(`Not expected output: %s`, output)
 	}
 }
+
+func TestRewriteAddCastopodEpisode(t *testing.T) {
+	output := Rewriter("https://podcast.demo/@demo/episodes/test", "Episode Description", `add_castopod_episode`)
+	expected := `<iframe width="650" frameborder="0" src="https://podcast.demo/@demo/episodes/test/embed/light"></iframe><br>Episode Description`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}


### PR DESCRIPTION
This new rewrite rule allows to add an embedded player for podcast episodes from a castopod instance.

You can test it with [this feed](https://podcast.picasoft.net/@la_voix_est_libre), you have to add `add_castopod_episode` in rewrite rules.

![image](https://user-images.githubusercontent.com/19993671/151692235-ee6f900e-225c-4462-8790-d70c8c6edc90.png)

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request