### PR TITLE
Fix conditional requests regression

### DIFF
--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -232,6 +232,8 @@ func RefreshFeed(store *storage.Storage, userID, feedID int64, forceRefresh bool
 	requestBuilder.WithUsernameAndPassword(originalFeed.Username, originalFeed.Password)
 	requestBuilder.WithUserAgent(originalFeed.UserAgent, config.Opts.HTTPClientUserAgent())
 	requestBuilder.WithCookie(originalFeed.Cookie)
+	requestBuilder.WithETag(originalFeed.EtagHeader)
+	requestBuilder.WithLastModified(originalFeed.LastModifiedHeader)
 	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
 	requestBuilder.WithProxy(config.Opts.HTTPClientProxy())
 	requestBuilder.UseProxy(originalFeed.FetchViaProxy)


### PR DESCRIPTION
The recent HTTP client refactor in 14e25ab9fe09b9951b38e56af2bdff7a0737b280 caused feed refreshes to no longer make conditional requests. Prior to the refactor, `client.WithCacheHeaders` handled this. Now this function is split into `fetcher.WithETag` and `fetcher.WithLastModified` but these functions are only declared and never actually used. Fix this by calling them inside `handler.RefreshFeed`.

Do you follow the guidelines?

---

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
