### PR TITLE
use dirs file for debian package

### DIFF
--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -22,6 +22,7 @@ cd /src && \
     cp /src/packaging/debian/miniflux.manpages /build/debian/miniflux.manpages && \
     cp /src/packaging/debian/miniflux.postinst /build/debian/miniflux.postinst && \
     cp /src/packaging/debian/rules /build/debian/rules && \
+    cp /src/packaging/debian/miniflux.dirs /build/debian/miniflux.dirs && \
     echo "miniflux ($PKG_VERSION) experimental; urgency=low" > /build/debian/changelog && \
     echo "  * Miniflux version $PKG_VERSION" >> /build/debian/changelog && \
     echo " -- Frédéric Guillot <f@miniflux.net>  $PKG_DATE" >> /build/debian/changelog && \

--- a/packaging/debian/miniflux.dirs
+++ b/packaging/debian/miniflux.dirs
@@ -1,0 +1,2 @@
+etc
+usr/bin

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -9,8 +9,6 @@ override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
 override_dh_auto_install:
-	mkdir -p $(DESTDIR)/etc
-	mkdir -p $(DESTDIR)/usr/bin
 	cp miniflux.conf $(DESTDIR)/etc/miniflux.conf
 	cp miniflux $(DESTDIR)/usr/bin/miniflux
 


### PR DESCRIPTION
Instead of running mkdir from debian/rules, the native way to create the necessary directories is with the dirs file which is read by the dh_installdirs helper script.

See:
* https://www.debian.org/doc/manuals/maint-guide/dother.en.html#dirs
* dh_installdirs(1) manual page

I am not aware of any specific problems that could arise from doing it manually instead of using dh_installdirs. But sticking to the native approach might be a good idea.
--
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
