### PR TITLE
API: Allow Basic authorization header

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -25,7 +25,7 @@ func (m *middleware) handleCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "X-Auth-Token")
+		w.Header().Set("Access-Control-Allow-Headers", "X-Auth-Token, Authorization")
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Access-Control-Max-Age", "3600")
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Allow "Authorization" header for the API to allow external clients to call the API without API key (using good ol' basic auth).
