### PR TITLE
Use rss channel>image>url as feed icon

### DIFF
--- a/model/feed.go
+++ b/model/feed.go
@@ -51,6 +51,7 @@ type Feed struct {
 	FetchViaProxy               bool      `json:"fetch_via_proxy"`
 	Category                    *Category `json:"category,omitempty"`
 	Entries                     Entries   `json:"entries,omitempty"`
+	IconURL                     string    `json:"icon_url"`
 	Icon                        *FeedIcon `json:"icon"`
 	HideGlobally                bool      `json:"hide_globally"`
 	UnreadCount                 int       `json:"-"`

--- a/reader/handler/handler.go
+++ b/reader/handler/handler.go
@@ -96,6 +96,7 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 		store,
 		subscription.ID,
 		subscription.SiteURL,
+		subscription.IconURL,
 		feedCreationRequest.UserAgent,
 		feedCreationRequest.FetchViaProxy,
 		feedCreationRequest.AllowSelfSignedCertificates,
@@ -189,6 +190,7 @@ func RefreshFeed(store *storage.Storage, userID, feedID int64) error {
 			store,
 			originalFeed.ID,
 			originalFeed.SiteURL,
+			updatedFeed.IconURL,
 			originalFeed.UserAgent,
 			originalFeed.FetchViaProxy,
 			originalFeed.AllowSelfSignedCertificates,
@@ -208,9 +210,9 @@ func RefreshFeed(store *storage.Storage, userID, feedID int64) error {
 	return nil
 }
 
-func checkFeedIcon(store *storage.Storage, feedID int64, websiteURL, userAgent string, fetchViaProxy, allowSelfSignedCertificates bool) {
+func checkFeedIcon(store *storage.Storage, feedID int64, websiteURL, iconURL, userAgent string, fetchViaProxy, allowSelfSignedCertificates bool) {
 	if !store.HasIcon(feedID) {
-		icon, err := icon.FindIcon(websiteURL, userAgent, fetchViaProxy, allowSelfSignedCertificates)
+		icon, err := icon.FindIcon(websiteURL, iconURL, userAgent, fetchViaProxy, allowSelfSignedCertificates)
 		if err != nil {
 			logger.Debug(`[CheckFeedIcon] %v (feedID=%d websiteURL=%s)`, err, feedID, websiteURL)
 		} else if icon == nil {

--- a/reader/icon/finder.go
+++ b/reader/icon/finder.go
@@ -23,30 +23,32 @@ import (
 )
 
 // FindIcon try to find the website's icon.
-func FindIcon(websiteURL, userAgent string, fetchViaProxy, allowSelfSignedCertificates bool) (*model.Icon, error) {
-	rootURL := url.RootURL(websiteURL)
-	logger.Debug("[FindIcon] Trying to find an icon: rootURL=%q websiteURL=%q userAgent=%q", rootURL, websiteURL, userAgent)
+func FindIcon(websiteURL, iconURL, userAgent string, fetchViaProxy, allowSelfSignedCertificates bool) (*model.Icon, error) {
+	if iconURL == "" {
+		rootURL := url.RootURL(websiteURL)
+		logger.Debug("[FindIcon] Trying to find an icon: rootURL=%q websiteURL=%q userAgent=%q", rootURL, websiteURL, userAgent)
 
-	clt := client.NewClientWithConfig(rootURL, config.Opts)
-	clt.WithUserAgent(userAgent)
-	clt.AllowSelfSignedCertificates = allowSelfSignedCertificates
+		clt := client.NewClientWithConfig(rootURL, config.Opts)
+		clt.WithUserAgent(userAgent)
+		clt.AllowSelfSignedCertificates = allowSelfSignedCertificates
 
-	if fetchViaProxy {
-		clt.WithProxy()
-	}
+		if fetchViaProxy {
+			clt.WithProxy()
+		}
 
-	response, err := clt.Get()
-	if err != nil {
-		return nil, fmt.Errorf("icon: unable to download website index page: %v", err)
-	}
+		response, err := clt.Get()
+		if err != nil {
+			return nil, fmt.Errorf("icon: unable to download website index page: %v", err)
+		}
 
-	if response.HasServerFailure() {
-		return nil, fmt.Errorf("icon: unable to download website index page: status=%d", response.StatusCode)
-	}
+		if response.HasServerFailure() {
+			return nil, fmt.Errorf("icon: unable to download website index page: status=%d", response.StatusCode)
+		}
 
-	iconURL, err := parseDocument(rootURL, response.Body)
-	if err != nil {
-		return nil, err
+		iconURL, err = parseDocument(rootURL, response.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if strings.HasPrefix(iconURL, "data:") {

--- a/reader/rss/rss.go
+++ b/reader/rss/rss.go
@@ -27,6 +27,7 @@ type rssFeed struct {
 	Version        string    `xml:"version,attr"`
 	Title          string    `xml:"channel>title"`
 	Links          []rssLink `xml:"channel>link"`
+	ImageURL       string    `xml:"channel>image>url"`
 	Language       string    `xml:"channel>language"`
 	Description    string    `xml:"channel>description"`
 	PubDate        string    `xml:"channel>pubDate"`
@@ -57,6 +58,8 @@ func (r *rssFeed) Transform(baseURL string) *model.Feed {
 	if feed.Title == "" {
 		feed.Title = feed.SiteURL
 	}
+
+	feed.IconURL = strings.TrimSpace(r.ImageURL)
 
 	for _, item := range r.Items {
 		entry := item.Transform()


### PR DESCRIPTION
- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

If an image is included in the rss feed under <channel><image><url> use it for the feed icon instead of fetching favicon. Useful for Mastodon user feeds where you'd want the profile picture and not the instance logo as the feed icon.
Might be able to close #1257