### PR TITLE
Filter feed entries based on url or title, applied to both whitelist …

### DIFF
--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -94,25 +94,41 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, user *model.Us
 
 func isBlockedEntry(feed *model.Feed, entry *model.Entry) bool {
 	if feed.BlocklistRules != "" {
-		match, _ := regexp.MatchString(feed.BlocklistRules, entry.Title)
-		if match {
-			logger.Debug("[Processor] Blocking entry %q from feed %q based on rule %q", entry.Title, feed.FeedURL, feed.BlocklistRules)
+		if matchField(feed.BlocklistRules, entry.URL) {
+			logger.Debug("[Processor] Block entry %q from feed %q based on rule %q applied on %s", entry.Title, feed.FeedURL, feed.BlocklistRules, "URL")
+			return true
+		}
+		if matchField(feed.BlocklistRules, entry.Title) {
+			logger.Debug("[Processor] Block entry %q from feed %q based on rule %q applied on %s", entry.Title, feed.FeedURL, feed.BlocklistRules, "Title")
 			return true
 		}
 	}
+
 	return false
 }
 
 func isAllowedEntry(feed *model.Feed, entry *model.Entry) bool {
 	if feed.KeeplistRules != "" {
-		match, _ := regexp.MatchString(feed.KeeplistRules, entry.Title)
-		if match {
-			logger.Debug("[Processor] Allow entry %q from feed %q based on rule %q", entry.Title, feed.FeedURL, feed.KeeplistRules)
+		if matchField(feed.KeeplistRules, entry.URL) {
+			logger.Debug("[Processor] Allow entry %q from feed %q based on rule %q applied on %s", entry.Title, feed.FeedURL, feed.KeeplistRules, "URL")
+			return true
+		}
+		if matchField(feed.KeeplistRules, entry.Title) {
+			logger.Debug("[Processor] Allow entry %q from feed %q based on rule %q applied on %s", entry.Title, feed.FeedURL, feed.KeeplistRules, "Title")
 			return true
 		}
 		return false
 	}
 	return true
+}
+
+func matchField(pattern, value string) bool {
+	match, err := regexp.MatchString(pattern, value)
+	if err != nil {
+		logger.Error("[Processor] Unable to match pattern %q with value %q: %v", pattern, value, err)
+	}
+
+	return match
 }
 
 // ProcessEntryWebPage downloads the entry web page and apply rewrite rules.

--- a/internal/reader/processor/processor_test.go
+++ b/internal/reader/processor/processor_test.go
@@ -16,6 +16,8 @@ func TestBlockingEntries(t *testing.T) {
 		entry    *model.Entry
 		expected bool
 	}{
+		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{URL: "https://example.com"}, true},
+		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{URL: "https://different.com"}, false},
 		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Some Example"}, true},
 		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Something different"}, false},
 		{&model.Feed{ID: 1}, &model.Entry{Title: "No rule defined"}, false},
@@ -35,6 +37,8 @@ func TestAllowEntries(t *testing.T) {
 		entry    *model.Entry
 		expected bool
 	}{
+		{&model.Feed{ID: 1, KeeplistRules: "(?i)example"}, &model.Entry{Title: "https://example.com"}, true},
+		{&model.Feed{ID: 1, KeeplistRules: "(?i)example"}, &model.Entry{Title: "https://different.com"}, false},
 		{&model.Feed{ID: 1, KeeplistRules: "(?i)example"}, &model.Entry{Title: "Some Example"}, true},
 		{&model.Feed{ID: 1, KeeplistRules: "(?i)example"}, &model.Entry{Title: "Something different"}, false},
 		{&model.Feed{ID: 1}, &model.Entry{Title: "No rule defined"}, true},


### PR DESCRIPTION
…and keeplist

Do you follow the guidelines?

- [x ] I have tested my changes
- [x ] I read this document: https://miniflux.app/faq.html#pull-request

The updated filter will first check URL then Title. I myself need this feature and found this also be mentioned in #2103. So it might be good to submit this pr.
  
Please kindly review 
