### PR TITLE
feat: Use podcast duration tag as reading time

### DIFF
--- a/internal/reader/rss/rss.go
+++ b/internal/reader/rss/rss.go
@@ -199,6 +199,9 @@ func (r *rssItem) Transform() *model.Entry {
 	entry.Title = r.entryTitle()
 	entry.Enclosures = r.entryEnclosures()
 	entry.Tags = r.entryCategories()
+	if duration, err := normalizeDuration(r.Duration); err == nil {
+		entry.ReadingTime = duration
+	}
 
 	return entry
 }


### PR DESCRIPTION
Use the `itunes:duration` tag as reading time. This is useful for podcast feeds to know if I have time to listen to the episode without opening it.

You can test the change with [this feed](https://radiofrance-podcast.net/podcast09/rss_23497.xml)

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
