### PR TITLE
Add filter replace_title to adjust entry titles

### DIFF
--- a/internal/reader/rewrite/rewriter.go
+++ b/internal/reader/rewrite/rewriter.go
@@ -91,6 +91,13 @@ func applyRule(entryURL string, entry *model.Entry, rule rule) {
 		} else {
 			logger.Debug("[Rewrite] Cannot find search and replace terms for replace rule %s", rule)
 		}
+	case "replace_title":
+		// Format: replace("search-term"|"replace-term")
+		if len(rule.args) >= 2 {
+			entry.Title = replaceCustom(entry.Title, rule.args[0], rule.args[1])
+		} else {
+			logger.Debug("[Rewrite] Cannot find search and replace terms for replace rule %s", rule)
+		}
 	case "remove":
 		// Format: remove("#selector > .element, .another")
 		if len(rule.args) >= 1 {


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

I'm adding a lot of feeds from github releases, for example `https://github.com/jesseduffield/lazygit/releases.atom`. Titles are only `v0.40.2`, and I have to read the small description underneath the title to see which software has a new release.

Having an ability to replace in title as well as content would solve this nicely for me, `replace_title("^"|"miniflux ")`.