### PR TITLE
Add 'Enter' key as a hotkey to open selected item

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -176,7 +176,7 @@
 
                 <p>{{ t "page.keyboard_shortcuts.subtitle.actions" }}</p>
                 <ul>
-                    <li>{{ t "page.keyboard_shortcuts.open_item" }} = <strong>o</strong></li>
+                    <li>{{ t "page.keyboard_shortcuts.open_item" }} = <strong>o</strong>, <strong>Enter</strong></li>
                     <li>{{ t "page.keyboard_shortcuts.open_original" }} = <strong>v</strong></li>
                     <li>{{ t "page.keyboard_shortcuts.open_original_same_window" }} = <strong>V</strong></li>
                     <li>{{ t "page.keyboard_shortcuts.open_comments" }} = <strong>c</strong></li>

--- a/internal/ui/static/js/bootstrap.js
+++ b/internal/ui/static/js/bootstrap.js
@@ -19,6 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
         keyboardHandler.on("l", () => goToPage("next"));
         keyboardHandler.on("z t", () => scrollToCurrentItem());
         keyboardHandler.on("o", () => openSelectedItem());
+        keyboardHandler.on("Enter", () => openSelectedItem());
         keyboardHandler.on("v", () => openOriginalLink());
         keyboardHandler.on("V", () => openOriginalLink(true));
         keyboardHandler.on("c", () => openCommentLink());

--- a/internal/ui/static/js/keyboard_handler.js
+++ b/internal/ui/static/js/keyboard_handler.js
@@ -17,7 +17,11 @@ class KeyboardHandler {
                 return;
             }
 
-            event.preventDefault();
+            if (key != "Enter")
+            {
+                event.preventDefault();
+            }
+
             this.queue.push(key);
 
             for (let combination in this.shortcuts) {


### PR DESCRIPTION
There are a few things that need to be done, to make this work.

First, we need to register `Enter` as another hotkey that opens the selected item.

However, by default the `KeyboardHandler` will override all default actions. That might make sense for any other key, but for the `Enter` key, we want to keep the default behavior (i.e. follow a selected link or press a button). So for this single key event, we do not call `preventDefault()`.

I see this as unproblematic for the following reasons.

1. With the changes from #2348, when we're in a list of items (articles, categories, feeds), there is no link selected. This is what made the `Enter` key work _implicitly_ in the past. With nothing selected, the `Enter` key will do nothing by default.
2. If we have **any** link selected (including when we are in a view with a list of selectable items), we'll get the default action of `Enter` (i.e. follow a link), which is exactly what we had before.

Lastly, we need to update the list of keyboard shortcuts displayed when pressing `?`.

This fixes #2366.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
