### PR TITLE
Use variables for the status in the entries table

### DIFF
--- a/internal/storage/category.go
+++ b/internal/storage/category.go
@@ -126,10 +126,10 @@ func (s *Storage) CategoriesWithFeedCount(userID int64) (model.Categories, error
 			(SELECT count(*)
 			   FROM feeds
 			     JOIN entries ON (feeds.id = entries.feed_id)
-			   WHERE feeds.category_id = c.id AND entries.status = 'unread') AS count_unread
+			   WHERE feeds.category_id = c.id AND entries.status = $1) AS count_unread
 		FROM categories c
 		WHERE
-			user_id=$1
+			user_id=$2
 	`
 
 	if user.CategoriesSortingOrder == "alphabetical" {
@@ -145,7 +145,7 @@ func (s *Storage) CategoriesWithFeedCount(userID int64) (model.Categories, error
 		`
 	}
 
-	rows, err := s.db.Query(query, userID)
+	rows, err := s.db.Query(query, model.EntryStatusUnread, userID)
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch categories: %v`, err)
 	}

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -323,12 +323,12 @@ func (s *Storage) ArchiveEntries(status string, days, limit int) (int64, error) 
 		UPDATE
 			entries
 		SET
-			status='removed'
+			status=$1
 		WHERE
-			id=ANY(SELECT id FROM entries WHERE status=$1 AND starred is false AND share_code='' AND created_at < now () - '%d days'::interval ORDER BY created_at ASC LIMIT %d)
+			id=ANY(SELECT id FROM entries WHERE status=$2 AND starred is false AND share_code='' AND created_at < now () - '%d days'::interval ORDER BY created_at ASC LIMIT %d)
 	`
 
-	result, err := s.db.Exec(fmt.Sprintf(query, days, limit), status)
+	result, err := s.db.Exec(fmt.Sprintf(query, days, limit), model.EntryStatusRemoved, status)
 	if err != nil {
 		return 0, fmt.Errorf(`store: unable to archive %s entries: %v`, status, err)
 	}


### PR DESCRIPTION
This is a cleanup. 
Because we are using these variables everywhere else.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
