### PR TITLE
Use `secrets.GITHUB_TOKEN` to push images instead of a PAT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,4 @@
 name: Docker
-permissions: read-all
 on:
   schedule:
     - cron: '0 1 * * *'
@@ -8,6 +7,8 @@ on:
       - '*.*.*'
 jobs:
   docker-images:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Quay Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] I read this document: https://miniflux.app/faq.html#pull-request
