### PR TITLE
Add mark as unread support for Linkding integration

### DIFF
--- a/database/migrations.go
+++ b/database/migrations.go
@@ -667,4 +667,11 @@ var migrations = []func(tx *sql.Tx) error{
 		_, err = tx.Exec(sql)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		sql := `
+			ALTER TABLE integrations ADD COLUMN linkding_mark_as_unread bool default 'f';
+		`
+		_, err = tx.Exec(sql)
+		return err
+	},
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -104,6 +104,7 @@ func SendEntry(entry *model.Entry, integration *model.Integration) {
 			integration.LinkdingURL,
 			integration.LinkdingAPIKey,
 			integration.LinkdingTags,
+			integration.LinkdingMarkAsUnread,
 		)
 		if err := client.AddEntry(entry.Title, entry.URL); err != nil {
 			logger.Error("[Integration] UserID #%d: %v", integration.UserID, err)

--- a/integration/linkding/linkding.go
+++ b/integration/linkding/linkding.go
@@ -16,6 +16,7 @@ type Document struct {
 	Url      string   `json:"url,omitempty"`
 	Title    string   `json:"title,omitempty"`
 	TagNames []string `json:"tag_names,omitempty"`
+	Unread   bool     `json:"unread,omitempty"`
 }
 
 // Client represents an Linkding client.
@@ -23,11 +24,12 @@ type Client struct {
 	baseURL string
 	apiKey  string
 	tags    string
+	unread  bool
 }
 
 // NewClient returns a new Linkding client.
-func NewClient(baseURL, apiKey, tags string) *Client {
-	return &Client{baseURL: baseURL, apiKey: apiKey, tags: tags}
+func NewClient(baseURL, apiKey, tags string, unread bool) *Client {
+	return &Client{baseURL: baseURL, apiKey: apiKey, tags: tags, unread: unread}
 }
 
 // AddEntry sends an entry to Linkding.
@@ -44,6 +46,7 @@ func (c *Client) AddEntry(title, url string) error {
 		Url:      url,
 		Title:    title,
 		TagNames: strings.FieldsFunc(c.tags, tagsSplitFn),
+		Unread:   c.unread,
 	}
 
 	apiURL, err := getAPIEndpoint(c.baseURL, "/api/bookmarks/")

--- a/model/integration.go
+++ b/model/integration.go
@@ -43,6 +43,7 @@ type Integration struct {
 	LinkdingURL          string
 	LinkdingAPIKey       string
 	LinkdingTags         string
+	LinkdingMarkAsUnread bool
 	MatrixBotEnabled     bool
 	MatrixBotUser        string
 	MatrixBotPassword    string

--- a/storage/integration.go
+++ b/storage/integration.go
@@ -147,6 +147,7 @@ func (s *Storage) Integration(userID int64) (*model.Integration, error) {
 			linkding_url,
 			linkding_api_key,
 			linkding_tags,
+			linkding_mark_as_unread,
 			matrix_bot_enabled,
 			matrix_bot_user,
 			matrix_bot_password,
@@ -197,6 +198,7 @@ func (s *Storage) Integration(userID int64) (*model.Integration, error) {
 		&integration.LinkdingURL,
 		&integration.LinkdingAPIKey,
 		&integration.LinkdingTags,
+		&integration.LinkdingMarkAsUnread,
 		&integration.MatrixBotEnabled,
 		&integration.MatrixBotUser,
 		&integration.MatrixBotPassword,
@@ -262,13 +264,14 @@ func (s *Storage) UpdateIntegration(integration *model.Integration) error {
 			linkding_url=$35,
 			linkding_api_key=$36,
 			linkding_tags=$37,
-			matrix_bot_enabled=$38,
-			matrix_bot_user=$39,
-			matrix_bot_password=$40,
-			matrix_bot_url=$41,
-			matrix_bot_chat_id=$42
+			linkding_mark_as_unread=$38,
+			matrix_bot_enabled=$39,
+			matrix_bot_user=$40,
+			matrix_bot_password=$41,
+			matrix_bot_url=$42,
+			matrix_bot_chat_id=$43
 		WHERE
-			user_id=$43
+			user_id=$44
 	`
 		_, err = s.db.Exec(
 			query,
@@ -309,6 +312,7 @@ func (s *Storage) UpdateIntegration(integration *model.Integration) error {
 			integration.LinkdingURL,
 			integration.LinkdingAPIKey,
 			integration.LinkdingTags,
+			integration.LinkdingMarkAsUnread,
 			integration.MatrixBotEnabled,
 			integration.MatrixBotUser,
 			integration.MatrixBotPassword,
@@ -358,13 +362,14 @@ func (s *Storage) UpdateIntegration(integration *model.Integration) error {
 		linkding_url=$35,
 		linkding_api_key=$36,
 		linkding_tags=$37,
-		matrix_bot_enabled=$38,
-		matrix_bot_user=$39,
-		matrix_bot_password=$40,
-		matrix_bot_url=$41,
-		matrix_bot_chat_id=$42
+		linkding_mark_as_unread=$38,
+		matrix_bot_enabled=$39,
+		matrix_bot_user=$40,
+		matrix_bot_password=$41,
+		matrix_bot_url=$42,
+		matrix_bot_chat_id=$43
 	WHERE
-		user_id=$43
+		user_id=$44
 	`
 		_, err = s.db.Exec(
 			query,
@@ -405,6 +410,7 @@ func (s *Storage) UpdateIntegration(integration *model.Integration) error {
 			integration.LinkdingURL,
 			integration.LinkdingAPIKey,
 			integration.LinkdingTags,
+			integration.LinkdingMarkAsUnread,
 			integration.MatrixBotEnabled,
 			integration.MatrixBotUser,
 			integration.MatrixBotPassword,

--- a/template/templates/views/integrations.html
+++ b/template/templates/views/integrations.html
@@ -195,6 +195,10 @@
         <label for="form-linkding-tags">{{ t "form.integration.linkding_tags" }}</label>
         <input type="text" name="linkding_tags" id="form-linkding-tags" value="{{ .form.LinkdingTags }}" spellcheck="false">
 
+        <label>
+            <input type="checkbox" name="linkding_mark_as_unread" value="1" {{ if .form.LinkdingMarkAsUnread }}checked{{ end }}> {{ t "form.integration.pinboard_bookmark" }}
+        </label>
+
         <div class="buttons">
             <button type="submit" class="button button-primary" data-label-loading="{{ t "form.submit.saving" }}">{{ t "action.update" }}</button>
         </div>

--- a/ui/form/integration.go
+++ b/ui/form/integration.go
@@ -48,6 +48,7 @@ type IntegrationForm struct {
 	LinkdingURL          string
 	LinkdingAPIKey       string
 	LinkdingTags         string
+	LinkdingMarkAsUnread bool
 	MatrixBotEnabled     bool
 	MatrixBotUser        string
 	MatrixBotPassword    string
@@ -92,6 +93,7 @@ func (i IntegrationForm) Merge(integration *model.Integration) {
 	integration.LinkdingURL = i.LinkdingURL
 	integration.LinkdingAPIKey = i.LinkdingAPIKey
 	integration.LinkdingTags = i.LinkdingTags
+	integration.LinkdingMarkAsUnread = i.LinkdingMarkAsUnread
 	integration.MatrixBotEnabled = i.MatrixBotEnabled
 	integration.MatrixBotUser = i.MatrixBotUser
 	integration.MatrixBotPassword = i.MatrixBotPassword
@@ -139,6 +141,7 @@ func NewIntegrationForm(r *http.Request) *IntegrationForm {
 		LinkdingURL:          r.FormValue("linkding_url"),
 		LinkdingAPIKey:       r.FormValue("linkding_api_key"),
 		LinkdingTags:         r.FormValue("linkding_tags"),
+		LinkdingMarkAsUnread: r.FormValue("linkding_mark_as_unread") == "1",
 		MatrixBotEnabled:     r.FormValue("matrix_bot_enabled") == "1",
 		MatrixBotUser:        r.FormValue("matrix_bot_user"),
 		MatrixBotPassword:    r.FormValue("matrix_bot_password"),

--- a/ui/integration_show.go
+++ b/ui/integration_show.go
@@ -63,6 +63,7 @@ func (h *handler) showIntegrationPage(w http.ResponseWriter, r *http.Request) {
 		LinkdingURL:          integration.LinkdingURL,
 		LinkdingAPIKey:       integration.LinkdingAPIKey,
 		LinkdingTags:         integration.LinkdingTags,
+		LinkdingMarkAsUnread: integration.LinkdingMarkAsUnread,
 		MatrixBotEnabled:     integration.MatrixBotEnabled,
 		MatrixBotUser:        integration.MatrixBotUser,
 		MatrixBotPassword:    integration.MatrixBotPassword,


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Similar to other bookmark integrations, Linkding supports marking a bookmark as unread ([API docs](https://github.com/sissbruecker/linkding/blob/master/docs/API.md#bookmarks)). This adds the ability to use this feature. 

In the template view, I took the liberty to point towards the exact string as for Pinboard. Since it has the same functionality just for another service (`Mark bookmark as unread`).