### PR TITLE
Build amd64/arm64 Debian packages with CGO disabled

### DIFF
--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -13,7 +13,7 @@ cd /src
 if [ "$PKG_ARCH" = "armhf" ]; then
     make miniflux-no-pie
 else
-    make miniflux
+    CGO_ENABLED=0 make miniflux
 fi
 
 mkdir -p /build/debian && \


### PR DESCRIPTION
That should ensure that the binary is compiled statically

Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] I read this document: https://miniflux.app/faq.html#pull-request
