### PR TITLE
Restore menu toggle when clicking on the logo

### DIFF
--- a/internal/ui/static/js/bootstrap.js
+++ b/internal/ui/static/js/bootstrap.js
@@ -111,9 +111,15 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }, true);
 
-    onClick("button[aria-controls='header-menu']", () => toggleMainMenu());
     if (document.documentElement.clientWidth < 600) {
+        let logoElement = document.querySelector(".logo");
+        if (logoElement) {
+            logoElement.setAttribute("role", "button");
+        }
+        onClick(".logo", () => toggleMainMenu());
         onClick(".header nav li", (event) => onClickMainMenuListItem(event));
+    } else {
+        onClick("button[aria-controls='header-menu']", () => toggleMainMenu());
     }
 
     if ("serviceWorker" in navigator) {


### PR DESCRIPTION
The caret icon is too small on smartphone to expand/collapse the menu

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
