### PR TITLE
Don't wrap text in article titles

### DIFF
--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -693,6 +693,16 @@ template {
     box-shadow: var(--current-item-box-shadow);
 }
 
+.item-header {
+    display: flex;
+}
+
+.item-title {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .item-title a {
     text-decoration: none;
     font-weight: var(--item-title-link-font-weight);


### PR DESCRIPTION
For feeds that post often, I tend to just skim titles without reading, then mark them as read. However, since the titles can wrap, this will make the button move around depending on the length of the title.

This change adds some simple CSS to show an ellipsis if the text is too long, rather than wrapping the article element to be bigger. Here's what it looks like before the change:

![Before](https://user-images.githubusercontent.com/15850505/180100481-615fd074-7132-4a4b-b2a2-c0ff03907490.png)

And after the change:

![After](https://user-images.githubusercontent.com/15850505/180100503-5ba638bc-42f1-4193-9bff-4a49d9ace1ef.png)

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
