### PR TITLE
Tighten a bit the <iframe> sandbox

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -174,7 +174,7 @@ func getExtraAttributes(tagName string) ([]string, []string) {
 	case "video", "audio":
 		return []string{"controls"}, []string{"controls"}
 	case "iframe":
-		return []string{"sandbox", "loading"}, []string{`sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"`, `loading="lazy"`}
+		return []string{"sandbox", "loading"}, []string{`sandbox="allow-scripts"`, `loading="lazy"`}
 	case "img":
 		return []string{"loading"}, []string{`loading="lazy"`}
 	default:


### PR DESCRIPTION
- `allow-popups` and `allow-popups-to-escape-sandbox` should be used, since there is no reason for an `<iframe>` in an Entry to create popups, but also to masquerade as a popup from miniflux itself.
- `allow-same-origin` makes the `<iframe>` considered as same-origin to the current page, meaning that an `<iframe>` in an Entry has full access to miniflux' DOM, making the sandbox useless.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
