### PR TITLE
Disable double-tap mobile gesture if swipe gesture is disabled

### DIFF
--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -308,7 +308,7 @@
     "form.prefs.select.alphabetical": "Alphabetical",
     "form.prefs.select.unread_count": "Unread count",
     "form.prefs.label.keyboard_shortcuts": "Enable keyboard shortcuts",
-    "form.prefs.label.entry_swipe": "Enable swipe gesture on entries on mobile",
+    "form.prefs.label.entry_swipe": "Enable swipe and double-tap gestures on entries on mobile",
     "form.prefs.label.show_reading_time": "Show estimated reading time for entries",
     "form.prefs.label.custom_css": "Custom CSS",
     "form.prefs.label.entry_order": "Entry sorting column",

--- a/template/templates/views/entry.html
+++ b/template/templates/views/entry.html
@@ -143,7 +143,7 @@
     </div>
     {{ end }}
     {{ end }}
-    <article role="article" class="entry-content" dir="auto">
+    <article role="article" class="entry-content {{ if $.user.EntrySwipe }}double-tap{{ end }}" dir="auto">
         {{ if .user }}
             {{ noescape (proxyFilter .entry.Content) }}
         {{ else }}

--- a/ui/static/js/touch_handler.js
+++ b/ui/static/js/touch_handler.js
@@ -104,7 +104,7 @@ class TouchHandler {
         });
 
         let entryContentElement = document.querySelector(".entry-content");
-        if (entryContentElement) {
+        if (entryContentElement && entryContentElement.classList.contains('double-tap')) {
             let doubleTapTimers = {
                 previous: null,
                 next: null


### PR DESCRIPTION
Fixes #441.

Concerns:

- [ ] This changes the meaning of the `EntrySwipe` parameter to control both the mobile double-tap gesture, as well as the mobile swipe gesture. I think this is in the spirit of the parameter, as both are gestures designed to imitate mobile apps at the cost of changing how Miniflux responds to touch inputs compared to regular websites. Nonetheless it's possible it breaks *somebody's* workflow (https://xkcd.com/1172/).
	- Should double-tap gestures be controlled by a separate `EntryDoubleTap` setting, in case someone wants swiping but not double-tap, or vice versa?
	- If not, should the key be renamed to `EntryGestures` in the Go code? What about the database as well?
- [ ] Should the text be simplified to say "Enable gestures on entries on mobile" (at the cost of losing information)?
- [ ] I did not update all translations.

(This does not fix pinch zooming mis-triggering a double-tap input. But I don't want pinch zooming *or* double tap to act differently from regular webpages.)

----

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
