### PR TITLE
Delay call of `view.New` after logging the user in

### DIFF
--- a/internal/ui/api_key_create.go
+++ b/internal/ui/api_key_create.go
@@ -14,15 +14,14 @@ import (
 )
 
 func (h *handler) showCreateAPIKeyPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", &form.APIKeyForm{})
 	view.Set("menu", "settings")
 	view.Set("user", user)

--- a/internal/ui/api_key_list.go
+++ b/internal/ui/api_key_list.go
@@ -13,9 +13,6 @@ import (
 )
 
 func (h *handler) showAPIKeysPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -28,6 +25,8 @@ func (h *handler) showAPIKeysPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("apiKeys", apiKeys)
 	view.Set("menu", "settings")
 	view.Set("user", user)

--- a/internal/ui/bookmark_entries.go
+++ b/internal/ui/bookmark_entries.go
@@ -43,7 +43,6 @@ func (h *handler) showStarredPage(w http.ResponseWriter, r *http.Request) {
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)
-
 	view.Set("total", count)
 	view.Set("entries", entries)
 	view.Set("pagination", getPagination(route.Path(h.router, "starred"), count, offset, user.EntriesPerPage))

--- a/internal/ui/category_edit.go
+++ b/internal/ui/category_edit.go
@@ -14,9 +14,6 @@ import (
 )
 
 func (h *handler) showEditCategoryPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -43,6 +40,8 @@ func (h *handler) showEditCategoryPage(w http.ResponseWriter, r *http.Request) {
 		categoryForm.HideGlobally = "checked"
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", categoryForm)
 	view.Set("category", category)
 	view.Set("menu", "categories")

--- a/internal/ui/session_list.go
+++ b/internal/ui/session_list.go
@@ -13,9 +13,6 @@ import (
 )
 
 func (h *handler) showSessionsPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -30,6 +27,8 @@ func (h *handler) showSessionsPage(w http.ResponseWriter, r *http.Request) {
 
 	sessions.UseTimezone(user.Timezone)
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("currentSessionToken", request.UserSessionToken(r))
 	view.Set("sessions", sessions)
 	view.Set("menu", "settings")

--- a/internal/ui/settings_show.go
+++ b/internal/ui/settings_show.go
@@ -16,9 +16,6 @@ import (
 )
 
 func (h *handler) showSettingsPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -58,6 +55,8 @@ func (h *handler) showSettingsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", settingsForm)
 	view.Set("themes", model.Themes())
 	view.Set("languages", locale.AvailableLanguages())

--- a/internal/ui/settings_update.go
+++ b/internal/ui/settings_update.go
@@ -18,9 +18,6 @@ import (
 )
 
 func (h *handler) updateSettings(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	loggedUser, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -35,6 +32,8 @@ func (h *handler) updateSettings(w http.ResponseWriter, r *http.Request) {
 
 	settingsForm := form.NewSettingsForm(r)
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", settingsForm)
 	view.Set("themes", model.Themes())
 	view.Set("languages", locale.AvailableLanguages())

--- a/internal/ui/subscription_add.go
+++ b/internal/ui/subscription_add.go
@@ -15,9 +15,6 @@ import (
 )
 
 func (h *handler) showAddSubscriptionPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -30,6 +27,8 @@ func (h *handler) showAddSubscriptionPage(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("categories", categories)
 	view.Set("menu", "feeds")
 	view.Set("user", user)

--- a/internal/ui/subscription_bookmarklet.go
+++ b/internal/ui/subscription_bookmarklet.go
@@ -17,9 +17,6 @@ import (
 )
 
 func (h *handler) bookmarklet(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -45,6 +42,8 @@ func (h *handler) bookmarklet(w http.ResponseWriter, r *http.Request) {
 		bookmarkletURL = xurls.Relaxed().FindString(text)
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", form.SubscriptionForm{URL: bookmarkletURL})
 	view.Set("categories", categories)
 	view.Set("menu", "feeds")

--- a/internal/ui/subscription_choose.go
+++ b/internal/ui/subscription_choose.go
@@ -18,9 +18,6 @@ import (
 )
 
 func (h *handler) showChooseSubscriptionPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -33,6 +30,8 @@ func (h *handler) showChooseSubscriptionPage(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("categories", categories)
 	view.Set("menu", "feeds")
 	view.Set("user", user)

--- a/internal/ui/subscription_submit.go
+++ b/internal/ui/subscription_submit.go
@@ -21,9 +21,6 @@ import (
 )
 
 func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	v := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -36,6 +33,8 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	v := view.New(h.tpl, r, sess)
 	v.Set("categories", categories)
 	v.Set("menu", "feeds")
 	v.Set("user", user)
@@ -141,15 +140,15 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 
 		html.Redirect(w, r, route.Path(h.router, "feedEntries", "feedID", feed.ID))
 	case n > 1:
-		v := view.New(h.tpl, r, sess)
-		v.Set("subscriptions", subscriptions)
-		v.Set("form", subscriptionForm)
-		v.Set("menu", "feeds")
-		v.Set("user", user)
-		v.Set("countUnread", h.store.CountUnreadEntries(user.ID))
-		v.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
-		v.Set("hasProxyConfigured", config.Opts.HasHTTPClientProxyConfigured())
+		view := view.New(h.tpl, r, sess)
+		view.Set("subscriptions", subscriptions)
+		view.Set("form", subscriptionForm)
+		view.Set("menu", "feeds")
+		view.Set("user", user)
+		view.Set("countUnread", h.store.CountUnreadEntries(user.ID))
+		view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
+		view.Set("hasProxyConfigured", config.Opts.HasHTTPClientProxyConfigured())
 
-		html.OK(w, r, v.Render("choose_subscription"))
+		html.OK(w, r, view.Render("choose_subscription"))
 	}
 }

--- a/internal/ui/unread_entries.go
+++ b/internal/ui/unread_entries.go
@@ -19,10 +19,6 @@ import (
 
 func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 	beginPreProcessing := time.Now()
-
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -59,6 +55,8 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 	}
 	finishSqlFetchUnreadEntries := time.Now()
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("entries", entries)
 	view.Set("pagination", getPagination(route.Path(h.router, "unread"), countUnread, offset, user.EntriesPerPage))
 	view.Set("menu", "unread")

--- a/internal/ui/user_create.go
+++ b/internal/ui/user_create.go
@@ -14,9 +14,6 @@ import (
 )
 
 func (h *handler) showCreateUserPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -28,6 +25,8 @@ func (h *handler) showCreateUserPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", &form.UserForm{})
 	view.Set("menu", "settings")
 	view.Set("user", user)

--- a/internal/ui/user_edit.go
+++ b/internal/ui/user_edit.go
@@ -15,9 +15,6 @@ import (
 
 // EditUser shows the form to edit a user.
 func (h *handler) showEditUserPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -46,6 +43,8 @@ func (h *handler) showEditUserPage(w http.ResponseWriter, r *http.Request) {
 		IsAdmin:  selectedUser.IsAdmin,
 	}
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("form", userForm)
 	view.Set("selected_user", selectedUser)
 	view.Set("menu", "settings")

--- a/internal/ui/user_list.go
+++ b/internal/ui/user_list.go
@@ -13,9 +13,6 @@ import (
 )
 
 func (h *handler) showUsersPage(w http.ResponseWriter, r *http.Request) {
-	sess := session.New(h.store, request.SessionID(r))
-	view := view.New(h.tpl, r, sess)
-
 	user, err := h.store.UserByID(request.UserID(r))
 	if err != nil {
 		html.ServerError(w, r, err)
@@ -35,6 +32,8 @@ func (h *handler) showUsersPage(w http.ResponseWriter, r *http.Request) {
 
 	users.UseTimezone(user.Timezone)
 
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
 	view.Set("users", users)
 	view.Set("menu", "settings")
 	view.Set("user", user)


### PR DESCRIPTION
There is no need to do extra work like creating a session and its associated view until the user has been properly identified and as many possibly-failing sql request have been successfully run.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
