### PR TITLE
request_builder.js: Fix syntax error

### DIFF
--- a/ui/static/js/request_builder.js
+++ b/ui/static/js/request_builder.js
@@ -30,7 +30,7 @@ class RequestBuilder {
     }
 
     getCsrfToken() {
-        let element = document.querySelector("body[data-csrf-token");
+        let element = document.querySelector("body[data-csrf-token]");
         if (element !== null) {
             return element.dataset.csrfToken;
         }


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

---

This simply fixes a syntax error in request_builder.js that causes most buttons to not work in Leopard Webkit and possibly other old browsers. I've tested it running from a Raspberry Pi and the fix does work.