### PR TITLE
Make internal/worker/worker.go read-only

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -21,7 +21,7 @@ type Worker struct {
 }
 
 // Run wait for a job and refresh the given feed.
-func (w *Worker) Run(c chan model.Job) {
+func (w *Worker) Run(c <-chan model.Job) {
 	slog.Debug("Worker started",
 		slog.Int("worker_id", w.id),
 	)


### PR DESCRIPTION
Since workers don't communicate anything back to the pool with the channel, there is no need to have it bidirectional.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
