### PR TITLE
Update docker compose examples to the latest Compose file format

### DIFF
--- a/contrib/docker-compose/README.md
+++ b/contrib/docker-compose/README.md
@@ -8,6 +8,5 @@ Here are few Docker Compose examples:
 - `traefik.yml`: Use Traefik as reverse-proxy with automatic HTTPS
 
 ```bash
-docker-compose -f basic.yml up -d db
-docker-compose -f basic.yml up
+docker compose -f basic.yml up -d
 ```

--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   miniflux:
     image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}

--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -6,7 +6,8 @@ services:
     ports:
       - "80:8080"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DATABASE_URL=postgres://miniflux:secret@db/miniflux?sslmode=disable
       - RUN_MIGRATIONS=1

--- a/contrib/docker-compose/caddy.yml
+++ b/contrib/docker-compose/caddy.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   caddy:
     image: caddy:2

--- a/contrib/docker-compose/caddy.yml
+++ b/contrib/docker-compose/caddy.yml
@@ -15,7 +15,8 @@ services:
     image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DATABASE_URL=postgres://miniflux:secret@db/miniflux?sslmode=disable
       - RUN_MIGRATIONS=1

--- a/contrib/docker-compose/traefik.yml
+++ b/contrib/docker-compose/traefik.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   traefik:
     image: "traefik:v2.3"

--- a/contrib/docker-compose/traefik.yml
+++ b/contrib/docker-compose/traefik.yml
@@ -20,7 +20,8 @@ services:
     image: ${MINIFLUX_IMAGE:-miniflux/miniflux:latest}
     container_name: miniflux
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     expose:
       - "8080"
     environment:


### PR DESCRIPTION
Fixes #1693.

According to the [Compose file versions](https://docs.docker.com/compose/compose-file/compose-versioning/#versioning),

>The latest Compose file format is defined by the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) and is implemented by Docker Compose 1.27.0+.

This PR updates the compose files examples.

- Add health check condition to `depends_on`, it was re-introduced in the specification after it was removed in v3. Effectively this reverts #1270.
- Remove [deprecated](https://docs.docker.com/compose/compose-file/#version-top-level-element) `version` top-level element.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
