### PR TITLE
Use modern for loops

### DIFF
--- a/internal/cli/refresh_feeds.go
+++ b/internal/cli/refresh_feeds.go
@@ -45,7 +45,7 @@ func refreshFeeds(store *storage.Storage) {
 		slog.Int("nb_workers", config.Opts.WorkerPoolSize()),
 	)
 
-	for i := 0; i < config.Opts.WorkerPoolSize(); i++ {
+	for i := range config.Opts.WorkerPoolSize() {
 		wg.Add(1)
 		go func(workerID int) {
 			defer wg.Done()

--- a/internal/reader/atom/atom_10_test.go
+++ b/internal/reader/atom/atom_10_test.go
@@ -418,7 +418,7 @@ func TestParseEntryWithPlainTextTitle(t *testing.T) {
 	}
 
 	expected := `AT&T bought by SBC!`
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if feed.Entries[i].Title != expected {
 			t.Errorf("Incorrect title for entry #%d, got: %q", i, feed.Entries[i].Title)
 		}
@@ -677,7 +677,7 @@ func TestParseEntryWithHTMLSummary(t *testing.T) {
 	}
 
 	expected := `<code>std::unique_ptr&lt;S&gt;</code>`
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if feed.Entries[i].Content != expected {
 			t.Errorf("Incorrect content for entry #%d, got: %q", i, feed.Entries[i].Content)
 		}
@@ -729,7 +729,7 @@ func TestParseEntryWithTextSummary(t *testing.T) {
 	}
 
 	expected := `AT&amp;T &lt;S&gt;`
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		if feed.Entries[i].Content != expected {
 			t.Errorf("Incorrect content for entry #%d, got: %q", i, feed.Entries[i].Content)
 		}
@@ -782,7 +782,7 @@ func TestParseEntryWithTextContent(t *testing.T) {
 	}
 
 	expected := `AT&amp;T &lt;S&gt;`
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		if feed.Entries[i].Content != expected {
 			t.Errorf("Incorrect content for entry #%d, got: %q", i, feed.Entries[i].Content)
 		}
@@ -827,7 +827,7 @@ func TestParseEntryWithHTMLContent(t *testing.T) {
 	}
 
 	expected := `AT&amp;T bought <b>by SBC</b>!`
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if feed.Entries[i].Content != expected {
 			t.Errorf("Incorrect content for entry #%d, got: %q", i, feed.Entries[i].Content)
 		}

--- a/internal/reader/opml/parser_test.go
+++ b/internal/reader/opml/parser_test.go
@@ -81,7 +81,7 @@ func TestParseOpmlWithCategories(t *testing.T) {
 		t.Fatalf("Wrong number of subscriptions: %d instead of %d", len(subscriptions), 3)
 	}
 
-	for i := 0; i < len(subscriptions); i++ {
+	for i := range len(subscriptions) {
 		if !subscriptions[i].Equals(expected[i]) {
 			t.Errorf(`Subscription is different: "%v" vs "%v"`, subscriptions[i], expected[i])
 		}
@@ -114,7 +114,7 @@ func TestParseOpmlWithEmptyTitleAndEmptySiteURL(t *testing.T) {
 		t.Fatalf("Wrong number of subscriptions: %d instead of %d", len(subscriptions), 2)
 	}
 
-	for i := 0; i < len(subscriptions); i++ {
+	for i := range len(subscriptions) {
 		if !subscriptions[i].Equals(expected[i]) {
 			t.Errorf(`Subscription is different: "%v" vs "%v"`, subscriptions[i], expected[i])
 		}
@@ -152,7 +152,7 @@ func TestParseOpmlVersion1(t *testing.T) {
 		t.Fatalf("Wrong number of subscriptions: %d instead of %d", len(subscriptions), 2)
 	}
 
-	for i := 0; i < len(subscriptions); i++ {
+	for i := range len(subscriptions) {
 		if !subscriptions[i].Equals(expected[i]) {
 			t.Errorf(`Subscription is different: "%v" vs "%v"`, subscriptions[i], expected[i])
 		}
@@ -186,7 +186,7 @@ func TestParseOpmlVersion1WithoutOuterOutline(t *testing.T) {
 		t.Fatalf("Wrong number of subscriptions: %d instead of %d", len(subscriptions), 2)
 	}
 
-	for i := 0; i < len(subscriptions); i++ {
+	for i := range len(subscriptions) {
 		if !subscriptions[i].Equals(expected[i]) {
 			t.Errorf(`Subscription is different: "%v" vs "%v"`, subscriptions[i], expected[i])
 		}
@@ -228,7 +228,7 @@ func TestParseOpmlVersion1WithSeveralNestedOutlines(t *testing.T) {
 		t.Fatalf("Wrong number of subscriptions: %d instead of %d", len(subscriptions), 3)
 	}
 
-	for i := 0; i < len(subscriptions); i++ {
+	for i := range len(subscriptions) {
 		if !subscriptions[i].Equals(expected[i]) {
 			t.Errorf(`Subscription is different: "%v" vs "%v"`, subscriptions[i], expected[i])
 		}
@@ -261,7 +261,7 @@ func TestParseOpmlWithInvalidCharacterEntity(t *testing.T) {
 		t.Fatalf("Wrong number of subscriptions: %d instead of %d", len(subscriptions), 1)
 	}
 
-	for i := 0; i < len(subscriptions); i++ {
+	for i := range len(subscriptions) {
 		if !subscriptions[i].Equals(expected[i]) {
 			t.Errorf(`Subscription is different: "%v" vs "%v"`, subscriptions[i], expected[i])
 		}

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -150,10 +150,10 @@ func (s *Storage) createEntry(tx *sql.Tx, entry *model.Entry) error {
 		return fmt.Errorf(`store: unable to create entry %q (feed #%d): %v`, entry.URL, entry.FeedID, err)
 	}
 
-	for i := 0; i < len(entry.Enclosures); i++ {
-		entry.Enclosures[i].EntryID = entry.ID
-		entry.Enclosures[i].UserID = entry.UserID
-		err := s.createEnclosure(tx, entry.Enclosures[i])
+	for _, enclosure := range entry.Enclosures {
+		enclosure.EntryID = entry.ID
+		enclosure.UserID = entry.UserID
+		err := s.createEnclosure(tx, enclosure)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -277,16 +277,16 @@ func (s *Storage) CreateFeed(feed *model.Feed) error {
 		return fmt.Errorf(`store: unable to create feed %q: %v`, feed.FeedURL, err)
 	}
 
-	for i := 0; i < len(feed.Entries); i++ {
-		feed.Entries[i].FeedID = feed.ID
-		feed.Entries[i].UserID = feed.UserID
+	for _, entry := range feed.Entries {
+		entry.FeedID = feed.ID
+		entry.UserID = feed.UserID
 
 		tx, err := s.db.Begin()
 		if err != nil {
 			return fmt.Errorf(`store: unable to start transaction: %v`, err)
 		}
 
-		entryExists, err := s.entryExists(tx, feed.Entries[i])
+		entryExists, err := s.entryExists(tx, entry)
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
 				return fmt.Errorf(`store: unable to rollback transaction: %v (rolled back due to: %v)`, rollbackErr, err)
@@ -295,7 +295,7 @@ func (s *Storage) CreateFeed(feed *model.Feed) error {
 		}
 
 		if !entryExists {
-			if err := s.createEntry(tx, feed.Entries[i]); err != nil {
+			if err := s.createEntry(tx, entry); err != nil {
 				if rollbackErr := tx.Rollback(); rollbackErr != nil {
 					return fmt.Errorf(`store: unable to rollback transaction: %v (rolled back due to: %v)`, rollbackErr, err)
 				}

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -28,7 +28,7 @@ const (
 
 func getRandomUsername() string {
 	var suffix []string
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		suffix = append(suffix, strconv.Itoa(rand.Intn(1000)))
 	}
 	return "user" + strings.Join(suffix, "")

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -26,7 +26,7 @@ func NewPool(store *storage.Storage, nbWorkers int) *Pool {
 		queue: make(chan model.Job),
 	}
 
-	for i := 0; i < nbWorkers; i++ {
+	for i := range nbWorkers {
 		worker := &Worker{id: i, store: store}
 		go worker.Run(workerPool.queue)
 	}


### PR DESCRIPTION
Go 1.22 introduced a new [for-range](https://go.dev/ref/spec#For_range) construct that looks a tad better than the usual `for i := 0; i < N; i++` construct. I also tool the liberty of replacing some `for i := 0; i < len(myitemsarray); i++ { … myitemsarray[i] …}` with  `for item := range myitemsarray` when `myitemsarray` contains only pointers.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
