### PR TITLE
Fix failed to parse date for timezone format

### DIFF
--- a/reader/date/parser.go
+++ b/reader/date/parser.go
@@ -223,6 +223,7 @@ var dateFormats = []string{
 
 var invalidTimezoneReplacer = strings.NewReplacer(
 	"Europe/Brussels", "CET",
+	"America/Los_Angeles", "PDT",
 	"GMT+0000 (Coordinated Universal Time)", "GMT",
 	"GMT-", "GMT -",
 )

--- a/reader/date/parser_test.go
+++ b/reader/date/parser_test.go
@@ -37,6 +37,35 @@ func TestParseAtomDate(t *testing.T) {
 	}
 }
 
+func TestParseRSSDateTimezone(t *testing.T) {
+	date, err := Parse("Fri, 31 Mar 2023 20:19:00 America/Los_Angeles")
+	if err != nil {
+		t.Fatalf(`RSS dates should be parsed correctly`)
+	}
+
+	expectedTS := int64(1680319140)
+	if date.Unix() != expectedTS {
+		t.Errorf(`The Unix timestamp should be %v instead of %v`, expectedTS, date.Unix())
+	}
+
+	expectedLocation := "America/Los_Angeles"
+	if date.Location().String() != expectedLocation {
+		t.Errorf(`The location should be %q instead of %q`, expectedLocation, date.Location())
+	}
+
+	name, offset := date.Zone()
+
+	expectedName := "PDT"
+	if name != expectedName {
+		t.Errorf(`The zone name should be %q instead of %q`, expectedName, name)
+	}
+
+	expectedOffset := -25200
+	if offset != expectedOffset {
+		t.Errorf(`The offset should be %v instead of %v`, expectedOffset, offset)
+	}
+}
+
 func TestParseRSSDateGMT(t *testing.T) {
 	date, err := Parse("Tue, 03 Jun 2003 09:39:21 GMT")
 	if err != nil {


### PR DESCRIPTION
### Fix Background
on my local instance I get a bunch of error logs:
```
[ERROR] rss: date parser: failed to parse date "Sat, 18 Mar 2023 20:21:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Sat, 19 Aug 2023 20:20:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Tue, 31 Jan 2023 20:20:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Fri, 31 Mar 2023 20:19:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Tue, 28 Mar 2023 20:19:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Thu, 9 Feb 2023 20:19:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Mon, 24 Jul 2023 20:18:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Mon, 2 Oct 2023 20:17:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Thu, 5 Oct 2023 20:16:00 America/Los_Angeles" (entry GUID = {{ }  })
[ERROR] rss: date parser: failed to parse date "Sat, 19 Aug 2023 20:16:00 America/Los_Angeles" (entry GUID = {{ }  })
```

fix(date-parser): failed to parse date "Fri, 31 Mar 2023 20:19:00 America/Los_Angeles" by adding timezone to invalidTimezoneReplacer
test(date-parser): add TestParseRSSDateTimezone unit test

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
