### PR TITLE
Makefile: quiet git describe and rev-parse stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APP          := miniflux
 DOCKER_IMAGE := miniflux/miniflux
-VERSION      := $(shell git describe --tags --abbrev=0)
-COMMIT       := $(shell git rev-parse --short HEAD)
+VERSION      := $(shell git describe --tags --abbrev=0 2>/dev/null)
+COMMIT       := $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE   := `date +%FT%T%z`
 LD_FLAGS     := "-s -w -X 'miniflux.app/v2/internal/version.Version=$(VERSION)' -X 'miniflux.app/v2/internal/version.Commit=$(COMMIT)' -X 'miniflux.app/v2/internal/version.BuildDate=$(BUILD_DATE)'"
 PKG_LIST     := $(shell go list ./... | grep -v /vendor/)


### PR DESCRIPTION
When building from a tarball instead of a cloned git repo, there would be two `fatal: not a git repository` errors emitted even though the build succeeds. This is because of how `VERSION` and `COMMIT` are set in the makefile. This PR suppresses the stderr for these variable assignments. There is no change in behavior for what the variables are set to, only a change in what is printed to the console. This is useful for distribution packages which use source tarballs and manually set the `VERSION` variable in the build script.

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request