### PR TITLE
touch_handler: Fix scroll up behavior on Firefox Android

### DIFF
--- a/internal/ui/static/js/touch_handler.js
+++ b/internal/ui/static/js/touch_handler.js
@@ -164,7 +164,7 @@ class TouchHandler {
 
         elements.forEach((element) => {
             element.addEventListener("touchstart", (e) => this.onItemTouchStart(e), hasPassiveOption ? { passive: true } : false);
-            element.addEventListener("touchmove", (e) => this.onItemTouchMove(e), hasPassiveOption ? { passive: false } : false);
+            element.addEventListener("touchmove", (e) => this.onItemTouchMove(e), hasPassiveOption ? { passive: true } : false);
             element.addEventListener("touchend", (e) => this.onItemTouchEnd(e), hasPassiveOption ? { passive: true } : false);
             element.addEventListener("touchcancel", () => this.reset(), hasPassiveOption ? { passive: true } : false);
         });


### PR DESCRIPTION
When the `touchmove` listener is registered with `passive: false`, scrolling up on Firefox Android only works every other attempt. When scrolling breaks, the `touchmove` callback is never invoked.

The `passive` flag was originally set to false as part of a fix to prevent vertical scrolling while swiping: 3f3174491103fc5a96b36918d8eada778f5b7210. Setting `passive` to true doesn't seem to negatively affect that in both Firefox and Chrome, but fixes the scoll up behavior on Firefox.

Fixes: #2053

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
