### PR TITLE
Miscellaneous improvements to internal/reader/subscription/finder.go

### DIFF
--- a/internal/reader/subscription/finder.go
+++ b/internal/reader/subscription/finder.go
@@ -232,14 +232,15 @@ func (f *SubscriptionFinder) FindSubscriptionsFromWellKnownURLs(websiteURL strin
 			defer responseHandler.Close()
 
 			if localizedError := responseHandler.LocalizedError(); localizedError != nil {
+				slog.Debug("Unable to subscribe", slog.String("fullURL", fullURL), slog.Any("error", localizedError.Error()))
 				continue
 			}
 
-			subscription := new(Subscription)
-			subscription.Type = kind
-			subscription.Title = fullURL
-			subscription.URL = fullURL
-			subscriptions = append(subscriptions, subscription)
+			subscriptions = append(subscriptions, &Subscription{
+				Type:  kind,
+				Title: fullURL,
+				URL:   fullURL,
+			})
 		}
 	}
 
@@ -267,7 +268,7 @@ func (f *SubscriptionFinder) FindSubscriptionsFromRSSBridge(websiteURL, rssBridg
 		return nil, nil
 	}
 
-	var subscriptions Subscriptions
+	subscriptions := make(Subscriptions, 0, len(bridges))
 	for _, bridge := range bridges {
 		subscriptions = append(subscriptions, &Subscription{
 			Title: bridge.BridgeMeta.Name,


### PR DESCRIPTION
- Surface `localizedError` in FindSubscriptionsFromWellKnownURLs via slog
- Use an inline declaration for new subscriptions, like done elsewhere in the file, if only for consistency's sake
- Preallocate the `subscriptions` slice when using an RSS-bridge, it's a good practise, and it might even marginally improve performances when adding __a lot__ of feeds via an rss-bridge instance, wooo!

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
