### PR TITLE
Support transparent status bar on iOS

### DIFF
--- a/template/templates/common/layout.html
+++ b/template/templates/common/layout.html
@@ -32,6 +32,10 @@
     <meta name="theme-color" content="{{ theme_color .theme "light" }}" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="{{ theme_color .theme "dark" }}" media="(prefers-color-scheme: dark)">
 
+    <!-- iOS status bar -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
     <link rel="stylesheet" type="text/css" href="{{ route "stylesheet" "name" .theme "checksum" .theme_checksum }}">
 
     {{ if and .user .user.Stylesheet }}

--- a/template/templates/standalone/offline.html
+++ b/template/templates/standalone/offline.html
@@ -7,6 +7,8 @@
         <meta name="color-scheme" content="dark light">
         <meta name="theme-color" content="{{ theme_color .theme "light" }}" media="(prefers-color-scheme: light)">
         <meta name="theme-color" content="{{ theme_color .theme "dark" }}" media="(prefers-color-scheme: dark)">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     </head>
     <body>
         <p>{{ t "page.offline.message" }} - <a href="{{ route "unread" }}">{{ t "page.offline.refresh_page" }}</a>.</p>


### PR DESCRIPTION
This is a small change to HTML to make the status bar on iOS transparent. It isn't really notable with the default themes, but is helpful for PWA when using custom CSS. Docs [from Apple](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html) regarding these tags

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
