### PR TITLE
a11y: Add alert role to alert message element

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -134,10 +134,10 @@
     </header>
     {{ end }}
     {{ if .flashMessage }}
-        <div class="flash-message alert alert-success">{{ .flashMessage }}</div>
+        <div role="alert" class="flash-message alert alert-success">{{ .flashMessage }}</div>
     {{ end }}
     {{ if .flashErrorMessage }}
-        <div class="flash-error-message alert alert-error">{{ .flashErrorMessage }}</div>
+        <div role="alert" class="flash-error-message alert alert-error">{{ .flashErrorMessage }}</div>
     {{ end }}
 
     {{template "page_header" .}}

--- a/internal/template/templates/views/add_subscription.html
+++ b/internal/template/templates/views/add_subscription.html
@@ -9,13 +9,13 @@
 
 {{ define "content"}}
 {{ if not .categories }}
-    <p class="alert alert-error">{{ t "page.add_feed.no_category" }}</p>
+    <p role="alert" class="alert alert-error">{{ t "page.add_feed.no_category" }}</p>
 {{ else }}
     <form action="{{ route "submitSubscription" }}" method="post" autocomplete="off">
         <input type="hidden" name="csrf" value="{{ .csrf }}">
 
         {{ if .errorMessage }}
-            <div class="alert alert-error">{{ .errorMessage }}</div>
+            <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
         {{ end }}
 
         <label for="form-url">{{ t "page.add_feed.label.url" }}</label>

--- a/internal/template/templates/views/bookmark_entries.html
+++ b/internal/template/templates/views/bookmark_entries.html
@@ -12,7 +12,7 @@
 
 {{ define "content"}}
 {{ if not .entries }}
-    <p class="alert alert-info">{{ t "alert.no_bookmark" }}</p>
+    <p role="alert" class="alert alert-info">{{ t "alert.no_bookmark" }}</p>
 {{ else }}
     <div class="pagination-top">
         {{ template "pagination" .pagination }}

--- a/internal/template/templates/views/categories.html
+++ b/internal/template/templates/views/categories.html
@@ -19,7 +19,7 @@
 
 {{ define "content"}}
 {{ if not .categories }}
-    <p class="alert alert-error">{{ t "alert.no_category" }}</p>
+    <p role="alert" class="alert alert-error">{{ t "alert.no_category" }}</p>
 {{ else }}
     <div class="items">
         {{ range .categories }}

--- a/internal/template/templates/views/category_entries.html
+++ b/internal/template/templates/views/category_entries.html
@@ -57,7 +57,7 @@
 
 {{ define "content"}}
 {{ if not .entries }}
-    <p class="alert">{{ t "alert.no_category_entry" }}</p>
+    <p role="alert" class="alert">{{ t "alert.no_category_entry" }}</p>
 {{ else }}
     <div class="pagination-top">
         {{ template "pagination" .pagination }}

--- a/internal/template/templates/views/category_feeds.html
+++ b/internal/template/templates/views/category_feeds.html
@@ -37,7 +37,7 @@
 
 {{ define "content"}}
 {{ if not .feeds }}
-    <p class="alert">{{ t "alert.no_feed_in_category" }}</p>
+    <p role="alert" class="alert">{{ t "alert.no_feed_in_category" }}</p>
 {{ else }}
     {{ template "feed_list" dict "user" .user "feeds" .feeds "ParsingErrorCount" .ParsingErrorCount }}
 {{ end }}

--- a/internal/template/templates/views/create_api_key.html
+++ b/internal/template/templates/views/create_api_key.html
@@ -12,7 +12,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <label for="form-description">{{ t "form.api_key.label.description" }}</label>

--- a/internal/template/templates/views/create_category.html
+++ b/internal/template/templates/views/create_category.html
@@ -18,7 +18,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <label for="form-title">{{ t "form.category.label.title" }}</label>

--- a/internal/template/templates/views/create_user.html
+++ b/internal/template/templates/views/create_user.html
@@ -12,7 +12,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <label for="form-username">{{ t "form.user.label.username" }}</label>

--- a/internal/template/templates/views/edit_category.html
+++ b/internal/template/templates/views/edit_category.html
@@ -24,7 +24,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <label for="form-title">{{ t "form.category.label.title" }}</label>

