### PR TITLE
fix: add `color-scheme` to themes

### DIFF
--- a/ui/static/css/dark.css
+++ b/ui/static/css/dark.css
@@ -116,3 +116,7 @@
 
     --counter-color: #bbb;
 }
+
+body {
+    color-scheme: dark;
+}

--- a/ui/static/css/light.css
+++ b/ui/static/css/light.css
@@ -116,3 +116,7 @@
 
     --counter-color: #666;
 }
+
+body {
+    color-scheme: light;
+}

--- a/ui/static/css/system.css
+++ b/ui/static/css/system.css
@@ -116,6 +116,10 @@
     --counter-color: #666;
 }
 
+body {
+    color-scheme: light;
+}
+
 @media (prefers-color-scheme: dark) {
     :root {
         --body-color: #efefef;
@@ -232,5 +236,9 @@
         --keyboard-shortcuts-li-color: #9b9b9b;
 
         --counter-color: #bbb;
+    }
+
+    body {
+        color-scheme: dark;
     }
 }


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

---

This is a simple PR that adds the `color-scheme` property to the different themes, so that native browser elements (e.g. form controls and the scrollbar) are rendered in the selected theme.
