### PR TITLE
Don't mix up capacity and length

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -984,7 +984,7 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 	}
 	contentItems := make([]contentItem, len(entries))
 	for i, entry := range entries {
-		enclosures := make([]contentItemEnclosure, len(entry.Enclosures))
+		enclosures := make([]contentItemEnclosure, 0, len(entry.Enclosures))
 		for _, enclosure := range entry.Enclosures {
 			enclosures = append(enclosures, contentItemEnclosure{URL: enclosure.URL, Type: enclosure.MimeType})
 		}

--- a/internal/storage/enclosure.go
+++ b/internal/storage/enclosure.go
@@ -132,7 +132,7 @@ func (s *Storage) updateEnclosures(tx *sql.Tx, entry *model.Entry) error {
 		return nil
 	}
 
-	sqlValues := make([]string, len(entry.Enclosures))
+	sqlValues := make([]string, 0, len(entry.Enclosures))
 	for _, enclosure := range entry.Enclosures {
 		sqlValues = append(sqlValues, strings.TrimSpace(enclosure.URL))
 


### PR DESCRIPTION
- `make([]a, b)` create a slice of `b` elements `a`
- `make([]a, b, c)` create a slice of `0` elements `a`, but reserve space for `c` of them

When using `append` on the former, it will result on a slice with `b` leading elements, which is unlikely to be what we want. This commit replaces the two instances where this happens with the latter construct.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
