### PR TITLE
Add add_dynamic_iframe rewrite action.

### DIFF
--- a/internal/reader/rewrite/rewrite_functions.go
+++ b/internal/reader/rewrite/rewrite_functions.go
@@ -167,6 +167,43 @@ func addDynamicImage(entryURL, entryContent string) string {
 	return entryContent
 }
 
+func addDynamicIframe(entryURL, entryContent string) string {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(entryContent))
+	if err != nil {
+		return entryContent
+	}
+
+	// Ordered most preferred to least preferred.
+	candidateAttrs := []string{
+		"data-src",
+		"data-original",
+		"data-orig",
+		"data-url",
+		"data-lazy-src",
+	}
+
+	changed := false
+
+	doc.Find("iframe").Each(func(i int, iframe *goquery.Selection) {
+		for _, candidateAttr := range candidateAttrs {
+			if srcAttr, found := iframe.Attr(candidateAttr); found {
+				changed = true
+
+				iframe.SetAttr("src", srcAttr)
+
+				break
+			}
+		}
+	})
+
+	if changed {
+		output, _ := doc.Find("body").First().Html()
+		return output
+	}
+
+	return entryContent
+}
+
 func fixMediumImages(entryURL, entryContent string) string {
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(entryContent))
 	if err != nil {

--- a/internal/reader/rewrite/rewriter.go
+++ b/internal/reader/rewrite/rewriter.go
@@ -69,6 +69,8 @@ func applyRule(entryURL string, entry *model.Entry, rule rule) {
 		entry.Content = addMailtoSubject(entryURL, entry.Content)
 	case "add_dynamic_image":
 		entry.Content = addDynamicImage(entryURL, entry.Content)
+	case "add_dynamic_iframe":
+		entry.Content = addDynamicIframe(entryURL, entry.Content)
 	case "add_youtube_video":
 		entry.Content = addYoutubeVideo(entryURL, entry.Content)
 	case "add_invidious_video":

--- a/internal/reader/rewrite/rewriter_test.go
+++ b/internal/reader/rewrite/rewriter_test.go
@@ -333,6 +333,54 @@ func TestRewriteWithImageAndLazySrcset(t *testing.T) {
 	}
 }
 
+func TestRewriteWithNoLazyIframe(t *testing.T) {
+	controlEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<iframe src="https://example.org/embed" allowfullscreen></iframe>`,
+	}
+	testEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<iframe src="https://example.org/embed" allowfullscreen></iframe>`,
+	}
+	Rewriter("https://example.org/article", testEntry, "add_dynamic_iframe")
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}
+
+func TestRewriteWithLazyIframe(t *testing.T) {
+	controlEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<iframe data-src="https://example.org/embed" allowfullscreen="" src="https://example.org/embed"></iframe>`,
+	}
+	testEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<iframe data-src="https://example.org/embed" allowfullscreen></iframe>`,
+	}
+	Rewriter("https://example.org/article", testEntry, "add_dynamic_iframe")
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}
+
+func TestRewriteWithLazyIframeAndSrc(t *testing.T) {
+	controlEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<iframe src="https://example.org/embed" data-src="https://example.org/embed" allowfullscreen=""></iframe>`,
+	}
+	testEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<iframe src="about:blank" data-src="https://example.org/embed" allowfullscreen></iframe>`,
+	}
+	Rewriter("https://example.org/article", testEntry, "add_dynamic_iframe")
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}
+
 func TestNewLineRewriteRule(t *testing.T) {
 	controlEntry := &model.Entry{
 		Title:   `A title`,


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

This rewrite action, `add_dynamic_iframe`, is similar to add_dynamic_image. It will parse a page for `iframe` tags that have data attributes for lazily loading iframes via JavaScript and rewrite these to proper `src` attributes.

Includes unit tests.

Updated documentation will be submitted in a separate PR to the [miniflux/website](https://github.com/miniflux/website) repository.