### PR TITLE
Fetch unread count with api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -47,6 +47,7 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	sr.HandleFunc("/discover", handler.discoverSubscriptions).Methods(http.MethodPost)
 	sr.HandleFunc("/feeds", handler.createFeed).Methods(http.MethodPost)
 	sr.HandleFunc("/feeds", handler.getFeeds).Methods(http.MethodGet)
+	sr.HandleFunc("/feeds/fetch-counters", handler.fetchCounters).Methods(http.MethodGet)
 	sr.HandleFunc("/feeds/refresh", handler.refreshAllFeeds).Methods(http.MethodPut)
 	sr.HandleFunc("/feeds/{feedID}/refresh", handler.refreshFeed).Methods(http.MethodPut)
 	sr.HandleFunc("/feeds/{feedID}", handler.getFeed).Methods(http.MethodGet)

--- a/api/feed.go
+++ b/api/feed.go
@@ -170,6 +170,17 @@ func (h *handler) getFeeds(w http.ResponseWriter, r *http.Request) {
 	json.OK(w, r, feeds)
 }
 
+func (h *handler) fetchCounters(w http.ResponseWriter, r *http.Request) {
+	_, unreadCounters, err := h.store.FetchCounters(request.UserID(r))
+
+	if err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	json.OK(w, r, unreadCounters)
+}
+
 func (h *handler) getFeed(w http.ResponseWriter, r *http.Request) {
 	feedID := request.RouteInt64Param(r, "feedID")
 	feed, err := h.store.FeedByID(request.UserID(r), feedID)

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -158,6 +158,13 @@ func (s *Storage) FeedsWithCounters(userID int64) (model.Feeds, error) {
 	return getFeedsSorted(builder)
 }
 
+// Return only read and unread count.
+func (s *Storage) FetchCounters(userID int64) (readCounters map[int64]int, unreadCounters map[int64]int, err error) {
+	builder := NewFeedQueryBuilder(s, userID)
+	builder.WithCounters()
+	return builder.fetchFeedCounter()
+}
+
 // FeedsByCategoryWithCounters returns all feeds of the given user/category with counters of read and unread entries.
 func (s *Storage) FeedsByCategoryWithCounters(userID, categoryID int64) (model.Feeds, error) {
 	builder := NewFeedQueryBuilder(s, userID)


### PR DESCRIPTION
Hi,

On alternative frontends using the api (such as reminiflux) there is no efficent way to retrieve the feeds unread count. At the moment, the only way to find out the unread count is a request for each feeds (total given by /v1/feeds/{feedID}/entries). I have a collection of 200+ feeds, this is a lot of calls.

This PR open an api /feeds/fetch-counters to return the unread count in one call. That way an issue may be openned on the reminiflux projet to use it.

One other solution could be a change in GET /v1/feeds to fetch the feed _WithCounters_ (and Feed.UnreadCount marshalled in json) but maybe some frontends does not want this request to be impeded by a count they do not need.

Of course,
- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Regards,
Pascal