### PR TITLE
sanitizer: allow id in <sup>

### DIFF
--- a/reader/sanitizer/sanitizer.go
+++ b/reader/sanitizer/sanitizer.go
@@ -414,7 +414,7 @@ func getTagAllowList() map[string][]string {
 	whitelist["wbr"] = []string{}
 	whitelist["dfn"] = []string{}
 	whitelist["sub"] = []string{}
-	whitelist["sup"] = []string{}
+	whitelist["sup"] = []string{"id"}
 	whitelist["var"] = []string{}
 	whitelist["samp"] = []string{}
 	whitelist["s"] = []string{}


### PR DESCRIPTION
One of blogs I read uses anchor on <sup> to link a footnote back to its reference.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
