### PR TITLE
Enable TLS-ALPN-01 challenge for ACME

### DIFF
--- a/service/httpd/httpd.go
+++ b/service/httpd/httpd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 )
 
@@ -128,6 +129,7 @@ func startAutoCertTLSServer(server *http.Server, certDomain string, store *stora
 	}
 	server.TLSConfig = tlsConfig()
 	server.TLSConfig.GetCertificate = certManager.GetCertificate
+	server.TLSConfig.NextProtos = []string{"h2", "http/1.1", acme.ALPNProto}
 
 	// Handle http-01 challenge.
 	s := &http.Server{


### PR DESCRIPTION
This type of challenge works purely at the TLS layer and is compatible with SNI proxies. The existing HTTP-01 challenge support has been left as-is.

Fixes #1476.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
