### PR TITLE
Allow setting a custom image proxy URL

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -46,6 +46,7 @@ const (
 	defaultCleanupArchiveBatchSize            = 10000
 	defaultCleanupRemoveSessionsDays          = 30
 	defaultProxyImages                        = "http-only"
+	defaultProxyImageUrl                      = ""
 	defaultFetchYouTubeWatchTime              = false
 	defaultCreateAdmin                        = false
 	defaultAdminUsername                      = ""
@@ -116,6 +117,7 @@ type Options struct {
 	adminUsername                      string
 	adminPassword                      string
 	proxyImages                        string
+	proxyImageUrl                      string
 	fetchYouTubeWatchTime              bool
 	oauth2UserCreationAllowed          bool
 	oauth2ClientID                     string
@@ -175,6 +177,7 @@ func NewOptions() *Options {
 		workerPoolSize:                     defaultWorkerPoolSize,
 		createAdmin:                        defaultCreateAdmin,
 		proxyImages:                        defaultProxyImages,
+		proxyImageUrl:                      defaultProxyImageUrl,
 		fetchYouTubeWatchTime:              defaultFetchYouTubeWatchTime,
 		oauth2UserCreationAllowed:          defaultOAuth2UserCreation,
 		oauth2ClientID:                     defaultOAuth2ClientID,
@@ -410,6 +413,11 @@ func (o *Options) ProxyImages() string {
 	return o.proxyImages
 }
 
+// ProxyImageUrl returns a string of a URL to use to proxy image requests
+func (o *Options) ProxyImageUrl() string {
+	return o.proxyImageUrl
+}
+
 // HasHTTPService returns true if the HTTP service is enabled.
 func (o *Options) HasHTTPService() bool {
 	return o.httpService
@@ -543,6 +551,7 @@ func (o *Options) SortedOptions(redactSecret bool) []*Option {
 		"POLLING_PARSING_ERROR_LIMIT":            o.pollingParsingErrorLimit,
 		"POLLING_SCHEDULER":                      o.pollingScheduler,
 		"PROXY_IMAGES":                           o.proxyImages,
+		"PROXY_IMAGE_URL":                        o.proxyImageUrl,
 		"ROOT_URL":                               o.rootURL,
 		"RUN_MIGRATIONS":                         o.runMigrations,
 		"SCHEDULER_ENTRY_FREQUENCY_MAX_INTERVAL": o.schedulerEntryFrequencyMaxInterval,

--- a/config/parser.go
+++ b/config/parser.go
@@ -139,6 +139,8 @@ func (p *Parser) parseLines(lines []string) (err error) {
 			p.opts.pollingParsingErrorLimit = parseInt(value, defaultPollingParsingErrorLimit)
 		case "PROXY_IMAGES":
 			p.opts.proxyImages = parseString(value, defaultProxyImages)
+		case "PROXY_IMAGE_URL":
+			p.opts.proxyImageUrl = parseString(value, defaultProxyImageUrl)
 		case "CREATE_ADMIN":
 			p.opts.createAdmin = parseBool(value, defaultCreateAdmin)
 		case "ADMIN_USERNAME":

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,16 +6,32 @@ package proxy // import "miniflux.app/proxy"
 
 import (
 	"encoding/base64"
+	"net/url"
+	"path"
 
 	"miniflux.app/http/route"
 
 	"github.com/gorilla/mux"
+
+	"miniflux.app/config"
 )
 
 // ProxifyURL generates an URL for a proxified resource.
 func ProxifyURL(router *mux.Router, link string) string {
 	if link != "" {
-		return route.Path(router, "proxy", "encodedURL", base64.URLEncoding.EncodeToString([]byte(link)))
+		proxyImageUrl := config.Opts.ProxyImageUrl()
+
+		if proxyImageUrl == "" {
+			return route.Path(router, "proxy", "encodedURL", base64.URLEncoding.EncodeToString([]byte(link)))
+		}
+
+		proxyUrl, err := url.Parse(proxyImageUrl)
+		if err != nil {
+			return ""
+		}
+
+		proxyUrl.Path = path.Join(proxyUrl.Path, base64.URLEncoding.EncodeToString([]byte(link)))
+		return proxyUrl.String()
 	}
 	return ""
 }


### PR DESCRIPTION
Adds an option to proxy images through a custom proxy host instead of miniflux. I wanted this so that I can. maintain a cache of the images on a local machine and can read my feeds with no internet.

I have a [sample implementation](https://github.com/nicolecomputer/rss-image-proxy) of the image server (and one that I'm using)

## Testing
- Added a test for automatic testing
- I've been running a [docker image](https://github.com/nicolecomputer/miniflux-v2/pkgs/container/miniflux) with the changes on my server and it works fine

## Guidelines
- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
