### PR TITLE
Hide sensitive information in config-dump

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -79,7 +79,9 @@ func Parse() {
 	}
 
 	if flagConfigDump {
-		fmt.Print(config.Opts)
+		for _, v := range config.Opts.SortedOptions(true) {
+			fmt.Printf("%v=%v\n", v.Key, v.Value)
+		}
 		return
 	}
 


### PR DESCRIPTION
Like the about page, config-dump has the potential of revealing
sensitive information. Re-use the same mechanism as used by the about
page to hide it.

Signed-off-by: Alexandros Kosiaris <akosiaris@gmail.com>

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
