### PR TITLE
support date filtering for all google reader api item ID calls

### DIFF
--- a/googlereader/handler.go
+++ b/googlereader/handler.go
@@ -1123,6 +1123,13 @@ func (h *handler) handleReadingListStream(w http.ResponseWriter, r *http.Request
 	builder.WithLimit(rm.Count)
 	builder.WithOrder(model.DefaultSortingOrder)
 	builder.WithDirection(rm.SortDirection)
+	if rm.StartTime > 0 {
+		builder.AfterDate(time.Unix(rm.StartTime, 0))
+	}
+	if rm.StopTime > 0 {
+		builder.BeforeDate(time.Unix(rm.StopTime, 0))
+	}
+
 	rawEntryIDs, err := builder.GetEntryIDs()
 	if err != nil {
 		logger.Error("[GoogleReader][/stream/items/ids#reading-list] [ClientIP=%s] %v", clientIP, err)
@@ -1145,6 +1152,13 @@ func (h *handler) handleStarredStream(w http.ResponseWriter, r *http.Request, rm
 	builder.WithLimit(rm.Count)
 	builder.WithOrder(model.DefaultSortingOrder)
 	builder.WithDirection(rm.SortDirection)
+	if rm.StartTime > 0 {
+		builder.AfterDate(time.Unix(rm.StartTime, 0))
+	}
+	if rm.StopTime > 0 {
+		builder.BeforeDate(time.Unix(rm.StopTime, 0))
+	}
+
 	rawEntryIDs, err := builder.GetEntryIDs()
 	if err != nil {
 		logger.Error("[GoogleReader][/stream/items/ids#starred] [ClientIP=%s] %v", clientIP, err)


### PR DESCRIPTION
Support the before/after date parameters on all forms of the streamItemIDs Google Reader API call. Previously only the read and feed variants of the call respected those parameters.

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
