### PR TITLE
RFC: Add (+) action next to Feeds to quickly add new feeds

### DIFF
--- a/template/templates/common/layout.html
+++ b/template/templates/common/layout.html
@@ -77,6 +77,9 @@
                           <span class="error-feeds-counter-wrapper">(<span class="error-feeds-counter">{{ .countErrorFeeds }}</span>)</span>
                       {{ end }}
                     </a>
+                    <a href="{{ route "addSubscription" }}" title="{{ t "tooltip.keyboard_shortcuts" "+" }}">
+                        (+)
+                    </a>
                 </li>
                 <li {{ if eq .menu "categories" }}class="active"{{ end }} title="{{ t "tooltip.keyboard_shortcuts" "g c" }}">
                     <a href="{{ route "categories" }}" data-page="categories">{{ t "menu.categories" }}</a>

--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -68,7 +68,7 @@ a:hover {
     border-bottom: 1px dotted var(--header-list-border-color);
 }
 
-.header li:hover a {
+.header li a:hover {
     color: #888;
 }
 


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

@fguillot curious if you like this change.
![localhost_8080_subscribe](https://user-images.githubusercontent.com/2840106/154827509-f3a9ed99-18b8-4ecd-b3e3-ea9e7e7beabb.png)

To add new feeds from mobile, you first need to click "Feeds" (which can be slow once you have lots of feeds, as all feeds are loaded without any pagination), and then "Add subscription". This change makes it easier to go straight to the "Add subscription" page, without needing to list all feeds.

We could potentially improve it a bit by adding some styling to the `(+)` (maybe by fading it out a bit).