### PR TITLE
Debian package is failing to build on `armhf` architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ export PGPASSWORD := postgres
 
 .PHONY: \
 	miniflux \
+	miniflux-no-pie \
 	linux-amd64 \
 	linux-arm64 \
 	linux-armv7 \
@@ -44,6 +45,9 @@ export PGPASSWORD := postgres
 
 miniflux:
 	@ CGO_ENABLED=0 go build -buildmode=pie -ldflags=$(LD_FLAGS) -o $(APP) main.go
+
+miniflux-no-pie:
+	@ go build -ldflags=$(LD_FLAGS) -o $(APP) main.go
 
 linux-amd64:
 	@ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags=$(LD_FLAGS) -o $(APP)-$@ main.go

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,9 +1,8 @@
 ARG BASE_IMAGE_ARCH="amd64"
 
-FROM ${BASE_IMAGE_ARCH}/golang:bookworm AS build
+FROM ${BASE_IMAGE_ARCH}/golang:1.22-bookworm AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV CGO_ENABLED=0
 
 RUN apt-get update -q && \
     apt-get install -y -qq build-essential devscripts dh-make debhelper && \

--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -8,25 +8,31 @@ echo "PKG_VERSION=$PKG_VERSION"
 echo "PKG_ARCH=$PKG_ARCH"
 echo "PKG_DATE=$PKG_DATE"
 
-cd /src && \
-    make miniflux && \
-    mkdir -p /build/debian && \
-    cd /build && \
-    cp /src/miniflux /build/ && \
-    cp /src/miniflux.1 /build/ && \
-    cp /src/LICENSE /build/ && \
-    cp /src/packaging/miniflux.conf /build/ && \
-    cp /src/packaging/systemd/miniflux.service /build/debian/ && \
-    cp /src/packaging/debian/compat /build/debian/compat && \
-    cp /src/packaging/debian/copyright /build/debian/copyright && \
-    cp /src/packaging/debian/miniflux.manpages /build/debian/miniflux.manpages && \
-    cp /src/packaging/debian/miniflux.postinst /build/debian/miniflux.postinst && \
-    cp /src/packaging/debian/rules /build/debian/rules && \
-    cp /src/packaging/debian/miniflux.dirs /build/debian/miniflux.dirs && \
-    echo "miniflux ($PKG_VERSION) experimental; urgency=low" > /build/debian/changelog && \
-    echo "  * Miniflux version $PKG_VERSION" >> /build/debian/changelog && \
-    echo " -- Frédéric Guillot <f@miniflux.net>  $PKG_DATE" >> /build/debian/changelog && \
-    sed "s/__PKG_ARCH__/${PKG_ARCH}/g" /src/packaging/debian/control > /build/debian/control && \
-    dpkg-buildpackage -us -uc -b && \
-    lintian --check --color always ../*.deb && \
-    cp ../*.deb /pkg/
+cd /src
+
+if [ "$PKG_ARCH" = "armhf" ]; then
+    make miniflux-no-pie
+else
+    make miniflux
+fi
+
+mkdir -p /build/debian && \
+cd /build && \
+cp /src/miniflux /build/ && \
+cp /src/miniflux.1 /build/ && \
+cp /src/LICENSE /build/ && \
+cp /src/packaging/miniflux.conf /build/ && \
+cp /src/packaging/systemd/miniflux.service /build/debian/ && \
+cp /src/packaging/debian/compat /build/debian/compat && \
+cp /src/packaging/debian/copyright /build/debian/copyright && \
+cp /src/packaging/debian/miniflux.manpages /build/debian/miniflux.manpages && \
+cp /src/packaging/debian/miniflux.postinst /build/debian/miniflux.postinst && \
+cp /src/packaging/debian/rules /build/debian/rules && \
+cp /src/packaging/debian/miniflux.dirs /build/debian/miniflux.dirs && \
+echo "miniflux ($PKG_VERSION) experimental; urgency=low" > /build/debian/changelog && \
+echo "  * Miniflux version $PKG_VERSION" >> /build/debian/changelog && \
+echo " -- Frédéric Guillot <f@miniflux.net>  $PKG_DATE" >> /build/debian/changelog && \
+sed "s/__PKG_ARCH__/${PKG_ARCH}/g" /src/packaging/debian/control > /build/debian/control && \
+dpkg-buildpackage -us -uc -b && \
+lintian --check --color always ../*.deb && \
+cp ../*.deb /pkg/


### PR DESCRIPTION
Error seen on GitHub Actions:

```
-buildmode=pie requires external (cgo) linking, but cgo is not enabled
```

Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] I read this document: https://miniflux.app/faq.html#pull-request
