### PR TITLE
Expose `next_check_at` in the web ui and API

### DIFF
--- a/internal/locale/translations/de_DE.json
+++ b/internal/locale/translations/de_DE.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Benutzer bearbeiten: %s",
     "page.feeds.title": "Abonnements",
     "page.feeds.last_check": "Letzte Aktualisierung:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Anzahl der ungelesenen Artikel",
     "page.feeds.read_counter": "Anzahl der gelesenen Artikel",
     "page.feeds.error_count": [

--- a/internal/locale/translations/el_EL.json
+++ b/internal/locale/translations/el_EL.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Επεξεργασία χρήστη: % s",
     "page.feeds.title": "Ροές",
     "page.feeds.last_check": "Τελευταίος έλεγχος:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Αριθμός μη αναγνωσμένων καταχωρήσεων",
     "page.feeds.read_counter": "Αριθμός αναγνωσμένων καταχωρήσεων",
     "page.feeds.error_count": [

--- a/internal/locale/translations/en_US.json
+++ b/internal/locale/translations/en_US.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Edit User: %s",
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "Last check:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Number of unread entries",
     "page.feeds.read_counter": "Number of read entries",
     "page.feeds.error_count": [

--- a/internal/locale/translations/es_ES.json
+++ b/internal/locale/translations/es_ES.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Editar usuario: %s",
     "page.feeds.title": "Fuentes",
     "page.feeds.last_check": "Última verificación:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Número de artículos no leídos",
     "page.feeds.read_counter": "Número de artículos leídos",
     "page.feeds.error_count": [

--- a/internal/locale/translations/fi_FI.json
+++ b/internal/locale/translations/fi_FI.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Muokkaa käyttäjä: %s",
     "page.feeds.title": "Syötteet",
     "page.feeds.last_check": "Viimeisin tarkistus:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Lukemattomien artikkeleiden määrä",
     "page.feeds.read_counter": "Luettujen artikkeleiden määrä",
     "page.feeds.error_count": [

--- a/internal/locale/translations/fr_FR.json
+++ b/internal/locale/translations/fr_FR.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Modification de l'utilisateur : %s",
     "page.feeds.title": "Abonnements",
     "page.feeds.last_check": "Dernière vérification :",
+    "page.feeds.next_check": "Prochaine vérification :",
     "page.feeds.unread_counter": "Nombre d'entrées non lues",
     "page.feeds.read_counter": "Nombre d'entrées lues",
     "page.feeds.error_count": [

--- a/internal/locale/translations/hi_IN.json
+++ b/internal/locale/translations/hi_IN.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "%s उपभोक्ता संपाद करे",
     "page.feeds.title": "फ़ीड",
     "page.feeds.last_check": "आखरी जाँच",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "अपठित विषयवस्तुया",
     "page.feeds.read_counter": "पड़े हुए विषयवस्तुया",
     "page.feeds.error_count": [

--- a/internal/locale/translations/id_ID.json
+++ b/internal/locale/translations/id_ID.json
@@ -99,6 +99,7 @@
     "page.edit_user.title": "Sunting Pengguna: %s",
     "page.feeds.title": "Umpan",
     "page.feeds.last_check": "Terakhir diperiksa:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Jumlah entri yang belum dibaca",
     "page.feeds.read_counter": "Jumlah entri yang telah dibaca",
     "page.feeds.error_count": [

--- a/internal/locale/translations/it_IT.json
+++ b/internal/locale/translations/it_IT.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Modifica utente: %s",
     "page.feeds.title": "Feed",
     "page.feeds.last_check": "Ultimo controllo:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Numero di voci non lette",
     "page.feeds.read_counter": "Numero di voci lette",
     "page.feeds.error_count": [

--- a/internal/locale/translations/ja_JP.json
+++ b/internal/locale/translations/ja_JP.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "ユーザーを編集: %s",
     "page.feeds.title": "フィード一覧",
     "page.feeds.last_check": "最終チェック:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "未読記事の数",
     "page.feeds.read_counter": "既読記事の数",
     "page.feeds.error_count": [

--- a/internal/locale/translations/nl_NL.json
+++ b/internal/locale/translations/nl_NL.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Bewerk gebruiker: %s",
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "Laatste update:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Aantal ongelezen vermeldingen",
     "page.feeds.read_counter": "Aantal gelezen vermeldingen",
     "page.feeds.error_count": [

--- a/internal/locale/translations/pl_PL.json
+++ b/internal/locale/translations/pl_PL.json
@@ -102,6 +102,7 @@
     "page.edit_user.title": "Edytuj użytkownika: %s",
     "page.feeds.title": "Kanały",
     "page.feeds.last_check": "Ostatnia aktualizacja:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Liczba nieprzeczytanych wpisów",
     "page.feeds.read_counter": "Liczba przeczytanych wpisów",
     "page.feeds.error_count": [

--- a/internal/locale/translations/pt_BR.json
+++ b/internal/locale/translations/pt_BR.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Editar usuário: %s",
     "page.feeds.title": "Fontes",
     "page.feeds.last_check": "Última verificação:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Numero de itens não lidos",
     "page.feeds.read_counter": "Número de itens lidos",
     "page.feeds.error_count": [

--- a/internal/locale/translations/ru_RU.json
+++ b/internal/locale/translations/ru_RU.json
@@ -102,6 +102,7 @@
     "page.edit_user.title": "Изменить пользователя: %s",
     "page.feeds.title": "Подписки",
     "page.feeds.last_check": "Последняя проверка:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Количество непрочитанных статей",
     "page.feeds.read_counter": "Количество прочитанных статей",
     "page.feeds.error_count": [

--- a/internal/locale/translations/tr_TR.json
+++ b/internal/locale/translations/tr_TR.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "Kullanıcıyı Düzenle: %s",
     "page.feeds.title": "Beslemeler",
     "page.feeds.last_check": "Son kontrol:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Okunmamış iletilerin sayısı",
     "page.feeds.read_counter": "Okunmuş iletilerin sayısı",
     "page.feeds.error_count": [

--- a/internal/locale/translations/uk_UA.json
+++ b/internal/locale/translations/uk_UA.json
@@ -103,6 +103,7 @@
     "page.edit_user.title": "Редагування користувача: %s",
     "page.feeds.title": "Стрічки",
     "page.feeds.last_check": "Остання перевірка:",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "Кількість непрочитаних записів",
     "page.feeds.read_counter": "Кількість прочитаних записів",
     "page.feeds.error_count": [

--- a/internal/locale/translations/zh_CN.json
+++ b/internal/locale/translations/zh_CN.json
@@ -100,6 +100,7 @@
     "page.edit_user.title": "编辑用户 : %s",
     "page.feeds.title": "源",
     "page.feeds.last_check": "最后检查时间：",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "未读文章数",
     "page.feeds.read_counter": "已读文章数",
     "page.feeds.error_count": [

--- a/internal/locale/translations/zh_TW.json
+++ b/internal/locale/translations/zh_TW.json
@@ -101,6 +101,7 @@
     "page.edit_user.title": "編輯使用者 : %s",
     "page.feeds.title": "Feeds",
     "page.feeds.last_check": "最後檢查時間：",
+    "page.feeds.next_check": "Next check:",
     "page.feeds.unread_counter": "未讀文章數",
     "page.feeds.read_counter": "已讀文章數",
     "page.feeds.error_count": [

--- a/internal/storage/feed_query_builder.go
+++ b/internal/storage/feed_query_builder.go
@@ -139,6 +139,7 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			f.last_modified_header,
 			f.user_id,
 			f.checked_at at time zone u.timezone,
+			f.next_check_at at time zone u.timezone,
 			f.parsing_error_count,
 			f.parsing_error_msg,
 			f.scraper_rules,
@@ -204,6 +205,7 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 			&feed.LastModifiedHeader,
 			&feed.UserID,
 			&feed.CheckedAt,
+			&feed.NextCheckAt,
 			&feed.ParsingErrorCount,
 			&feed.ParsingErrorMsg,
 			&feed.ScraperRules,
@@ -252,6 +254,7 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 		}
 
 		feed.CheckedAt = timezone.Convert(tz, feed.CheckedAt)
+		feed.NextCheckAt = timezone.Convert(tz, feed.NextCheckAt)
 		feed.Category.UserID = feed.UserID
 		feeds = append(feeds, &feed)
 	}

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -107,7 +107,8 @@ func (f *funcMap) Map() template.FuncMap {
 		"nonce": func() string {
 			return crypto.GenerateRandomStringHex(16)
 		},
-		"deRef": func(i *int) int { return *i },
+		"deRef":    func(i *int) int { return *i },
+		"duration": duration,
 
 		// These functions are overrode at runtime after the parsing.
 		"elapsed": func(timezone string, t time.Time) string {
@@ -158,6 +159,21 @@ func truncate(str string, max int) string {
 func isEmail(str string) bool {
 	_, err := mail.ParseAddress(str)
 	return err == nil
+}
+
+// Returns the duration in human readable format (hours and minutes).
+func duration(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+
+	diff := time.Until(t)
+
+	if diff < 0 {
+		return ""
+	}
+
+	return diff.String()
 }
 
 func elapsedTime(printer *locale.Printer, tz string, t time.Time) string {

--- a/internal/template/templates/common/feed_list.html
+++ b/internal/template/templates/common/feed_list.html
@@ -25,6 +25,12 @@
                     <li class="item-meta-info-checked-at">
                         {{ t "page.feeds.last_check" }} <time datetime="{{ isodate .CheckedAt }}" title="{{ isodate .CheckedAt }}">{{ elapsed $.user.Timezone .CheckedAt }}</time>
                     </li>
+                    {{ $nextCheckDuration := duration .NextCheckAt }}
+                    {{ if ne $nextCheckDuration "" }}
+                    <li class="item-meta-info-next-check-at">
+                        {{ t "page.feeds.next_check" }} <time datetime="{{ isodate .NextCheckAt }}" title="{{ isodate .NextCheckAt }}">{{ $nextCheckDuration }}</time>
+                    </li>
+                    {{ end }}
                 </ul>
                 <ul class="item-meta-icons">
                     <li class="item-meta-icons-refresh">

--- a/internal/template/templates/views/edit_feed.html
+++ b/internal/template/templates/views/edit_feed.html
@@ -187,6 +187,10 @@
     <div class="panel">
         <ul>
             <li><strong>{{ t "page.edit_feed.last_check" }} </strong><time datetime="{{ isodate .feed.CheckedAt }}" title="{{ isodate .feed.CheckedAt }}">{{ elapsed $.user.Timezone .feed.CheckedAt }}</time></li>
+            {{ $nextCheckDuration := duration .feed.NextCheckAt }}
+            {{ if ne $nextCheckDuration "" }}
+            <li><strong>{{ t "page.feeds.next_check" }}</strong> <time datetime="{{ isodate .feed.NextCheckAt }}" title="{{ isodate .feed.NextCheckAt }}">{{ $nextCheckDuration }}</time></li>
+            {{ end }}
             <li><strong>{{ t "page.edit_feed.etag_header" }} </strong>{{ if .feed.EtagHeader }}{{ .feed.EtagHeader }}{{ else }}{{ t "page.edit_feed.no_header" }}{{ end }}</li>
             <li><strong>{{ t "page.edit_feed.last_modified_header" }} </strong>{{ if .feed.LastModifiedHeader }}{{ .feed.LastModifiedHeader }}{{ else }}{{ t "page.edit_feed.no_header" }}{{ end }}</li>
         </ul>


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
