### PR TITLE
Add rewrite rule to open HN comments w/ iOS apps

### DIFF
--- a/internal/reader/rewrite/rewrite_functions.go
+++ b/internal/reader/rewrite/rewrite_functions.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"miniflux.app/v2/internal/config"
+	"miniflux.app/v2/internal/logger"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/yuin/goldmark"
@@ -319,6 +320,56 @@ func decodeBase64Content(entryContent string) string {
 	} else {
 		return html.EscapeString(string(ret))
 	}
+}
+
+func addHackerNewsLinksUsing(entryContent, app string) string {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(entryContent))
+	if err != nil {
+		return entryContent
+	}
+
+	hn_prefix := "https://news.ycombinator.com/"
+	matches := doc.Find(`a[href^="` + hn_prefix + `"]`)
+
+	if matches.Length() > 0 {
+		matches.Each(func(i int, a *goquery.Selection) {
+			hrefAttr, _ := a.Attr("href")
+
+			hn_uri, err := url.Parse(hrefAttr)
+			if err != nil {
+				return
+			}
+
+			if app == "opener" {
+				params := url.Values{}
+				params.Add("url", hn_uri.String())
+
+				url := url.URL{
+					Scheme:   "opener",
+					Host:     "x-callback-url",
+					Path:     "show-options",
+					RawQuery: params.Encode(),
+				}
+
+				open_with_opener := `<a href="` + url.String() + `">Open with Opener</a>`
+				a.Parent().AppendHtml(" " + open_with_opener)
+			} else if app == "hack" {
+				url := strings.Replace(hn_uri.String(), hn_prefix, "hack://", 1)
+
+				open_with_hack := `<a href="` + url + `">Open with HACK</a>`
+				a.Parent().AppendHtml(" " + open_with_hack)
+			} else {
+				logger.Error("[openHackerNewsLinksWith] unknown app provided: %q", app)
+				return
+			}
+
+		})
+
+		output, _ := doc.Find("body").First().Html()
+		return output
+	}
+
+	return entryContent
 }
 
 func parseMarkdown(entryContent string) string {

--- a/internal/reader/rewrite/rewriter.go
+++ b/internal/reader/rewrite/rewriter.go
@@ -113,6 +113,10 @@ func applyRule(entryURL string, entry *model.Entry, rule rule) {
 		} else {
 			entry.Content = applyFuncOnTextContent(entry.Content, "body", decodeBase64Content)
 		}
+	case "add_hn_links_using_hack":
+		entry.Content = addHackerNewsLinksUsing(entry.Content, "hack")
+	case "add_hn_links_using_opener":
+		entry.Content = addHackerNewsLinksUsing(entry.Content, "opener")
 	case "parse_markdown":
 		entry.Content = parseMarkdown(entry.Content)
 	case "remove_tables":

--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -297,6 +297,10 @@ func hasValidURIScheme(src string) bool {
 		"tel:",
 		"webcal://",
 		"xmpp:",
+
+		// iOS Apps
+		"opener://",  // https://www.opener.link
+		"hack://",  // https://apps.apple.com/it/app/hack-for-hacker-news-reader/id1464477788?l=en-GB
 	}
 
 	for _, prefix := range whitelist {


### PR DESCRIPTION
Here's my use case: I use `hnrss.org` as a feed for `news.ycombinator.com`, which returns a page as follows:

<img width="990" alt="Screenshot 2023-09-16 at 15 57 33" src="https://github.com/miniflux/v2/assets/1721633/5a987938-ebd0-451a-b633-8a79a1a18675">

When browsing from iPhone/iPad, clicking the "Comments URL" link opens Safari, instead of HN-specific apps ([HACK](https://apps.apple.com/it/app/hack-for-hacker-news-reader/id1464477788?l=en-GB), for example, or [Opener](https://www.opener.link) for a more generic solution).

This PR adds two rewrite rules that add a "deep-link" to open the content directly in the app, as follows (the screenshot shows both rewrites applied):

<img width="970" alt="Screenshot 2023-09-16 at 16 00 14" src="https://github.com/miniflux/v2/assets/1721633/36357e6d-7d95-4bc6-aefe-9345770944ae">

NOTEs: 

- In order to make this work, I had to add two additional schemes to the sanitizer's whitelist.
- Not sure about the policy for adding rewrite rules; this is useful to me, would be useful to the community as well?

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
