### PR TITLE
Parse markdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/tdewolff/minify/v2 v2.12.0
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
+	github.com/yuin/goldmark v1.1.32
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20210916014120-12bc252f5db8
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.1.32 h1:5tjfNdR2ki3yYQ842+eX2sQHeiwpKJ0RnHO4IYOc4V8=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -15,6 +15,8 @@ import (
 	"miniflux.app/config"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/yuin/goldmark"
+	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
 )
 
 var (
@@ -317,4 +319,19 @@ func decodeBase64Content(entryContent string) string {
 	} else {
 		return html.EscapeString(string(ret))
 	}
+}
+
+func parseMarkdown(entryContent string) string {
+	var sb strings.Builder
+	md := goldmark.New(
+		goldmark.WithRendererOptions(
+			goldmarkhtml.WithUnsafe(),
+		),
+	)
+
+	if err := md.Convert([]byte(entryContent), &sb); err != nil {
+		return entryContent
+	}
+
+	return sb.String()
 }

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -108,6 +108,8 @@ func applyRule(entryURL, entryContent string, rule rule) string {
 		} else {
 			entryContent = applyFuncOnTextContent(entryContent, "body", decodeBase64Content)
 		}
+	case "parse_markdown":
+		entryContent = parseMarkdown(entryContent)
 	}
 
 	return entryContent

--- a/reader/rewrite/rules.go
+++ b/reader/rewrite/rules.go
@@ -10,6 +10,7 @@ package rewrite // import "miniflux.app/reader/rewrite"
 var predefinedRules = map[string]string{
 	"abstrusegoose.com":      "add_image_title",
 	"amazingsuperpowers.com": "add_image_title",
+	"blog.laravel.com":       "parse_markdown",
 	"cowbirdsinlove.com":     "add_image_title",
 	"drawingboardcomic.com":  "add_image_title",
 	"exocomics.com":          "add_image_title",


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

## Details

This PR adds a new rewrite rule that parses markdown. Parsing is done with a new dependency [yuin/goldmark](https://github.com/yuin/goldmark). This PR also configures the parse markdown rule by default for `blog.laravel.com`.

Note that goldmark sanitizes all input HTML by default, so I added the `html.WithUnsafe` flag. This flag allows HTML input to show up in the parsed output, causing it to behave more like other Miniflux rewrite rules.

## Testing

Tested working with https://blog.laravel.com/feed.

## Screenshots:

<details>
  <summary>Before</summary>

  <img width="600" alt="image" src="https://user-images.githubusercontent.com/7717888/181283592-a6fab807-08e4-4d41-8c6a-d3e172a55be1.png">
</details>

<details>
  <summary>After</summary>

  <img width="600" alt="image" src="https://user-images.githubusercontent.com/7717888/181283693-2fd2b0be-895d-4545-812a-d4446f9cdeaf.png">
</details>