### PR TITLE
Reduce number of preflight check to save network brandwidth

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -27,6 +27,7 @@ func (m *middleware) handleCORS(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "X-Auth-Token")
 		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Max-Age", "3600")
 			w.WriteHeader(http.StatusOK)
 			return
 		}


### PR DESCRIPTION
Hi,

When I used the api, for example with reminiflux frontend, I noticed there is a lot of preflight check (almost one per api request). 

We can actually add an extra _[Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age)_ header so that the browser will cache the preflight for while.

This will save a lot of calls during browsing. It is relevant not only in term of brandwidth but also a relief for miniflux which can only handle a limited number of paralel requests.

![before_after](https://user-images.githubusercontent.com/2127862/167250247-f5c9e517-57bb-4f47-b7f2-932aa1370023.png)

Of course, 
- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Regards,
Pascal Noisette
