### PR TITLE
Fix non-numeric UID

### DIFF
--- a/packaging/docker/distroless/Dockerfile
+++ b/packaging/docker/distroless/Dockerfile
@@ -7,7 +7,7 @@ RUN go build \
     -ldflags="-s -w -X 'miniflux.app/v2/internal/version.Version=`git describe --tags --abbrev=0`' -X 'miniflux.app/v2/internal/version.Commit=`git rev-parse --short HEAD`' -X 'miniflux.app/v2/internal/version.BuildDate=`date +%FT%T%z`'" \
     main.go
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base:nonroot
 
 LABEL org.opencontainers.image.title=Miniflux
 LABEL org.opencontainers.image.description="Miniflux is a minimalist and opinionated feed reader"
@@ -20,5 +20,4 @@ LABEL org.opencontainers.image.documentation=https://miniflux.app/docs/
 EXPOSE 8080
 ENV LISTEN_ADDR 0.0.0.0:8080
 COPY --from=build /go/src/app/miniflux /usr/bin/miniflux
-USER nonroot:nonroot
 CMD ["/usr/bin/miniflux"]


### PR DESCRIPTION
This patch adjusts the distroless image to use the predefined non-root UID, which uses explicit UID definitions. This allows orchestrators like Kubernetes to validate non-zero UIDs directly by checking the Image metadata.

The previous setup without an explicit `runAsUser` in the securityContext would produce the following error when enabling `runAsNonRoot`:

```
Error: container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root (pod: "miniflux-97cc5955f-pt7vf_miniflux(d1c56d29-ea0a-407c-b3f3-9821fbd7ee61)", container: miniflux)
```

This should not introduce any functional change. It just moves the UID evaluation from "inspecting the image's `/etc/passwd`" to image metadata.

Do you follow the guidelines?

- [ ] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
