### PR TITLE
Use `r.RemoteAddr` to check `/metrics` endpoint network access

### DIFF
--- a/http/request/client_ip.go
+++ b/http/request/client_ip.go
@@ -10,15 +10,7 @@ import (
 	"strings"
 )
 
-func dropIPv6zone(address string) string {
-	i := strings.IndexByte(address, '%')
-	if i != -1 {
-		address = address[:i]
-	}
-	return address
-}
-
-// FindClientIP returns client real IP address.
+// FindClientIP returns the client real IP address based on trusted Reverse-Proxy HTTP headers.
 func FindClientIP(r *http.Request) string {
 	headers := []string{"X-Forwarded-For", "X-Real-Ip"}
 	for _, header := range headers {
@@ -36,6 +28,11 @@ func FindClientIP(r *http.Request) string {
 	}
 
 	// Fallback to TCP/IP source IP address.
+	return FindRemoteIP(r)
+}
+
+// FindRemoteIP returns remote client IP address.
+func FindRemoteIP(r *http.Request) string {
 	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		remoteIP = r.RemoteAddr
@@ -48,4 +45,12 @@ func FindClientIP(r *http.Request) string {
 	}
 
 	return remoteIP
+}
+
+func dropIPv6zone(address string) string {
+	i := strings.IndexByte(address, '%')
+	if i != -1 {
+		address = address[:i]
+	}
+	return address
 }


### PR DESCRIPTION
HTTP headers like X-Forwarded-For or X-Real-Ip can be easily spoofed. As such, it cannot be used to test if the client IP is allowed.

The recommendation is to use HTTP Basic authentication to protect the metrics endpoint, or run Miniflux behind a trusted reverse-proxy.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
