### PR TITLE
Hide menu button in desktop layout instead of icon

### DIFF
--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -335,7 +335,7 @@ a:hover {
         flex-direction: row;
     }
 
-    .header nav button[aria-controls="header-menu"] svg {
+    .header nav button[aria-controls="header-menu"] {
         display: none;
     }
 


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

This would cause screen reader users can still focus on menu button in desktop layout. It will confuse them because it doesn't affect anything when clicking the button in desktop layout.