### PR TITLE
Add support for SVG icons with data url without encoding

### DIFF
--- a/internal/reader/icon/finder.go
+++ b/internal/reader/icon/finder.go
@@ -194,6 +194,8 @@ func parseImageDataURL(value string) (*model.Icon, error) {
 			return nil, fmt.Errorf(`icon: unable to decode data URL %q`, value)
 		}
 		blob = []byte(decodedData)
+	case "utf8":
+		blob = []byte(data)
 	default:
 		return nil, fmt.Errorf(`icon: unsupported data URL encoding %q`, value)
 	}

--- a/internal/reader/icon/finder_test.go
+++ b/internal/reader/icon/finder_test.go
@@ -44,6 +44,26 @@ func TestParseImageDataURLWithNoEncoding(t *testing.T) {
 	}
 }
 
+func TestParseImageWithRawSVGEncodedInUTF8(t *testing.T) {
+	iconURL := `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 456 456'><circle></circle></svg>`
+	icon, err := parseImageDataURL(iconURL)
+	if err != nil {
+		t.Fatalf(`We should be able to parse valid data URL: %v`, err)
+	}
+
+	if icon.MimeType != "image/svg+xml" {
+		t.Fatal(`Invalid mime type parsed`)
+	}
+
+	if icon.Hash == "" {
+		t.Fatal(`Image hash should be computed`)
+	}
+
+	if string(icon.Content) != `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 456 456'><circle></circle></svg>` {
+		t.Fatal(`Invalid SVG content`)
+	}
+}
+
 func TestParseImageDataURLWithNoMediaTypeAndNoEncoding(t *testing.T) {
 	iconURL := `data:,Hello%2C%20World%21`
 	_, err := parseImageDataURL(iconURL)


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
