### PR TITLE
Generate title from content for RSS, Atom 0.3 and Atom 1.0 feeds, truncate too long title

### DIFF
--- a/reader/atom/atom_03.go
+++ b/reader/atom/atom_03.go
@@ -94,7 +94,22 @@ func (a *atom03Entry) Transform() *model.Entry {
 }
 
 func (a *atom03Entry) entryTitle() string {
-	return sanitizer.StripTags(a.Title.String())
+	title := a.Title.String()
+
+	if title == "" {
+		title = a.entryContent()
+	}
+
+	// Strip HTML/XML tags
+	title = sanitizer.StripTags(title)
+	// Trim spaces
+	title = strings.TrimSpace(title)
+	// Replace newlines with spaces
+	title = strings.ReplaceAll(title, "\n", " ")
+	// Truncate to max length
+	title = truncate(title)
+
+	return title
 }
 
 func (a *atom03Entry) entryContent() string {

--- a/reader/atom/atom_03_test.go
+++ b/reader/atom/atom_03_test.go
@@ -125,6 +125,34 @@ func TestParseAtom03WithoutEntryTitle(t *testing.T) {
 	}
 }
 
+func TestParseAtom03WithoutEntryTitleButSummary(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<feed version="0.3" xmlns="http://purl.org/atom/ns#">
+		<title>dive into mark</title>
+		<link rel="alternate" type="text/html" href="http://diveintomark.org/"/>
+		<modified>2003-12-13T18:30:02Z</modified>
+		<author><name>Mark Pilgrim</name></author>
+		<entry>
+			<link rel="alternate" type="text/html" href="http://diveintomark.org/2003/12/13/atom03"/>
+			<id>tag:diveintomark.org,2003:3.2397</id>
+			<summary type="text/plain">Test</summary>
+		</entry>
+	</feed>`
+
+	feed, err := Parse("http://diveintomark.org/", bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(feed.Entries) != 1 {
+		t.Errorf("Incorrect number of entries, got: %d", len(feed.Entries))
+	}
+
+	if feed.Entries[0].Title != "Test" {
+		t.Errorf("Incorrect entry title, got: %s", feed.Entries[0].Content)
+	}
+}
+
 func TestParseAtom03WithSummaryOnly(t *testing.T) {
 	data := `<?xml version="1.0" encoding="utf-8"?>
 	<feed version="0.3" xmlns="http://purl.org/atom/ns#">

--- a/reader/atom/atom_10_test.go
+++ b/reader/atom/atom_10_test.go
@@ -116,7 +116,6 @@ func TestParseEntryWithoutTitle(t *testing.T) {
 		<link href="http://example.org/2003/12/13/atom03"/>
 		<id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
 		<updated>2003-12-13T18:30:02Z</updated>
-		<summary>Some text.</summary>
 	  </entry>
 
 	</feed>`
@@ -127,6 +126,37 @@ func TestParseEntryWithoutTitle(t *testing.T) {
 	}
 
 	if feed.Entries[0].Title != "http://example.org/2003/12/13/atom03" {
+		t.Errorf("Incorrect entry title, got: %s", feed.Entries[0].Title)
+	}
+}
+
+func TestParseEntryWithoutTitleButSummary(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<feed xmlns="http://www.w3.org/2005/Atom">
+
+	  <title>Example Feed</title>
+	  <link href="http://example.org/"/>
+	  <updated>2003-12-13T18:30:02Z</updated>
+	  <author>
+		<name>John Doe</name>
+	  </author>
+	  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+
+	  <entry>
+		<link href="http://example.org/2003/12/13/atom03"/>
+		<id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+		<updated>2003-12-13T18:30:02Z</updated>
+		<summary>Some text.</summary>
+	  </entry>
+
+	</feed>`
+
+	feed, err := Parse("https://example.org/", bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feed.Entries[0].Title != "Some text." {
 		t.Errorf("Incorrect entry title, got: %s", feed.Entries[0].Title)
 	}
 }

--- a/reader/rss/rss.go
+++ b/reader/rss/rss.go
@@ -260,7 +260,21 @@ func (r *rssItem) entryTitle() string {
 		}
 	}
 
-	return html.UnescapeString(strings.TrimSpace(title))
+	if title == "" {
+		// Use content and strip HTML/XML tags
+		title = sanitizer.StripTags(r.entryContent())
+	}
+
+	// Unescape HTML
+	title = html.UnescapeString(title)
+	// Trim spaces
+	title = strings.TrimSpace(title)
+	// Replace newlines with spaces
+	title = strings.ReplaceAll(title, "\n", " ")
+	// Truncate to max length
+	title = truncate(title)
+
+	return title
 }
 
 func (r *rssItem) entryContent() string {
@@ -380,4 +394,17 @@ func isValidLinkRelation(rel string) bool {
 		}
 		return false
 	}
+}
+
+func truncate(str string) string {
+	max := 100
+	str = strings.TrimSpace(str)
+
+	// Convert to runes to be safe with unicode
+	runes := []rune(str)
+	if len(runes) > max {
+		return string(runes[:max]) + "…"
+	}
+
+	return str
 }


### PR DESCRIPTION
With this PR, I try to adjust the parsing behaviour of RSS and ATOM feeds to the one of JSON Feeds regarding the title. I'm not sure about RDF feeds yet, but I suggest doing the same there.

Related issue: #1373 

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
