### PR TITLE
Update entry processor to allow blocking articles by tags

### DIFF
--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -115,7 +115,15 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, user *model.Us
 
 func isBlockedEntry(feed *model.Feed, entry *model.Entry) bool {
 	if feed.BlocklistRules != "" {
-		if matchField(feed.BlocklistRules, entry.URL) || matchField(feed.BlocklistRules, entry.Title) {
+		var containsBlockedTag bool = false
+		for _, tag := range entry.Tags {
+        if matchField(feed.BlocklistRules, tag) {
+					containsBlockedTag = true
+					break
+				}
+		}
+
+		if matchField(feed.BlocklistRules, entry.URL) || matchField(feed.BlocklistRules, entry.Title) || containsBlockedTag {
 			slog.Debug("Blocking entry based on rule",
 				slog.Int64("entry_id", entry.ID),
 				slog.String("entry_url", entry.URL),

--- a/internal/reader/processor/processor_test.go
+++ b/internal/reader/processor/processor_test.go
@@ -20,6 +20,10 @@ func TestBlockingEntries(t *testing.T) {
 		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{URL: "https://different.com"}, false},
 		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Some Example"}, true},
 		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Something different"}, false},
+		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Something different", Tags: []string{"example", "something else"}}, true},
+		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Example", Tags: []string{"example", "something else"}}, true},
+		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Example", Tags: []string{"something different", "something else"}}, true},
+		{&model.Feed{ID: 1, BlocklistRules: "(?i)example"}, &model.Entry{Title: "Something different", Tags: []string{"something different", "something else"}}, false},
 		{&model.Feed{ID: 1}, &model.Entry{Title: "No rule defined"}, false},
 	}
 


### PR DESCRIPTION
Since tags are supported and parsed, and contain valuable metadata, it makes sense that our filtering rules also apply to them. 

Do you follow the guidelines?
- [ x] I have tested my changes
- [ x] I read this document: https://miniflux.app/faq.html#pull-request
