### PR TITLE
Gray out pagination buttons when they are not applicable

### DIFF
--- a/template/templates/common/entry_pagination.html
+++ b/template/templates/common/entry_pagination.html
@@ -1,6 +1,6 @@
 {{ define "entry_pagination" }}
 <div class="pagination">
-    <div class="pagination-prev">
+    <div class="pagination-prev {{ if not .prevEntry }}disabled{{end}}">
         {{ if .prevEntry }}
             <a href="{{ .prevEntryRoute }}{{ if .searchQuery }}?q={{ .searchQuery }}{{ end }}" title="{{ .prevEntry.Title }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
         {{ else }}
@@ -8,7 +8,7 @@
         {{ end }}
     </div>
 
-    <div class="pagination-next">
+    <div class="pagination-next {{ if not .nextEntry }}disabled{{end}}">
         {{ if .nextEntry }}
             <a href="{{ .nextEntryRoute }}{{ if .searchQuery }}?q={{ .searchQuery }}{{ end }}" title="{{ .nextEntry.Title }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
         {{ else }}

--- a/template/templates/common/pagination.html
+++ b/template/templates/common/pagination.html
@@ -1,6 +1,6 @@
 {{ define "pagination" }}
 <div class="pagination">
-    <div class="pagination-prev">
+    <div class="pagination-prev {{ if not .ShowPrev }}disabled{{end}}">
         {{ if .ShowPrev }}
             <a href="{{ .Route }}{{ if gt .PrevOffset 0 }}?offset={{ .PrevOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}{{ else }}{{ if .SearchQuery }}?q={{ .SearchQuery }}{{ end }}{{ end }}" data-page="previous" rel="prev">{{ t "pagination.previous" }}</a>
         {{ else }}
@@ -8,7 +8,7 @@
         {{ end }}
     </div>
 
-    <div class="pagination-next">
+    <div class="pagination-next {{ if not .ShowNext }}disabled{{end}}">
         {{ if .ShowNext }}
             <a href="{{ .Route }}?offset={{ .NextOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}" data-page="next" rel="next">{{ t "pagination.next" }}</a>
         {{ else }}

--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -1065,3 +1065,7 @@ details.entry-enclosures {
 .rules-entry {
     display: flex;
 }
+
+.disabled {
+    opacity: 20%;
+}


### PR DESCRIPTION
Whenever the "prev" and "next" buttons have no hyperlink, decrease their
opacity to signal that they lead to nowhere.

This signal is stronger and more obvious than the current one which
merely removes the underline decoration from the text.

This patch is an improvement on top of
https://github.com/miniflux/v2/pull/1107

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
