### PR TITLE
Filter related articles section for theverge.com

### DIFF
--- a/reader/rewrite/rules.go
+++ b/reader/rewrite/rules.go
@@ -31,7 +31,7 @@ var predefinedRules = map[string]string{
 	"quantamagazine.org":     `add_youtube_video_from_id, remove("h6:not(.byline,.post__title__kicker), #comments, .next-post__content, .footer__section, figure .outer--content, script")`,
 	"sentfromthemoon.com":    "add_image_title",
 	"thedoghousediaries.com": "add_image_title",
-	"theverge.com":           "add_dynamic_image",
+	"theverge.com":           `add_dynamic_image, remove("div.duet--recirculation--related-list")`,
 	"treelobsters.com":       "add_image_title",
 	"www.qwantz.com":         "add_image_title,add_mailto_subject",
 	"www.recalbox.com":       "parse_markdown",


### PR DESCRIPTION
The body of The Verge articles can contain a section for related articles. This section is distracting in reader mode. Therefore, filter the related article section using the scraper rules.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
