### PR TITLE
Google Reader API: Fix incorrect ParseInt

### DIFF
--- a/googlereader/handler.go
+++ b/googlereader/handler.go
@@ -357,7 +357,7 @@ func getItemIDs(r *http.Request) ([]int64, error) {
 		var itemID int64
 		_, err := fmt.Sscanf(item, EntryIDLong, &itemID)
 		if err != nil {
-			itemID, err = strconv.ParseInt(item, 16, 64)
+			itemID, err = strconv.ParseInt(item, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("could not parse item: %v", item)
 			}


### PR DESCRIPTION
Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] I read this document: https://miniflux.app/faq.html#pull-request
