### PR TITLE
Speed up removeUnlikelyCandidates

### DIFF
--- a/internal/reader/readability/readability.go
+++ b/internal/reader/readability/readability.go
@@ -138,7 +138,10 @@ func getArticle(topCandidate *candidate, candidates candidateList) string {
 }
 
 func removeUnlikelyCandidates(document *goquery.Document) {
-	document.Find("*").Not("html,body").Each(func(i int, s *goquery.Selection) {
+	document.Find("*").Each(func(i int, s *goquery.Selection) {
+		if s.Length() == 0 || s.Get(0).Data == "html" || s.Get(0).Data == "body" {
+			return
+		}
 		class, _ := s.Attr("class")
 		id, _ := s.Attr("id")
 		str := class + id


### PR DESCRIPTION
`.Not` returns a brand new Selection, copied element by element.

![Screenshot 2024-02-29 13 32 19](https://github.com/miniflux/v2/assets/325724/e7d71ffe-a6b9-4024-9428-f6f765eebdb4)


- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
