### PR TITLE
Use automatic variable for build target file names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,55 +46,55 @@ miniflux:
 	@ go build -buildmode=pie -ldflags=$(LD_FLAGS) -o $(APP) main.go
 
 linux-amd64:
-	@ GOOS=linux GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-linux-amd64 main.go
+	@ GOOS=linux GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 linux-arm64:
-	@ GOOS=linux GOARCH=arm64 go build -ldflags=$(LD_FLAGS) -o $(APP)-linux-arm64 main.go
+	@ GOOS=linux GOARCH=arm64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 linux-armv7:
-	@ GOOS=linux GOARCH=arm GOARM=7 go build -ldflags=$(LD_FLAGS) -o $(APP)-linux-armv7 main.go
+	@ GOOS=linux GOARCH=arm GOARM=7 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 linux-armv6:
-	@ GOOS=linux GOARCH=arm GOARM=6 go build -ldflags=$(LD_FLAGS) -o $(APP)-linux-armv6 main.go
+	@ GOOS=linux GOARCH=arm GOARM=6 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 linux-armv5:
-	@ GOOS=linux GOARCH=arm GOARM=5 go build -ldflags=$(LD_FLAGS) -o $(APP)-linux-armv5 main.go
+	@ GOOS=linux GOARCH=arm GOARM=5 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 darwin-amd64:
-	@ GOOS=darwin GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-darwin-amd64 main.go
+	@ GOOS=darwin GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 darwin-arm64:
-	@ GOOS=darwin GOARCH=arm64 go build -ldflags=$(LD_FLAGS) -o $(APP)-darwin-arm64 main.go
+	@ GOOS=darwin GOARCH=arm64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 freebsd-amd64:
-	@ GOOS=freebsd GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-freebsd-amd64 main.go
+	@ GOOS=freebsd GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 openbsd-amd64:
-	@ GOOS=openbsd GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-openbsd-amd64 main.go
+	@ GOOS=openbsd GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 windows-amd64:
-	@ GOOS=windows GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-windows-amd64 main.go
+	@ GOOS=windows GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 build: linux-amd64 linux-arm64 linux-armv7 linux-armv6 linux-armv5 darwin-amd64 darwin-arm64 freebsd-amd64 openbsd-amd64 windows-amd64
 
 # NOTE: unsupported targets
 netbsd-amd64:
-	@ GOOS=netbsd GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-netbsd-amd64 main.go
+	@ GOOS=netbsd GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 linux-x86:
-	@ GOOS=linux GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-linux-x86 main.go
+	@ GOOS=linux GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 freebsd-x86:
-	@ GOOS=freebsd GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-freebsd-x86 main.go
+	@ GOOS=freebsd GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 netbsd-x86:
-	@ GOOS=netbsd GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-netbsd-x86 main.go
+	@ GOOS=netbsd GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 openbsd-x86:
-	@ GOOS=openbsd GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-freebsd-x86 main.go
+	@ GOOS=openbsd GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 windows-x86:
-	@ GOOS=windows GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-windows-x86 main.go
+	@ GOOS=windows GOARCH=386 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go
 
 run:
 	@ LOG_DATE_TIME=1 DEBUG=1 RUN_MIGRATIONS=1 go run main.go


### PR DESCRIPTION
Do you follow the guidelines?
- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

---

A simple change that parameterizes some data and might help avoid typo bugs in the future.
I tested it by running `make clean && make build && file miniflux-* | nl` before and after the change and the output of `file` is the same (aside from the `BuildID`s) and it looks like this:

```
     1	miniflux-darwin-amd64:  Mach-O 64-bit x86_64 executable
     2	miniflux-darwin-arm64:  Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
     3	miniflux-freebsd-amd64: ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD), statically linked, Go BuildID=PUiF7g7HsVk6m5Bi55_V/v8OL5-jOP8xd7JogjUGA/SaJwnCAExIrQNFzlffBY/2ZSV90CbrS_yUeYDNlzZ, stripped
     4	miniflux-linux-amd64:   ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=-QYWiZaygfl0Zg6k9Okp/qdKyi_AhutVgCkpPLUOP/c4R_G8bE65iuuuxh0CDO/ZIZgKApeosh8h80dkbMa, stripped
     5	miniflux-linux-arm64:   ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=Frn-9hj5VoAqXdIzpRUq/LUp2esbPbVSidklB_iYt/irwwUFXwzTNwq5xikY_z/iZCBXKBDXom3TyW1iwlR, stripped
     6	miniflux-linux-armv5:   ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=foXMOrZhyGpC_2MVkF9a/dKV-agVcIXBW0zxfi_Da/HlW9M3lwK0oHK95LWlTV/WW1Mc_Aanl58wz3UAiII, stripped
     7	miniflux-linux-armv6:   ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=Nu9ervvbmmRa1TAWaTHf/uaXvB83Gcc1I6CMBbc6O/HlW9M3lwK0oHK95LWlTV/VKLcMLQDYisJf0HLKHYd, stripped
     8	miniflux-linux-armv7:   ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=y_7mKyjHT9fHyJRI3Cl1/Qp9LgHQ9XOSzRXQnIHwN/HlW9M3lwK0oHK95LWlTV/F4n_aDIQgXt1UOjw6TvO, stripped
     9	miniflux-openbsd-amd64: ELF 64-bit LSB executable, x86-64, version 1 (OpenBSD), dynamically linked, interpreter /usr/libexec/ld.so, for OpenBSD, Go BuildID=qHX-6HhNMRMxmrpJp0DY/XusYFyNxGPhKxMe_BmlL/T1KUxbCsrh21oL5HlAIH/auw-KlY5BJWs8wHvF6mf, stripped
    10	miniflux-windows-amd64: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```