### PR TITLE
Make the feed category optional for API clients who don't support categories

### DIFF
--- a/internal/api/feed.go
+++ b/internal/api/feed.go
@@ -24,6 +24,16 @@ func (h *handler) createFeed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Make the feed category optional for clients who don't support categories.
+	if feedCreationRequest.CategoryID == 0 {
+		category, err := h.store.FirstCategory(userID)
+		if err != nil {
+			json.ServerError(w, r, err)
+			return
+		}
+		feedCreationRequest.CategoryID = category.ID
+	}
+
 	if validationErr := validator.ValidateFeedCreation(h.store, userID, &feedCreationRequest); validationErr != nil {
 		json.BadRequest(w, r, validationErr.Error())
 		return


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
