### PR TITLE
Document that -config-dump shows sensitive info

### DIFF
--- a/miniflux.1
+++ b/miniflux.1
@@ -25,7 +25,7 @@ Load configuration file\&.
 .PP
 .B \-config-dump
 .RS 4
-Print parsed configuration values\&.
+Print parsed configuration values. This will include sensitive information like passwords\&.
 .RE
 .PP
 .B \-create-admin


### PR DESCRIPTION
Why:
Avoid surprising users that may not expect that passwords might be
printed in the config dump output

What:
Update manpage

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
