### PR TITLE
remove_tables rewrite rule

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -342,25 +342,26 @@ func removeTables(entryContent string) string {
 		return entryContent
 	}
 
-	var table *goquery.Selection
+	selectors := []string{"table", "tbody", "thead", "td", "th", "td"}
 
-	for {
-		table = doc.Find("table").First()
+	var loopElement *goquery.Selection
 
-		if table.Length() == 0 {
-			break
+	for _, selector := range selectors {
+		for {
+			loopElement = doc.Find(selector).First()
+
+			if loopElement.Length() == 0 {
+				break
+			}
+
+			innerHtml, err := loopElement.Html()
+			if err != nil {
+				break
+			}
+
+			loopElement.Parent().AppendHtml(innerHtml)
+			loopElement.Remove()
 		}
-
-		td := table.Find("td").First()
-
-		if td.Length() == 0 {
-			break
-		}
-
-		tdHtml, _ := td.Html()
-
-		table.Parent().AppendHtml(tdHtml)
-		table.Remove()
 	}
 
 	output, _ := doc.Find("body").First().Html()

--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -335,3 +335,34 @@ func parseMarkdown(entryContent string) string {
 
 	return sb.String()
 }
+
+func removeTables(entryContent string) string {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(entryContent))
+	if err != nil {
+		return entryContent
+	}
+
+	var table *goquery.Selection
+
+	for {
+		table = doc.Find("table").First()
+
+		if table.Length() == 0 {
+			break
+		}
+
+		td := table.Find("td").First()
+
+		if td.Length() == 0 {
+			break
+		}
+
+		tdHtml, _ := td.Html()
+
+		table.Parent().AppendHtml(tdHtml)
+		table.Remove()
+	}
+
+	output, _ := doc.Find("body").First().Html()
+	return output
+}

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -110,6 +110,8 @@ func applyRule(entryURL, entryContent string, rule rule) string {
 		}
 	case "parse_markdown":
 		entryContent = parseMarkdown(entryContent)
+	case "remove_tables":
+		entryContent = removeTables(entryContent)
 	}
 
 	return entryContent

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -325,3 +325,13 @@ func TestRewriteBase64DecodeArgs(t *testing.T) {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
 	}
 }
+
+func TestRewriteRemoveTables(t *testing.T) {
+	content := `<table class="container"><tbody><tr><td><p>Test</p><table class="row"><tbody><tr><td>Hello World!</td></tr></tbody></table></td></tr></tbody></table>`
+	expected := `<p>Test</p>Hello World!`
+	output := Rewriter("https://example.org/article", content, `remove_tables`)
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -327,8 +327,8 @@ func TestRewriteBase64DecodeArgs(t *testing.T) {
 }
 
 func TestRewriteRemoveTables(t *testing.T) {
-	content := `<table class="container"><tbody><tr><td><p>Test</p><table class="row"><tbody><tr><td>Hello World!</td></tr></tbody></table></td></tr></tbody></table>`
-	expected := `<p>Test</p>Hello World!`
+	content := `<table class="container"><tbody><tr><td><p>Test</p><table class="row"><tbody><tr><td><p>Hello World!</p></td><td><p>Test</p></td></tr></tbody></table></td></tr></tbody></table>`
+	expected := `<p>Test</p><p>Hello World!</p><p>Test</p>`
 	output := Rewriter("https://example.org/article", content, `remove_tables`)
 
 	if expected != output {


### PR DESCRIPTION
I've been using a service to convert email newsletters into RSS feeds for use in Miniflux. However, as you will be able to see below, lots of email newsletter styling is done through tables which aren't sanitised and makes the readability not so great.

I've added a simple filter (`remove_tables`) that removes table elements (`table`, `thead`, `tbody`, `tr`, `th`, `td`), only keeping the content inside. I realise not many people might be using email newsletters like I am but hopefully this can help where they are.

<table>
<tr>
<td>
<p><b>Before</b></p>
<img src="https://user-images.githubusercontent.com/10981005/229277588-8f4ed920-eb29-4072-a503-74468e04787f.png"/>
</td>
<td>
<p><b>After</b></p>
<img src="https://user-images.githubusercontent.com/10981005/229277493-388639ea-af56-4693-9864-b122cdfaf21a.png"/>
</td>
</tr>
</table>

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request