### PR TITLE
Create default miniflux db

### DIFF
--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - POSTGRES_USER=miniflux
       - POSTGRES_PASSWORD=secret
+      - POSTGRES_DB=miniflux
     volumes:
       - miniflux-db:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
Create a default debase called `miniflux` on first startup of Postgres (see [docs](https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_db)).

Without this, initial startup failed with the following error message:
```
[FATAL] Unable to connect to the database: pq: database "miniflux" does not exist
```

See explanation at https://github.com/miniflux/v2/issues/1302#issuecomment-1000293153.

Related docs PR: miniflux/website#68

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
