### PR TITLE
Avoid XSS when opening a broken image due to unescaped ServerError in proxy handler

### DIFF
--- a/http/response/html/html.go
+++ b/http/response/html/html.go
@@ -26,6 +26,7 @@ func ServerError(w http.ResponseWriter, r *http.Request, err error) {
 
 	builder := response.New(w, r)
 	builder.WithStatus(http.StatusInternalServerError)
+	builder.WithHeader("Content-Security-Policy", `default-src 'self'`)
 	builder.WithHeader("Content-Type", "text/html; charset=utf-8")
 	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
 	builder.WithBody(err)
@@ -38,6 +39,7 @@ func BadRequest(w http.ResponseWriter, r *http.Request, err error) {
 
 	builder := response.New(w, r)
 	builder.WithStatus(http.StatusBadRequest)
+	builder.WithHeader("Content-Security-Policy", `default-src 'self'`)
 	builder.WithHeader("Content-Type", "text/html; charset=utf-8")
 	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
 	builder.WithBody(err)

--- a/ui/proxy.go
+++ b/ui/proxy.go
@@ -83,7 +83,8 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := clt.Do(req)
 	if err != nil {
-		html.ServerError(w, r, err)
+		logger.Error(`[Proxy] Unable to initialize HTTP client: %v`, err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
Creating an RSS feed item with the inline description containing an `<img>` tag with a `srcset` attribute pointing to an invalid URL like `http:a<script>alert(1)</script>`, we can coerce the proxy handler into an error condition where the invalid URL is returned unescaped and in full.

This results in JavaScript execution on the Miniflux instance as soon as the user is convinced to open the broken image.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
