### PR TITLE
Add RSS-Bridge integration

### DIFF
--- a/internal/api/subscription.go
+++ b/internal/api/subscription.go
@@ -7,6 +7,7 @@ import (
 	json_parser "encoding/json"
 	"net/http"
 
+	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response/json"
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/reader/subscription"
@@ -25,6 +26,12 @@ func (h *handler) discoverSubscriptions(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	var rssbridgeURL string
+	intg, err := h.store.Integration(request.UserID(r))
+	if err == nil && intg != nil && intg.RSSBridgeEnabled {
+		rssbridgeURL = intg.RSSBridgeURL
+	}
+
 	subscriptions, finderErr := subscription.FindSubscriptions(
 		subscriptionDiscoveryRequest.URL,
 		subscriptionDiscoveryRequest.UserAgent,
@@ -33,6 +40,7 @@ func (h *handler) discoverSubscriptions(w http.ResponseWriter, r *http.Request) 
 		subscriptionDiscoveryRequest.Password,
 		subscriptionDiscoveryRequest.FetchViaProxy,
 		subscriptionDiscoveryRequest.AllowSelfSignedCertificates,
+		rssbridgeURL,
 	)
 	if finderErr != nil {
 		json.ServerError(w, r, finderErr)

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -783,4 +783,12 @@ var migrations = []func(tx *sql.Tx) error{
 		_, err = tx.Exec(sql)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		sql := `
+			ALTER TABLE integrations ADD COLUMN rssbridge_enabled bool default 'f';
+			ALTER TABLE integrations ADD COLUMN rssbridge_url text default '';
+		`
+		_, err = tx.Exec(sql)
+		return
+	},
 }

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -673,7 +673,7 @@ func (h *handler) quickAddHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	subscriptions, s_err := mfs.FindSubscriptions(url, "", "", "", "", false, false)
+	subscriptions, s_err := mfs.FindSubscriptions(url, "", "", "", "", false, false, "")
 	if s_err != nil {
 		json.ServerError(w, r, s_err)
 		return

--- a/internal/locale/translations/de_DE.json
+++ b/internal/locale/translations/de_DE.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API-Schlüsselbezeichnung",
     "form.submit.loading": "Lade...",
     "form.submit.saving": "Speichern...",

--- a/internal/locale/translations/el_EL.json
+++ b/internal/locale/translations/el_EL.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Ετικέτα κλειδιού API",
     "form.submit.loading": "Φόρτωση...",
     "form.submit.saving": "Αποθήκευση...",

--- a/internal/locale/translations/en_US.json
+++ b/internal/locale/translations/en_US.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API Key Label",
     "form.submit.loading": "Loading…",
     "form.submit.saving": "Saving…",

--- a/internal/locale/translations/es_ES.json
+++ b/internal/locale/translations/es_ES.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Etiqueta de clave API",
     "form.submit.loading": "Cargando...",
     "form.submit.saving": "Guardando...",

--- a/internal/locale/translations/fi_FI.json
+++ b/internal/locale/translations/fi_FI.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API Key Label",
     "form.submit.loading": "Ladataan...",
     "form.submit.saving": "Tallennetaan...",

--- a/internal/locale/translations/fr_FR.json
+++ b/internal/locale/translations/fr_FR.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Activer le webhook",
     "form.integration.webhook_url": "URL du webhook",
     "form.integration.webhook_secret": "Secret du webhook",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Libellé de la clé d'API",
     "form.submit.loading": "Chargement...",
     "form.submit.saving": "Sauvegarde en cours...",

--- a/internal/locale/translations/hi_IN.json
+++ b/internal/locale/translations/hi_IN.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "एपीआई कुंजी लेबल",
     "form.submit.loading": "लोड हो रहा है...",
     "form.submit.saving": "सहेजा जा रहा है...",

--- a/internal/locale/translations/id_ID.json
+++ b/internal/locale/translations/id_ID.json
@@ -400,6 +400,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Label Kunci API",
     "form.submit.loading": "Memuat...",
     "form.submit.saving": "Menyimpan...",

--- a/internal/locale/translations/it_IT.json
+++ b/internal/locale/translations/it_IT.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Etichetta chiave API",
     "form.submit.loading": "Caricamento in corso...",
     "form.submit.saving": "Salvataggio in corso...",

--- a/internal/locale/translations/ja_JP.json
+++ b/internal/locale/translations/ja_JP.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API キーラベル",
     "form.submit.loading": "読み込み中…",
     "form.submit.saving": "保存中…",

--- a/internal/locale/translations/nl_NL.json
+++ b/internal/locale/translations/nl_NL.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API-sleutellabel",
     "form.submit.loading": "Laden...",
     "form.submit.saving": "Opslaag...",

--- a/internal/locale/translations/pl_PL.json
+++ b/internal/locale/translations/pl_PL.json
@@ -405,6 +405,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Etykieta klucza API",
     "form.submit.loading": "Ładowanie...",
     "form.submit.saving": "Zapisywanie...",

--- a/internal/locale/translations/pt_BR.json
+++ b/internal/locale/translations/pt_BR.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Etiqueta da chave de API",
     "form.submit.loading": "Carregando...",
     "form.submit.saving": "Salvando...",

--- a/internal/locale/translations/ru_RU.json
+++ b/internal/locale/translations/ru_RU.json
@@ -405,6 +405,8 @@
     "form.integration.webhook_activate": "Включить вебхуки",
     "form.integration.webhook_url": "Адрес вебхуков",
     "form.integration.webhook_secret": "Секретный ключ для вебхуков",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Описание API-ключа",
     "form.submit.loading": "Загрузка…",
     "form.submit.saving": "Сохранение…",

--- a/internal/locale/translations/tr_TR.json
+++ b/internal/locale/translations/tr_TR.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API Anahtar Etiketi",
     "form.submit.loading": "Yükleniyor...",
     "form.submit.saving": "Kaydediliyor...",

--- a/internal/locale/translations/uk_UA.json
+++ b/internal/locale/translations/uk_UA.json
@@ -406,6 +406,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "Назва ключа API",
     "form.submit.loading": "Завантаження...",
     "form.submit.saving": "Зберігаю...",

--- a/internal/locale/translations/zh_CN.json
+++ b/internal/locale/translations/zh_CN.json
@@ -401,6 +401,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API密钥标签",
     "form.submit.loading": "载入中…",
     "form.submit.saving": "保存中…",

--- a/internal/locale/translations/zh_TW.json
+++ b/internal/locale/translations/zh_TW.json
@@ -403,6 +403,8 @@
     "form.integration.webhook_activate": "Enable Webhook",
     "form.integration.webhook_url": "Webhook URL",
     "form.integration.webhook_secret": "Webhook Secret",
+    "form.integration.rssbridge_activate": "Check RSS-Bridge when adding subscriptions",
+    "form.integration.rssbridge_url": "RSS-Bridge server URL",
     "form.api_key.label.description": "API金鑰標籤",
     "form.submit.loading": "載入中…",
     "form.submit.saving": "儲存中…",

--- a/internal/model/integration.go
+++ b/internal/model/integration.go
@@ -71,4 +71,6 @@ type Integration struct {
 	WebhookEnabled                   bool
 	WebhookURL                       string
 	WebhookSecret                    string
+	RSSBridgeEnabled                 bool
+	RSSBridgeURL                     string
 }

--- a/internal/storage/integration.go
+++ b/internal/storage/integration.go
@@ -174,7 +174,9 @@ func (s *Storage) Integration(userID int64) (*model.Integration, error) {
 			shaarli_api_secret,
 			webhook_enabled,
 			webhook_url,
-			webhook_secret
+			webhook_secret,
+			rssbridge_enabled,
+			rssbridge_url
 		FROM
 			integrations
 		WHERE
@@ -248,6 +250,8 @@ func (s *Storage) Integration(userID int64) (*model.Integration, error) {
 		&integration.WebhookEnabled,
 		&integration.WebhookURL,
 		&integration.WebhookSecret,
+		&integration.RSSBridgeEnabled,
+		&integration.RSSBridgeURL,
 	)
 	switch {
 	case err == sql.ErrNoRows:
@@ -329,9 +333,11 @@ func (s *Storage) UpdateIntegration(integration *model.Integration) error {
 			shaarli_api_secret=$62,
 			webhook_enabled=$63,
 			webhook_url=$64,
-			webhook_secret=$65
+			webhook_secret=$65,
+			rssbridge_enabled=$66,
+			rssbridge_url=$67
 		WHERE
-			user_id=$66
+			user_id=$68
 	`
 	_, err := s.db.Exec(
 		query,
@@ -400,6 +406,8 @@ func (s *Storage) UpdateIntegration(integration *model.Integration) error {
 		integration.WebhookEnabled,
 		integration.WebhookURL,
 		integration.WebhookSecret,
+		integration.RSSBridgeEnabled,
+		integration.RSSBridgeURL,
 		integration.UserID,
 	)
 

--- a/internal/template/templates/views/choose_subscription.html
+++ b/internal/template/templates/views/choose_subscription.html
@@ -7,6 +7,9 @@
 </section>
 
 <form action="{{ route "chooseSubscription" }}" method="POST">
+    {{ if .errorMessage }}
+        <div class="alert alert-error">{{ t .errorMessage }}</div>
+    {{ end }}
     <input type="hidden" name="csrf" value="{{ .csrf }}">
     <input type="hidden" name="category_id" value="{{ .form.CategoryID }}">
     <input type="hidden" name="user_agent" value="{{ .form.UserAgent }}">

--- a/internal/template/templates/views/integrations.html
+++ b/internal/template/templates/views/integrations.html
@@ -401,6 +401,22 @@
             </div>
         </div>
     </details>
+
+    <details {{ if .form.RSSBridgeEnabled }}open{{ end }}>
+        <summary>RSS-Bridge</summary>
+        <div class="form-section">
+            <label>
+                <input type="checkbox" name="rssbridge_enabled" value="1" {{ if .form.RSSBridgeEnabled }}checked{{ end }}> {{ t "form.integration.rssbridge_activate" }}
+            </label>
+
+            <label for="form-rssbridge-url">{{ t "form.integration.rssbridge_url" }}</label>
+            <input type="url" name="rssbridge_url" id="form-rssbridge-url" value="{{ .form.RSSBridgeURL }}" spellcheck="false">
+
+            <div class="buttons">
+                <button type="submit" class="button button-primary" data-label-loading="{{ t "form.submit.saving" }}">{{ t "action.update" }}</button>
+            </div>
+        </div>
+    </details>
 </form>
 
 <h3>{{ t "page.integration.bookmarklet" }}</h3>

--- a/internal/ui/form/integration.go
+++ b/internal/ui/form/integration.go
@@ -77,6 +77,8 @@ type IntegrationForm struct {
 	WebhookEnabled                   bool
 	WebhookURL                       string
 	WebhookSecret                    string
+	RSSBridgeEnabled                 bool
+	RSSBridgeURL                     string
 }
 
 // Merge copy form values to the model.
@@ -143,6 +145,8 @@ func (i IntegrationForm) Merge(integration *model.Integration) {
 	integration.ShaarliAPISecret = i.ShaarliAPISecret
 	integration.WebhookEnabled = i.WebhookEnabled
 	integration.WebhookURL = i.WebhookURL
+	integration.RSSBridgeEnabled = i.RSSBridgeEnabled
+	integration.RSSBridgeURL = i.RSSBridgeURL
 }
 
 // NewIntegrationForm returns a new IntegrationForm.
@@ -212,6 +216,8 @@ func NewIntegrationForm(r *http.Request) *IntegrationForm {
 		ShaarliAPISecret:                 r.FormValue("shaarli_api_secret"),
 		WebhookEnabled:                   r.FormValue("webhook_enabled") == "1",
 		WebhookURL:                       r.FormValue("webhook_url"),
+		RSSBridgeEnabled:                 r.FormValue("rssbridge_enabled") == "1",
+		RSSBridgeURL:                     r.FormValue("rssbridge_url"),
 	}
 }
 

--- a/internal/ui/integration_show.go
+++ b/internal/ui/integration_show.go
@@ -91,6 +91,8 @@ func (h *handler) showIntegrationPage(w http.ResponseWriter, r *http.Request) {
 		WebhookEnabled:                   integration.WebhookEnabled,
 		WebhookURL:                       integration.WebhookURL,
 		WebhookSecret:                    integration.WebhookSecret,
+		RSSBridgeEnabled:                 integration.RSSBridgeEnabled,
+		RSSBridgeURL:                     integration.RSSBridgeURL,
 	}
 
 	sess := session.New(h.store, request.SessionID(r))

--- a/internal/ui/subscription_submit.go
+++ b/internal/ui/subscription_submit.go
@@ -50,6 +50,11 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var rssbridgeURL string
+	if intg, err := h.store.Integration(user.ID); err == nil && intg != nil && intg.RSSBridgeEnabled {
+		rssbridgeURL = intg.RSSBridgeURL
+	}
+
 	subscriptions, findErr := subscription.FindSubscriptions(
 		subscriptionForm.URL,
 		subscriptionForm.UserAgent,
@@ -58,21 +63,20 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 		subscriptionForm.Password,
 		subscriptionForm.FetchViaProxy,
 		subscriptionForm.AllowSelfSignedCertificates,
+		rssbridgeURL,
 	)
-	if findErr != nil {
-		v.Set("form", subscriptionForm)
-		v.Set("errorMessage", findErr)
-		html.OK(w, r, v.Render("add_subscription"))
-		return
-	}
 
 	n := len(subscriptions)
 	switch {
 	case n == 0:
 		v.Set("form", subscriptionForm)
-		v.Set("errorMessage", "error.subscription_not_found")
+		if findErr != nil {
+			v.Set("errorMessage", findErr)
+		} else {
+			v.Set("errorMessage", "error.subscription_not_found")
+		}
 		html.OK(w, r, v.Render("add_subscription"))
-	case n == 1:
+	case n == 1 && findErr == nil:
 		feed, err := feedHandler.CreateFeed(h.store, user.ID, &model.FeedCreationRequest{
 			CategoryID:                  subscriptionForm.CategoryID,
 			FeedURL:                     subscriptions[0].URL,
@@ -97,8 +101,11 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 		}
 
 		html.Redirect(w, r, route.Path(h.router, "feedEntries", "feedID", feed.ID))
-	case n > 1:
+	default:
 		v := view.New(h.tpl, r, sess)
+		if findErr != nil {
+			v.Set("errorMessage", findErr)
+		}
 		v.Set("subscriptions", subscriptions)
 		v.Set("form", subscriptionForm)
 		v.Set("menu", "feeds")


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

When adding a new subscription, this integration will send the URL to an RSS-Bridge instance's [detect endpoint](https://rss-bridge.github.io/rss-bridge/For_Developers/Actions.html#detect) to see if there are any bridges available.
You can test this with the official RSS-Bridge instance https://rss-bridge.org/bridge01/
and an example site that will be detected is Patreon.
![rssbridgeintegration](https://github.com/miniflux/v2/assets/2389047/1e7fbad2-0e39-45f0-b712-7bed3b0f3b6f)
