### PR TITLE
Add a couple of new possible locations for feeds

### DIFF
--- a/internal/reader/subscription/finder.go
+++ b/internal/reader/subscription/finder.go
@@ -196,11 +196,14 @@ func (f *SubscriptionFinder) FindSubscriptionsFromWebPage(websiteURL, contentTyp
 
 func (f *SubscriptionFinder) FindSubscriptionsFromWellKnownURLs(websiteURL string) (Subscriptions, *locale.LocalizedErrorWrapper) {
 	knownURLs := map[string]string{
-		"atom.xml": parser.FormatAtom,
-		"feed.xml": parser.FormatAtom,
-		"feed/":    parser.FormatAtom,
-		"rss.xml":  parser.FormatRSS,
-		"rss/":     parser.FormatRSS,
+		"atom.xml":  parser.FormatAtom,
+		"feed.xml":  parser.FormatAtom,
+		"feed/":     parser.FormatAtom,
+		"rss.xml":   parser.FormatRSS,
+		"rss/":      parser.FormatRSS,
+		"index.rss": parser.FormatRSS,
+		"index.xml": parser.FormatRSS,
+		"feed.atom": parser.FormatAtom,
 	}
 
 	websiteURLRoot := urllib.RootURL(websiteURL)


### PR DESCRIPTION
- Hugo likes to generate index.xml
- feed.atom and feed.rss are used by enterprise-scale/old-school gigantic CMS

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
