### PR TITLE
Add Category ID to webhooks

### DIFF
--- a/internal/integration/webhook/webhook.go
+++ b/internal/integration/webhook/webhook.go
@@ -54,12 +54,13 @@ func (c *Client) SendSaveEntryWebhookEvent(entry *model.Entry) error {
 			Enclosures:  entry.Enclosures,
 			Tags:        entry.Tags,
 			Feed: &WebhookFeed{
-				ID:        entry.Feed.ID,
-				UserID:    entry.Feed.UserID,
-				FeedURL:   entry.Feed.FeedURL,
-				SiteURL:   entry.Feed.SiteURL,
-				Title:     entry.Feed.Title,
-				CheckedAt: entry.Feed.CheckedAt,
+				ID:         entry.Feed.ID,
+				UserID:     entry.Feed.UserID,
+				CategoryID: entry.Feed.Category.ID,
+				FeedURL:    entry.Feed.FeedURL,
+				SiteURL:    entry.Feed.SiteURL,
+				Title:      entry.Feed.Title,
+				CheckedAt:  entry.Feed.CheckedAt,
 			},
 		},
 	})
@@ -97,12 +98,13 @@ func (c *Client) SendNewEntriesWebhookEvent(feed *model.Feed, entries model.Entr
 	return c.makeRequest(NewEntriesEventType, &WebhookNewEntriesEvent{
 		EventType: NewEntriesEventType,
 		Feed: &WebhookFeed{
-			ID:        feed.ID,
-			UserID:    feed.UserID,
-			FeedURL:   feed.FeedURL,
-			SiteURL:   feed.SiteURL,
-			Title:     feed.Title,
-			CheckedAt: feed.CheckedAt,
+			ID:         feed.ID,
+			UserID:     feed.UserID,
+			CategoryID: feed.Category.ID,
+			FeedURL:    feed.FeedURL,
+			SiteURL:    feed.SiteURL,
+			Title:      feed.Title,
+			CheckedAt:  feed.CheckedAt,
 		},
 		Entries: webhookEntries,
 	})
@@ -143,12 +145,13 @@ func (c *Client) makeRequest(eventType string, payload any) error {
 }
 
 type WebhookFeed struct {
-	ID        int64     `json:"id"`
-	UserID    int64     `json:"user_id"`
-	FeedURL   string    `json:"feed_url"`
-	SiteURL   string    `json:"site_url"`
-	Title     string    `json:"title"`
-	CheckedAt time.Time `json:"checked_at"`
+	ID         int64     `json:"id"`
+	UserID     int64     `json:"user_id"`
+	CategoryID int64     `json:"category_id"`
+	FeedURL    string    `json:"feed_url"`
+	SiteURL    string    `json:"site_url"`
+	Title      string    `json:"title"`
+	CheckedAt  time.Time `json:"checked_at"`
 }
 
 type WebhookEntry struct {


### PR DESCRIPTION
My use case for this is I want to ignore some webhooks based on the category the feed is in

Do you follow the guidelines?

- [ ] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
