### PR TITLE
Fix null reference in toggle entry attachments shortcut

### DIFF
--- a/ui/static/js/bootstrap.js
+++ b/ui/static/js/bootstrap.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", function () {
         keyboardHandler.on("+", () => goToAddSubscription());
         keyboardHandler.on("#", () => unsubscribeFromFeed());
         keyboardHandler.on("/", (e) => setFocusToSearchInput(e));
-        keyboardHandler.on("a", () => document.querySelector('.entry-enclosures').toggleAttribute('open'));
+        keyboardHandler.on("a", () => document.querySelector('.entry-enclosures')?.toggleAttribute('open'));
         keyboardHandler.on("Escape", () => ModalHandler.close());
         keyboardHandler.listen();
     }


### PR DESCRIPTION
- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

---

`document.querySelector()` possibly return null.

If entry has not attachment, return value is null. `null.toggleAttribute('open')` cause TypeError.

[Optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) can fix it, supported by [most modern browsers](https://caniuse.com/mdn-javascript_operators_optional_chaining):

- Chrome: 80+ (2020-)
- Saferi: 13.4+ (2020-)
- Firefox: 74+ (2020-)