### PR TITLE
Support other repo owners in GH docker action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Generate Alpine Docker tag
         id: docker_alpine_tag
         run: |
-          DOCKER_IMAGE=miniflux/miniflux
+          DOCKER_IMAGE=${{ github.repository_owner }}/miniflux
           DOCKER_VERSION=dev
           if [ "${{ github.event_name }}" = "schedule" ]; then
           DOCKER_VERSION=nightly
@@ -32,7 +32,7 @@ jobs:
       - name: Generate Distroless Docker tag
         id: docker_distroless_tag
         run: |
-          DOCKER_IMAGE=miniflux/miniflux
+          DOCKER_IMAGE=${{ github.repository_owner }}/miniflux
           DOCKER_VERSION=dev-distroless
           if [ "${{ github.event_name }}" = "schedule" ]; then
           DOCKER_VERSION=nightly-distroless


### PR DESCRIPTION
Being able to functionaly utilize the same GH Docker action can be
beneficial for users wanting to build, test and develop in their own
repos. To do so, use ${{ github.repository_owner }} in the action. That
should provide some rudimentary flexibility without breaking the
canonical repo.

Users of this functionality should take care to populate the required
secrets in Github

* DOCKERHUB_TOKEN, DOCKERHUB_USERNAME
* CR_PAT

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
