### PR TITLE
fetcher: Force try HTTP/2. Fixes #2255

### DIFF
--- a/internal/reader/fetcher/request_builder.go
+++ b/internal/reader/fetcher/request_builder.go
@@ -104,6 +104,8 @@ func (r *RequestBuilder) IgnoreTLSErrors(value bool) *RequestBuilder {
 func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, error) {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
+		// Setting `DialContext` disables HTTP/2, this option forces the transport to try HTTP/2 regardless.
+		ForceAttemptHTTP2: true,
 		DialContext: (&net.Dialer{
 			// Default is 30s.
 			Timeout: 10 * time.Second,


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

After experiencing the same problem as in #2255, I have dug into it and found that reddit appears to be blocking HTTP requests originating specifically from Golang's std lib's HTTP/1.1 transport, however if we do the request using HTTP/2 it appears to go through.

PoC code that demonstrates the issue:
```golang
func main() {
	transport := &http.Transport{
		Proxy: http.ProxyFromEnvironment,
		// ForceAttemptHTTP2: true,
		DialContext: (&net.Dialer{}).DialContext,
	}
	client := &http.Client{
		Transport: transport,
	}
	req, _ := http.NewRequest("GET", "https://reddit.com/r/rss/.rss", nil)
	resp, _ := client.Do(req)
	resp.Body.Close()
	fmt.Println("Response status:", resp.Status)
}
```
Without `ForceAttemptHTTP2: true` but with a non-nil `DialContext` go only does a HTTP/1.1 request, which results in reddit blocking it:
```sh
$ go run main.go
Response status: 403 Blocked
```
But, if we force the transport to try HTTP/2 instead, this seems to circumvent reddit's peculiar bot blocking algo, and we get a 200 OK:
```sh
$ go run main.go
Response status: 200 OK
```
Surprisingly though, both curl HTTP/1.1 and HTTP/2 appear to go through without any issues, and the only difference between curl and go's stdlib seem to be in TLS Client Hello (specifically in the number of supported elliptic curves and other extensions), which for lack of a more thorough investigation seems to be how they're able to target golang so accurately. 


This fix allows fetcher to use HTTP/2 when it's available and solves #2255 by circumventing reddit's bot blocking mechanism (for now, at least). 