### PR TITLE
Setting NextCheckAt due to TTL of a feed in feed.go.

### DIFF
--- a/internal/model/feed_test.go
+++ b/internal/model/feed_test.go
@@ -72,7 +72,8 @@ func TestFeedScheduleNextCheckDefault(t *testing.T) {
 
 	feed := &Feed{}
 	weeklyCount := 10
-	feed.ScheduleNextCheck(weeklyCount)
+	newTTL := 0
+	feed.ScheduleNextCheck(weeklyCount, newTTL)
 
 	if feed.NextCheckAt.IsZero() {
 		t.Error(`The next_check_at must be set`)
@@ -99,7 +100,8 @@ func TestFeedScheduleNextCheckEntryCountBasedMaxInterval(t *testing.T) {
 	}
 	feed := &Feed{}
 	weeklyCount := maxInterval * 100
-	feed.ScheduleNextCheck(weeklyCount)
+	newTTL := 0
+	feed.ScheduleNextCheck(weeklyCount, newTTL)
 
 	if feed.NextCheckAt.IsZero() {
 		t.Error(`The next_check_at must be set`)
@@ -126,7 +128,8 @@ func TestFeedScheduleNextCheckEntryCountBasedMinInterval(t *testing.T) {
 	}
 	feed := &Feed{}
 	weeklyCount := minInterval / 2
-	feed.ScheduleNextCheck(weeklyCount)
+	newTTL := 0
+	feed.ScheduleNextCheck(weeklyCount, newTTL)
 
 	if feed.NextCheckAt.IsZero() {
 		t.Error(`The next_check_at must be set`)
@@ -151,7 +154,8 @@ func TestFeedScheduleNextCheckEntryFrequencyFactor(t *testing.T) {
 	}
 	feed := &Feed{}
 	weeklyCount := 7
-	feed.ScheduleNextCheck(weeklyCount)
+	newTTL := 0
+	feed.ScheduleNextCheck(weeklyCount, newTTL)
 
 	if feed.NextCheckAt.IsZero() {
 		t.Error(`The next_check_at must be set`)
@@ -159,5 +163,71 @@ func TestFeedScheduleNextCheckEntryFrequencyFactor(t *testing.T) {
 
 	if feed.NextCheckAt.After(time.Now().Add(time.Minute * time.Duration(config.Opts.SchedulerEntryFrequencyMaxInterval()/factor))) {
 		t.Error(`The next_check_at should not be after the now + factor * count`)
+	}
+}
+
+func TestFeedScheduleNextCheckEntryFrequencySmallNewTTL(t *testing.T) {
+	// If the feed has a TTL defined, we use it to make sure we don't check it too often.
+	maxInterval := 500
+	minInterval := 100
+	os.Clearenv()
+	os.Setenv("POLLING_SCHEDULER", "entry_frequency")
+	os.Setenv("SCHEDULER_ENTRY_FREQUENCY_MAX_INTERVAL", fmt.Sprintf("%d", maxInterval))
+	os.Setenv("SCHEDULER_ENTRY_FREQUENCY_MIN_INTERVAL", fmt.Sprintf("%d", minInterval))
+
+	var err error
+	parser := config.NewParser()
+	config.Opts, err = parser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing failure: %v`, err)
+	}
+	feed := &Feed{}
+	weeklyCount := minInterval / 2
+	// TTL is smaller than minInterval.
+	newTTL := minInterval / 2
+	feed.ScheduleNextCheck(weeklyCount, newTTL)
+
+	if feed.NextCheckAt.IsZero() {
+		t.Error(`The next_check_at must be set`)
+	}
+
+	if feed.NextCheckAt.Before(time.Now().Add(time.Minute * time.Duration(minInterval))) {
+		t.Error(`The next_check_at should not be before the now + min interval`)
+	}
+	if feed.NextCheckAt.Before(time.Now().Add(time.Minute * time.Duration(newTTL))) {
+		t.Error(`The next_check_at should not be before the now + TTL`)
+	}
+}
+
+func TestFeedScheduleNextCheckEntryFrequencyLargeNewTTL(t *testing.T) {
+	// If the feed has a TTL defined, we use it to make sure we don't check it too often.
+	maxInterval := 500
+	minInterval := 100
+	os.Clearenv()
+	os.Setenv("POLLING_SCHEDULER", "entry_frequency")
+	os.Setenv("SCHEDULER_ENTRY_FREQUENCY_MAX_INTERVAL", fmt.Sprintf("%d", maxInterval))
+	os.Setenv("SCHEDULER_ENTRY_FREQUENCY_MIN_INTERVAL", fmt.Sprintf("%d", minInterval))
+
+	var err error
+	parser := config.NewParser()
+	config.Opts, err = parser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing failure: %v`, err)
+	}
+	feed := &Feed{}
+	// TTL is larger than minInterval.
+	weeklyCount := minInterval / 2
+	newTTL := minInterval * 2
+	feed.ScheduleNextCheck(weeklyCount, newTTL)
+
+	if feed.NextCheckAt.IsZero() {
+		t.Error(`The next_check_at must be set`)
+	}
+
+	if feed.NextCheckAt.Before(time.Now().Add(time.Minute * time.Duration(minInterval))) {
+		t.Error(`The next_check_at should not be before the now + min interval`)
+	}
+	if feed.NextCheckAt.Before(time.Now().Add(time.Minute * time.Duration(newTTL))) {
+		t.Error(`The next_check_at should not be before the now + TTL`)
 	}
 }


### PR DESCRIPTION
This is a cleanup change, and added unit tests.
It is not easy to unit test the old codes.

Do you follow the guidelines?

- [x] I have tested my changes. **Only unit tested.**
- [x] I read this document: https://miniflux.app/faq.html#pull-request
