### PR TITLE
Strip version prefix when building Debian package

### DIFF
--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -2,7 +2,7 @@
 
 PKG_ARCH=$(dpkg --print-architecture)
 PKG_DATE=$(date -R)
-PKG_VERSION=$(cd /src && git describe --tags --abbrev=0)
+PKG_VERSION=$(cd /src && git describe --tags --abbrev=0 | sed 's/^v//')
 
 echo "PKG_VERSION=$PKG_VERSION"
 echo "PKG_ARCH=$PKG_ARCH"


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