--- a/internal/template/templates/views/edit_feed.html
+++ b/internal/template/templates/views/edit_feed.html
@@ -28,10 +28,10 @@
 
 {{ define "content"}}
 {{ if not .categories }}
-    <p class="alert alert-error">{{ t "page.add_feed.no_category" }}</p>
+    <p role="alert" class="alert alert-error">{{ t "page.add_feed.no_category" }}</p>
 {{ else }}
     {{ if ne .feed.ParsingErrorCount 0 }}
-    <div class="alert alert-error">
+    <div role="alert" class="alert alert-error">
         <h3>{{ t "page.edit_feed.last_parsing_error" }}</h3>
         <p>{{ t .feed.ParsingErrorMsg }}</p>
     </div>
@@ -41,7 +41,7 @@
         <input type="hidden" name="csrf" value="{{ .csrf }}">
 
         {{ if .errorMessage }}
-            <div class="alert alert-error">{{ .errorMessage }}</div>
+            <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
         {{ end }}
 
         <fieldset>
@@ -200,7 +200,7 @@
         </ul>
     </div>
 
-    <div class="alert alert-error">
+    <div role="alert" class="alert alert-error">
         <a href="#"
             data-confirm="true"
             data-action="remove-feed"

--- a/internal/template/templates/views/edit_user.html
+++ b/internal/template/templates/views/edit_user.html
@@ -12,7 +12,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <label for="form-username">{{ t "form.user.label.username" }}</label>

--- a/internal/template/templates/views/feed_entries.html
+++ b/internal/template/templates/views/feed_entries.html
@@ -75,7 +75,7 @@
 
 {{ define "content"}}
 {{ if ne .feed.ParsingErrorCount 0 }}
-<div class="alert alert-error">
+<div role="alert" class="alert alert-error">
     <h3>{{ t "alert.feed_error" }}</h3>
     <p>{{ t .feed.ParsingErrorMsg }}</p>
 </div>
@@ -83,9 +83,9 @@
 
 {{ if not .entries }}
     {{ if .showOnlyUnreadEntries }}
-        <p class="alert">{{ t "alert.no_unread_entry" }}</p>
+        <p role="alert" class="alert">{{ t "alert.no_unread_entry" }}</p>
     {{ else }}
-        <p class="alert">{{ t "alert.no_feed_entry" }}</p>
+        <p role="alert" class="alert">{{ t "alert.no_feed_entry" }}</p>
     {{ end }}
 {{ else }}
     <div class="pagination-top">

--- a/internal/template/templates/views/feeds.html
+++ b/internal/template/templates/views/feeds.html
@@ -9,7 +9,7 @@
 
 {{ define "content"}}
 {{ if not .feeds }}
-    <p class="alert">{{ t "alert.no_feed" }}</p>
+    <p role="alert" class="alert">{{ t "alert.no_feed" }}</p>
 {{ else }}
     {{ template "feed_list" dict "user" .user "feeds" .feeds "ParsingErrorCount" .ParsingErrorCount }}
 {{ end }}

--- a/internal/template/templates/views/history_entries.html
+++ b/internal/template/templates/views/history_entries.html
@@ -31,7 +31,7 @@
 
 {{ define "content"}}
 {{ if not .entries }}
-    <p class="alert alert-info">{{ t "alert.no_history" }}</p>
+    <p role="alert" class="alert alert-info">{{ t "alert.no_history" }}</p>
 {{ else }}
     <div class="pagination-top">
         {{ template "pagination" .pagination }}

--- a/internal/template/templates/views/import.html
+++ b/internal/template/templates/views/import.html
@@ -9,7 +9,7 @@
 
 {{ define "content"}}
 {{ if .errorMessage }}
-    <div class="alert alert-error">{{ .errorMessage }}</div>
+    <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
 {{ end }}
 
 <form action="{{ route "uploadOPML" }}" method="post" enctype="multipart/form-data">

--- a/internal/template/templates/views/integrations.html
+++ b/internal/template/templates/views/integrations.html
@@ -12,7 +12,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <details {{ if .form.AppriseEnabled }}open{{ end }}>

