### PR TITLE
Makefile: do not force CGO_ENABLED=0 for miniflux target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ export PGPASSWORD := postgres
 	debian-packages
 
 miniflux:
-	@ CGO_ENABLED=0 go build -buildmode=pie -ldflags=$(LD_FLAGS) -o $(APP) main.go
+	@ go build -buildmode=pie -ldflags=$(LD_FLAGS) -o $(APP) main.go
 
 miniflux-no-pie:
 	@ go build -ldflags=$(LD_FLAGS) -o $(APP) main.go


### PR DESCRIPTION
The go 1.22 issues w.r.t. PIE is due to certain architectures requiring cgo for PIE (and silently not obeying conflicting settings in prior go versions). In Alpine Linux we want PIE binaries of miniflux on all architectures, so the new `miniflux-no-pie` makefile target is not desirable. Instead we are now [patching out](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/miniflux/0001-makefile-unset-cgo-enabled.patch) the forced `CGO_ENABLED=0` in the regular `miniflux` makefile target. Upstreaming this patch gives packagers of miniflux the ability to set or not set `CGO_ENABLED` at their discretion instead of hardcoding it.