### PR TITLE
Small refactoring of internal/reader/date/parser.go

### DIFF
--- a/internal/reader/date/parser_test.go
+++ b/internal/reader/date/parser_test.go
@@ -228,14 +228,19 @@ func TestParseWeirdDateFormat(t *testing.T) {
 }
 
 func TestParseDateWithTimezoneOutOfRange(t *testing.T) {
-	date, err := Parse("2023-05-29 00:00:00-23:00")
-
-	if err != nil {
-		t.Errorf(`Unable to parse date: %v`, err)
+	inputs := []string{
+		"2023-05-29 00:00:00-13:00",
+		"2023-05-29 00:00:00+15:00",
 	}
+	for _, input := range inputs {
+		date, err := Parse(input)
 
-	_, offset := date.Zone()
-	if offset != 0 {
-		t.Errorf(`The offset should be reinitialized to 0 instead of %v because it's out of range`, offset)
+		if err != nil {
+			t.Errorf(`Unable to parse date: %v`, err)
+		}
+
+		if _, offset := date.Zone(); offset != 0 {
+			t.Errorf(`The offset should be reinitialized to 0 instead of %v because it's out of range`, offset)
+		}
 	}
 }


### PR DESCRIPTION
- Split dates formats into those that require local times and those who don't, so that there is no need to have a switch-case in the for loop with around 250 iterations at most.
- Be more strict when it comes to timezones, previously invalid ones like -13 were accepted. Also add a test for this.
- Bail out early if the date is an empty string.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
