### PR TITLE
Use custom home page in PWA

### DIFF
--- a/ui/static_manifest.go
+++ b/ui/static_manifest.go
@@ -59,7 +59,7 @@ func (h *handler) showWebManifest(w http.ResponseWriter, r *http.Request) {
 		ShortName:       "Miniflux",
 		Description:     "Minimalist Feed Reader",
 		Display:         displayMode,
-		StartURL:        route.Path(h.router, "unread"),
+		StartURL:        route.Path(h.router, "login"),
 		ThemeColor:      themeColor,
 		BackgroundColor: themeColor,
 		Icons: []webManifestIcon{


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

#1509 added the ability to set a custom home page, but this change was not available in the PWA since the home page was hard-coded in the web manifest. This PR just use the root endpoint to take advantage of the new feature also in the PWA.