### PR TITLE
fix: remove title for a hrefs

### DIFF
--- a/template/templates/views/bookmark_entries.html
+++ b/template/templates/views/bookmark_entries.html
@@ -19,7 +19,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "starredEntry" "entryID" .ID }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "starredEntry" "entryID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/template/templates/views/category_entries.html
+++ b/template/templates/views/category_entries.html
@@ -56,7 +56,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "categoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "categoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/template/templates/views/feed_entries.html
+++ b/template/templates/views/feed_entries.html
@@ -81,7 +81,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "feedEntry" "feedID" .Feed.ID "entryID" .ID }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "feedEntry" "feedID" .Feed.ID "entryID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/template/templates/views/history_entries.html
+++ b/template/templates/views/history_entries.html
@@ -35,7 +35,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "readEntry" "entryID" .ID }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "readEntry" "entryID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/template/templates/views/search_entries.html
+++ b/template/templates/views/search_entries.html
@@ -19,7 +19,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "searchEntry" "entryID" .ID }}?q={{ $.searchQuery }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "searchEntry" "entryID" .ID }}?q={{ $.searchQuery }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>

--- a/template/templates/views/shared_entries.html
+++ b/template/templates/views/shared_entries.html
@@ -32,7 +32,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "readEntry" "entryID" .ID }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "readEntry" "entryID" .ID }}">{{ .Title }}</a>
                     {{ if .ShareCode }}
                         <a href="{{ route "sharedEntry" "shareCode" .ShareCode }}"
                             title="{{ t "entry.shared_entry.title" }}"

--- a/template/templates/views/unread_entries.html
+++ b/template/templates/views/unread_entries.html
@@ -42,7 +42,7 @@
                     {{ if ne .Feed.Icon.IconID 0 }}
                         <img src="{{ route "icon" "iconID" .Feed.Icon.IconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
                     {{ end }}
-                    <a href="{{ route "unreadEntry" "entryID" .ID }}" title="{{ .Title }}">{{ .Title }}</a>
+                    <a href="{{ route "unreadEntry" "entryID" .ID }}">{{ .Title }}</a>
                 </span>
                 <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </div>


### PR DESCRIPTION
Remove the title attribute on article links:

<img width="1033" alt="image" src="https://github.com/miniflux/v2/assets/864376/661962af-0896-42c9-bd0a-737912de5a10">

Closes https://github.com/miniflux/v2/issues/1864

There is no need for the `title` attribute. Reasons:
* It annoys keyboard navigation (See #1846)
* We don't put in any kind of truncation justifying the full length
* If it is important enough to show, it should be a dedicated element

--

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
