### PR TITLE
Fix categories import from Thunderbird's OPML

### DIFF
--- a/internal/reader/opml/parser.go
+++ b/internal/reader/opml/parser.go
@@ -37,7 +37,7 @@ func getSubscriptionsFromOutlines(outlines opmlOutlineCollection, category strin
 				CategoryName: category,
 			})
 		} else if outline.Outlines.HasChildren() {
-			subscriptions = append(subscriptions, getSubscriptionsFromOutlines(outline.Outlines, outline.Text)...)
+			subscriptions = append(subscriptions, getSubscriptionsFromOutlines(outline.Outlines, outline.GetTitle())...)
 		}
 	}
 	return subscriptions

--- a/internal/reader/opml/parser_test.go
+++ b/internal/reader/opml/parser_test.go
@@ -129,10 +129,10 @@ func TestParseOpmlVersion1(t *testing.T) {
 			<dateCreated>Wed, 13 Mar 2019 11:51:41 GMT</dateCreated>
 		</head>
 		<body>
-			<outline title="Feed 1">
+			<outline title="Category 1">
 				<outline type="rss" title="Feed 1" xmlUrl="http://example.org/feed1/" htmlUrl="http://example.org/1"></outline>
 			</outline>
-			<outline title="Feed 2">
+			<outline title="Category 2">
 				<outline type="rss" title="Feed 2" xmlUrl="http://example.org/feed2/" htmlUrl="http://example.org/2"></outline>
 			</outline>
 		</body>
@@ -140,8 +140,8 @@ func TestParseOpmlVersion1(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: ""})
-	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryName: ""})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: "Category 1"})
+	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryName: "Category 2"})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {
@@ -250,7 +250,7 @@ func TestParseOpmlWithInvalidCharacterEntity(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/a&b", SiteURL: "http://example.org/c&d", CategoryName: ""})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/a&b", SiteURL: "http://example.org/c&d", CategoryName: "Feed 1"})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {


### PR DESCRIPTION
Thunderbird OPML exports are looking like this:

```xml
<opml version="1.0" xmlns:fz="urn:forumzilla:">
<head>
	<title>Thunderbird OPML Export - RSS</title>
    	<dateCreated>Sat, 24 Feb 2024 11:31:13 GMT</dateCreated>
</head>
<body>
	<outline title="News">
		<outline type="rss" ...>
		<outline type="rss" ...>
		...
	</outline>
	<outline title="Blogs">
		<outline type="rss" ...>
		<outline type="rss" ...>
		...
	</outline>
</body>
```

This commit make it so that categories are now correctly imported.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