--- a/internal/template/templates/views/login.html
+++ b/internal/template/templates/views/login.html
@@ -9,7 +9,7 @@
         <input type="hidden" name="csrf" value="{{ .csrf }}">
 
         {{ if .errorMessage }}
-            <div class="alert alert-error">{{ .errorMessage }}</div>
+            <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
         {{ end }}
 
         <label for="form-username">{{ t "form.user.label.username" }}</label>
@@ -24,7 +24,7 @@
     </form>
     {{ if .webAuthnEnabled }}
     <div class="webauthn">
-        <div class="alert alert-error hidden" id="webauthn-error">
+        <div role="alert" class="alert alert-error hidden" id="webauthn-error">
             {{ t "page.login.webauthn_login.error" }}
         </div>
         <div class="buttons">

--- a/internal/template/templates/views/search_entries.html
+++ b/internal/template/templates/views/search_entries.html
@@ -8,7 +8,7 @@
 
 {{ define "content"}}
 {{ if not .entries }}
-    <p class="alert alert-info">{{ t "alert.no_search_result" }}</p>
+    <p role="alert" class="alert alert-info">{{ t "alert.no_search_result" }}</p>
 {{ else }}
     <div class="pagination-top">
         {{ template "pagination" .pagination }}

--- a/internal/template/templates/views/settings.html
+++ b/internal/template/templates/views/settings.html
@@ -12,7 +12,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <fieldset>
@@ -54,7 +54,7 @@
     <fieldset>
         <legend>{{ t "page.settings.webauthn.passkeys" }}</legend>
 
-        <div class="alert alert-error hidden" id="webauthn-error">
+        <div role="alert" class="alert alert-error hidden" id="webauthn-error">
             {{ t "page.settings.webauthn.register.error" }}
         </div>
 

--- a/internal/template/templates/views/shared_entries.html
+++ b/internal/template/templates/views/shared_entries.html
@@ -31,7 +31,7 @@
 
 {{ define "content"}}
 {{ if not .entries }}
-    <p class="alert alert-info">{{ t "alert.no_shared_entry" }}</p>
+    <p role="alert" class="alert alert-info">{{ t "alert.no_shared_entry" }}</p>
 {{ else }}
     <div class="items">
         {{ range .entries }}

--- a/internal/template/templates/views/unread_entries.html
+++ b/internal/template/templates/views/unread_entries.html
@@ -39,7 +39,7 @@
 
 {{ define "content"}}
 {{ if not .entries }}
-    <p class="alert">{{ t "alert.no_unread_entry" }}</p>
+    <p role="alert" class="alert">{{ t "alert.no_unread_entry" }}</p>
 {{ else }}
     <div class="pagination-top">
         {{ template "pagination" .pagination }}

--- a/internal/template/templates/views/users.html
+++ b/internal/template/templates/views/users.html
@@ -9,7 +9,7 @@
 
 {{ define "content"}}
 {{ if eq (len .users) 1 }}
-    <p class="alert">{{ t "alert.no_user" }}</p>
+    <p role="alert" class="alert">{{ t "alert.no_user" }}</p>
 {{ else }}
     <table>
         <tr>

--- a/internal/template/templates/views/webauthn_rename.html
+++ b/internal/template/templates/views/webauthn_rename.html
@@ -11,7 +11,7 @@
     <input type="hidden" name="csrf" value="{{ .csrf }}">
 
     {{ if .errorMessage }}
-        <div class="alert alert-error">{{ .errorMessage }}</div>
+        <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>
     {{ end }}
 
     <label for="form-title">{{ t "page.settings.webauthn.passkey_name" }}</label>


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request

Current alert message element without [alert role](https://www.w3.org/WAI/ARIA/apg/patterns/alert/) won't be announced by screen readers unless screen reader users navigate on it.
For example: in Login page, if a user type the wrong username or password, the user will redirect to the same page and the alert message "Invalid username or password." shows. But the screen reader will announce the login page is load and is focus on username input (because of the autofocus attribute.) The user won't know why they get back to the login page instead of the home page.
But if the alert message element has set the alert role, the screen reader will announce the message once the page loaded. The user can understand the situation better.