### PR TITLE
Add attribute to add_dynamic_image rewrite candidates.

### DIFF
--- a/internal/reader/rewrite/rewrite_functions.go
+++ b/internal/reader/rewrite/rewrite_functions.go
@@ -98,6 +98,7 @@ func addDynamicImage(entryURL, entryContent string) string {
 		"data-orig-file",
 		"data-large-file",
 		"data-medium-file",
+		"data-original-mos",
 		"data-2000src",
 		"data-1000src",
 		"data-800src",


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Add `data-original-mos` as a candidate attribute when rewriting using `add_dynamic_image`.

This is used on *Future US, Inc.* sites.