### PR TITLE
Disable WebAuthn by default because it requires to configure the `BASE_URL` option

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -81,7 +81,7 @@ const (
 	defaultMetricsPassword                    = ""
 	defaultWatchdog                           = true
 	defaultInvidiousInstance                  = "yewtu.be"
-	defaultWebAuthn                           = true
+	defaultWebAuthn                           = false
 )
 
 var defaultHTTPClientUserAgent = "Mozilla/5.0 (compatible; Miniflux/" + version.Version + "; +https://miniflux.app)"

--- a/miniflux.1
+++ b/miniflux.1
@@ -514,7 +514,7 @@ Default is randomly generated at startup\&.
 .B WEBAUTHN
 Enable or disable WebAuthn/Passkey authentication\&.
 .br
-Default is true\&.
+Default is disabled\&.
 
 .SH AUTHORS
 .P


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
