### PR TITLE
feat: support searching well-known urls in subdirectory

### DIFF
--- a/reader/subscription/finder.go
+++ b/reader/subscription/finder.go
@@ -143,46 +143,53 @@ func parseYoutubeVideoPage(websiteURL string) string {
 func tryWellKnownUrls(websiteURL, userAgent, cookie, username, password string) (Subscriptions, *errors.LocalizedError) {
 	var subscriptions Subscriptions
 	knownURLs := map[string]string{
-		"/atom.xml": "atom",
-		"/feed.xml": "atom",
-		"/feed/":    "atom",
-		"/rss.xml":  "rss",
-		"/rss/":     "rss",
+		"atom.xml": "atom",
+		"feed.xml": "atom",
+		"feed/":    "atom",
+		"rss.xml":  "rss",
+		"rss/":     "rss",
 	}
 
-	lastCharacter := websiteURL[len(websiteURL)-1:]
-	if lastCharacter == "/" {
-		websiteURL = websiteURL[:len(websiteURL)-1]
+	websiteURLRoot := url.RootURL(websiteURL)
+	baseURLs := []string{
+		// Look for knownURLs in the root.
+		websiteURLRoot,
+	}
+	// Look for knownURLs in current subdirectory, such as 'example.com/blog/'.
+	websiteURL, _ = url.AbsoluteURL(websiteURL, "./")
+	if websiteURL != websiteURLRoot {
+		baseURLs = append(baseURLs, websiteURL)
 	}
 
-	for knownURL, kind := range knownURLs {
-		fullURL, err := url.AbsoluteURL(websiteURL, knownURL)
-		if err != nil {
-			continue
-		}
+	for _, baseURL := range baseURLs {
+		for knownURL, kind := range knownURLs {
+			fullURL, err := url.AbsoluteURL(baseURL, knownURL)
+			if err != nil {
+				continue
+			}
+			clt := client.NewClientWithConfig(fullURL, config.Opts)
+			clt.WithCredentials(username, password)
+			clt.WithUserAgent(userAgent)
+			clt.WithCookie(cookie)
 
-		clt := client.NewClientWithConfig(fullURL, config.Opts)
-		clt.WithCredentials(username, password)
-		clt.WithUserAgent(userAgent)
-		clt.WithCookie(cookie)
+			// Some websites redirects unknown URLs to the home page.
+			// As result, the list of known URLs is returned to the subscription list.
+			// We don't want the user to choose between invalid feed URLs.
+			clt.WithoutRedirects()
 
-		// Some websites redirects unknown URLs to the home page.
-		// As result, the list of known URLs is returned to the subscription list.
-		// We don't want the user to choose between invalid feed URLs.
-		clt.WithoutRedirects()
+			response, err := clt.Get()
+			if err != nil {
+				continue
+			}
 
-		response, err := clt.Get()
-		if err != nil {
-			continue
-		}
-
-		if response != nil && response.StatusCode == 200 {
-			subscription := new(Subscription)
-			subscription.Type = kind
-			subscription.Title = fullURL
-			subscription.URL = fullURL
-			if subscription.URL != "" {
-				subscriptions = append(subscriptions, subscription)
+			if response != nil && response.StatusCode == 200 {
+				subscription := new(Subscription)
+				subscription.Type = kind
+				subscription.Title = fullURL
+				subscription.URL = fullURL
+				if subscription.URL != "" {
+					subscriptions = append(subscriptions, subscription)
+				}
 			}
 		}
 	}

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -25,6 +25,8 @@ func TestAbsoluteURL(t *testing.T) {
 	scenarios := [][]string{
 		{"https://example.org/path/file.ext", "https://example.org/folder/", "/path/file.ext"},
 		{"https://example.org/folder/path/file.ext", "https://example.org/folder/", "path/file.ext"},
+		{"https://example.org/", "https://example.org/path", "./"},
+		{"https://example.org/folder/", "https://example.org/folder/", "./"},
 		{"https://example.org/path/file.ext", "https://example.org/folder", "path/file.ext"},
 		{"https://example.org/path/file.ext", "https://example.org/folder/", "https://example.org/path/file.ext"},
 		{"https://static.example.org/path/file.ext", "https://www.example.org/", "//static.example.org/path/file.ext"},


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

This pr increases the search scope for well-known urls:

- The default is to search in the root directory, as before
- When the url is a subdirectory (not the root and ending with `/`), e.g. `https://example.com/blog/`, it will also search in that subdirectory

Real-world example: https://www.brendangregg.com/blog/.