### PR TITLE
Use a switch-case construct in internal/locale/plural.go instead of an avalanche of if-if-if-if-if

### DIFF
--- a/internal/locale/catalog.go
+++ b/internal/locale/catalog.go
@@ -20,7 +20,7 @@ var translationFiles embed.FS
 // LoadCatalogMessages loads and parses all translations encoded in JSON.
 func LoadCatalogMessages() error {
 	var err error
-	defaultCatalog = make(catalog)
+	defaultCatalog = make(catalog, len(AvailableLanguages()))
 
 	for language := range AvailableLanguages() {
 		defaultCatalog[language], err = loadTranslationFile(language)

--- a/internal/locale/plural.go
+++ b/internal/locale/plural.go
@@ -3,53 +3,40 @@
 
 package locale // import "miniflux.app/v2/internal/locale"
 
-type pluralFormFunc func(n int) int
-
 // See https://localization-guide.readthedocs.io/en/latest/l10n/pluralforms.html
 // And http://www.unicode.org/cldr/charts/29/supplemental/language_plural_rules.html
-var pluralForms = map[string]pluralFormFunc{
+var pluralForms = map[string](func(n int) int){
 	// nplurals=2; plural=(n != 1);
 	"default": func(n int) int {
 		if n != 1 {
 			return 1
 		}
-
 		return 0
 	},
 	// nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);
 	"ar_AR": func(n int) int {
-		if n == 0 {
+		switch {
+		case n == 0:
 			return 0
-		}
-
-		if n == 1 {
+		case n == 1:
 			return 1
-		}
-
-		if n == 2 {
+		case n == 2:
 			return 2
-		}
-
-		if n%100 >= 3 && n%100 <= 10 {
+		case n%100 >= 3 && n%100 <= 10:
 			return 3
-		}
-
-		if n%100 >= 11 {
+		case n%100 >= 11:
 			return 4
 		}
-
 		return 5
 	},
 	// nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;
 	"cs_CZ": func(n int) int {
-		if n == 1 {
+		switch {
+		case n == 1:
 			return 0
-		}
-
-		if n >= 2 && n <= 4 {
+		case n >= 2 && n <= 4:
 			return 1
 		}
-
 		return 2
 	},
 	// nplurals=1; plural=0;
@@ -58,14 +45,12 @@ var pluralForms = map[string]pluralFormFunc{
 	},
 	// nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
 	"pl_PL": func(n int) int {
-		if n == 1 {
+		switch {
+		case n == 1:
 			return 0
-		}
-
-		if n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20) {
+		case n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20):
 			return 1
 		}
-
 		return 2
 	},
 	// nplurals=2; plural=(n > 1);
@@ -86,13 +71,11 @@ var pluralForms = map[string]pluralFormFunc{
 
 // nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
 func pluralFormRuSrUa(n int) int {
-	if n%10 == 1 && n%100 != 11 {
+	switch {
+	case n%10 == 1 && n%100 != 11:
 		return 0
-	}
-
-	if n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20) {
+	case n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20):
 		return 1
 	}
-
 	return 2
 }


### PR DESCRIPTION
Less lines or code and marginally greater readability, yay! Oh and also preallocate a map in LoadCatalogMessages just because we can.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
