### PR TITLE
GET categories returns total_unread & feed_count

### DIFF
--- a/api/category.go
+++ b/api/category.go
@@ -98,12 +98,20 @@ func (h *handler) markCategoryAsRead(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) getCategories(w http.ResponseWriter, r *http.Request) {
-	categories, err := h.store.Categories(request.UserID(r))
+	var categories model.Categories
+	var err error
+	includeCounts := request.QueryStringParam(r, "counts", "false")
+
+	if includeCounts == "true" {
+		categories, err = h.store.CategoriesWithFeedCount(request.UserID(r))
+	} else {
+		categories, err = h.store.Categories(request.UserID(r))
+	}
+
 	if err != nil {
 		json.ServerError(w, r, err)
 		return
 	}
-
 	json.OK(w, r, categories)
 }
 

--- a/model/category.go
+++ b/model/category.go
@@ -12,8 +12,8 @@ type Category struct {
 	Title        string `json:"title"`
 	UserID       int64  `json:"user_id"`
 	HideGlobally bool   `json:"hide_globally"`
-	FeedCount    int    `json:"-"`
-	TotalUnread  int    `json:"-"`
+	FeedCount    *int   `json:"feed_count,omitempty"`
+	TotalUnread  *int   `json:"total_unread,omitempty"`
 }
 
 func (c *Category) String() string {


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [ x] I read this document: https://miniflux.app/faq.html#pull-request

Adds ability to request feed count and total unread count through GET /v1/categories api by appending ?counts=true query parameter.

Maintains backward compatibility for the API

**TODO**: API Documentation for [Get Categories]( https://miniflux.app/docs/api.html#endpoint-get-categories ) needs to be updated