### PR TITLE
Fix feed hide_globally property to use it with third-party clients

### DIFF
--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -266,6 +266,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 			f.crawler,
 			f.user_agent,
 			f.cookie,
+			f.hide_globally,
 			f.no_media_player,
 			fi.icon_id,
 			u.timezone
@@ -331,6 +332,7 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 			&entry.Feed.Crawler,
 			&entry.Feed.UserAgent,
 			&entry.Feed.Cookie,
+			&entry.Feed.HideGlobally,
 			&entry.Feed.NoMediaPlayer,
 			&iconID,
 			&tz,


### PR DESCRIPTION
Currently, it is always False in the API response.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
