### PR TITLE
remove httpbin.org dependency and make unit test local

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.9
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
+	github.com/mccutchen/go-httpbin/v2 v2.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/rylans/getlang v0.0.0-20201227074721-9e7f44ff8aa0
 	github.com/tdewolff/minify/v2 v2.12.7

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX
 github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2/go.mod h1:0KeJpeMD6o+O4hW7qJOT7vyQPKrWmj26uf5wMc/IiIs=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mccutchen/go-httpbin/v2 v2.9.1 h1:blH3ecpqy7aQ9IHFjO9Xrmkfuv80rACnrg6M53gra8A=
+github.com/mccutchen/go-httpbin/v2 v2.9.1/go.mod h1:+DBHcmg6EOeoizuiOI8iL12VIHXx+9YQNlz+gjB9uxk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.1.0 h1:yJMy84ti9h/+OEWa752kBTKv4XC30OtVVHYv/8cTqKc=

--- a/http/client/client_test.go
+++ b/http/client/client_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Frédéric Guillot. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package client // import "miniflux.app/http/client"
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/mccutchen/go-httpbin/v2/httpbin"
+)
+
+var srv *httptest.Server
+
+func TestMain(m *testing.M) {
+	srv = httptest.NewServer(httpbin.New())
+	exitCode := m.Run()
+	srv.Close()
+	os.Exit(exitCode)
+}
+
+func MakeClient(path string) *Client {
+	return New(fmt.Sprintf("%s%s", srv.URL, path))
+}
+
+func TestClientWithDelay(t *testing.T) {
+	clt := MakeClient("/delay/5")
+	clt.ClientTimeout = 1
+	_, err := clt.Get()
+	if err == nil {
+		t.Fatal(`The client should stops after 1 second`)
+	}
+}
+
+func TestClientWithError(t *testing.T) {
+	clt := MakeClient("/status/502")
+	clt.ClientTimeout = 5
+	response, err := clt.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if response.StatusCode != 502 {
+		t.Fatalf(`Unexpected response status code: %d`, response.StatusCode)
+	}
+
+	if !response.HasServerFailure() {
+		t.Fatal(`A 502 error is considered as server failure`)
+	}
+}
+
+func TestClientWithResponseTooLarge(t *testing.T) {
+	clt := MakeClient("/bytes/100")
+	clt.ClientMaxBodySize = 10
+	_, err := clt.Get()
+	if err == nil {
+		t.Fatal(`The client should fails when reading a response too large`)
+	}
+}
+
+func TestClientWithBasicAuth(t *testing.T) {
+	clt := MakeClient("/basic-auth/testuser/testpassword")
+	clt.WithCredentials("testuser", "testpassword")
+	_, err := clt.Get()
+	if err != nil {
+		t.Fatalf(`The client should be authenticated successfully: %v`, err)
+	}
+}


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

https://github.com/mccutchen/go-httpbin is MIT licensed and implements httpbin interfaces in golang. Combining this package with httptest.Server allows client unit tests to run entirely locally with no dependency on remote calls to httpbin.org