### PR TITLE
`user/{userID}/state/com.google/read` is missing in `categories` section for read entries

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -992,7 +992,7 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 		if entry.Feed.Category.Title != "" {
 			categories = append(categories, fmt.Sprintf(UserLabelPrefix, userID)+entry.Feed.Category.Title)
 		}
-		if entry.Starred {
+		if entry.Status == model.EntryStatusRead {
 			categories = append(categories, userRead)
 		}
 


### PR DESCRIPTION
Fixes #2183

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
