### PR TITLE
With content/description extract in list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/gddo v0.0.0-20200831202555-721e228c7686 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.6
+	github.com/microcosm-cc/bluemonday v1.0.18 // indirect
 	github.com/mitchellh/go-server-timing v1.0.2-0.20201108055052-feb680ab92c2
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -171,6 +173,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -220,6 +224,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/microcosm-cc/bluemonday v1.0.18 h1:6HcxvXDAi3ARt3slx6nTesbvorIc3QeTzBNRvWktHBo=
+github.com/microcosm-cc/bluemonday v1.0.18/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-server-timing v1.0.2-0.20201108055052-feb680ab92c2 h1:9kYRAm87/M5VL+HWegDGIorBWDiErrZrksLKTJBF2IQ=
 github.com/mitchellh/go-server-timing v1.0.2-0.20201108055052-feb680ab92c2/go.mod h1:8mKJVJkyMI20ifXXO0zlV3sh3FrtjvltAeBqz38clBE=
@@ -404,6 +410,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8 h1:/6y1LfuqNuQdHAm0jjtPtgRcxIxjVZgm5OTu8/QhZvk=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20170912212905-13449ad91cb2/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/template/functions.go
+++ b/template/functions.go
@@ -23,7 +23,6 @@ import (
 	"miniflux.app/url"
 
 	"github.com/gorilla/mux"
-	"github.com/microcosm-cc/bluemonday"
 )
 
 type funcMap struct {
@@ -31,7 +30,6 @@ type funcMap struct {
 }
 
 var imgRE = regexp.MustCompile(`<img[^>]+\bsrc=["']([^"']+)\.jpg["']`)
-var bmpolicy = bluemonday.StripTagsPolicy()
 
 // Map returns a map of template functions that are compiled during template parsing.
 func (f *funcMap) Map() template.FuncMap {
@@ -42,7 +40,7 @@ func (f *funcMap) Map() template.FuncMap {
 		"truncate":       truncate,
 		"isEmail":        isEmail,
 		"stripHTML": func(htm string) template.HTML {
-			stripped := bmpolicy.Sanitize(string(htm))
+			stripped := sanitizer.StripTags(string(htm))
 			return template.HTML(fmt.Sprintf("%s", stripped))
 		},
 		"findImages": func (htm, title string) template.HTML {

--- a/template/templates/common/item_meta.html
+++ b/template/templates/common/item_meta.html
@@ -15,6 +15,16 @@
         </li>
         {{ end }}
     </ul>
+    <article role="article" class="item-meta-desc" dir="auto">
+        <p>
+            {{ findImages .entry.Content (t .entry.Title) }}
+            {{ if .user }}
+                {{  stripHTML (proxyFilter .entry.Content) }}
+            {{ else }}
+                {{ stripHTML (.entry.Content) }}
+            {{ end }}
+        </p>
+    </article>
     <ul class="item-meta-icons">
         <li>
             <a href="#"

--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -1,3 +1,5 @@
+:root {--itemmetadescsize: 8}
+
 /* Layout */
 * {
     margin: 0;
@@ -723,6 +725,22 @@ template {
 
 .item-meta li {
     display: inline-block;
+}
+
+.item-meta-desc {
+    display: -webkit-box;
+    -webkit-line-clamp: var(--itemmetadescsize);
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin-top: 0.5em;
+}
+
+.item-meta-desc img:first-child {
+    float: right;
+    box-shadow: 0 0.1em 0.25em 0 rgba(0, 0, 0, 0.2), 0 0.1em 0.25em 0 rgba(0, 0, 0, 0.2);
+    border-radius: 0.5em;
+    margin: 0.25em 0.5em 0 0.5em;
+    max-height: calc(var(--itemmetadescsize) * 1em);
 }
 
 .item-meta-info {


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
- [X] I don't code in go usually so there is probably a better way to implement this.

This PR adds a small section of the description or content of the feed under the title (and if there is an image in the content it will try to use the first one it finds).  

It is useful for feeds that have generic titles.  Personally I find it useful for ebay feeds where the price of the item is not included in the title but near the beginning of the description tag, using this PR prevents me from multiple mouse clicks and shows me a quick thumbnail of the item without having to either click on the external link or through to the item view page for every item in the feed I am interested in.

The image/description size can be altered using custom css:

`:root {--itemmetadescsize: 8}`

That would mean a description 8 lines long with an image the same height.  CSS is used to truncate the description and style the image.