### PR TITLE
Add scrape and rewrite rules for webtoons

### DIFF
--- a/reader/rewrite/rules.go
+++ b/reader/rewrite/rules.go
@@ -32,6 +32,7 @@ var predefinedRules = map[string]string{
 	"thedoghousediaries.com": "add_image_title",
 	"theverge.com":           `add_dynamic_image, remove("div.duet--recirculation--related-list")`,
 	"treelobsters.com":       "add_image_title",
+	"webtoons.com":           `add_dynamic_image,replace("webtoon"|"swebtoon")`,
 	"www.qwantz.com":         "add_image_title,add_mailto_subject",
 	"www.recalbox.com":       "parse_markdown",
 	"xkcd.com":               "add_image_title",

--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -50,6 +50,7 @@ var predefinedRules = map[string]string{
 	"universfreebox.com":   "#corps_corps",
 	"version2.dk":          "section.body",
 	"wdwnt.com":            "div.entry-content",
+	"webtoons.com":         ".viewer_img",
 	"wired.com":            "main figure, article",
 	"zeit.de":              ".summary, .article-body",
 	"zdnet.com":            "div.storyBody",


### PR DESCRIPTION
Although the only source I have for the rewrite rule is, in fact, https://github.com/miniflux/v2/pull/892, it does work when combined with add_dynamic_image and scraping the right element. I have not investigated further.

Works around https://github.com/miniflux/v2/issues/775 and https://github.com/miniflux/v2/issues/1871 (as in, gives us working webtoons feeds but referer spoofing would still be a nice tool to have).

Fixes https://github.com/miniflux/v2/issues/256.

Do you follow the guidelines?

- [x] ~I have tested my changes - I've tested the rules by manually adding them to feeds. I've not rebuilt the whole program, but syntax is identical to similar entries in both lists.
- [x] I read this document: https://miniflux.app/faq.html#pull-request
