### PR TITLE
Preallocate memory when exporting to OPML

### DIFF
--- a/internal/reader/opml/handler.go
+++ b/internal/reader/opml/handler.go
@@ -23,7 +23,7 @@ func (h *Handler) Export(userID int64) (string, error) {
 		return "", err
 	}
 
-	var subscriptions SubcriptionList
+	subscriptions := make(SubcriptionList, 0, len(feeds))
 	for _, feed := range feeds {
 		subscriptions = append(subscriptions, &Subcription{
 			Title:        feed.Title,

--- a/internal/reader/opml/serializer.go
+++ b/internal/reader/opml/serializer.go
@@ -38,14 +38,14 @@ func convertSubscriptionsToOPML(subscriptions SubcriptionList) *opmlDocument {
 	opmlDocument.Header.DateCreated = time.Now().Format("Mon, 02 Jan 2006 15:04:05 MST")
 
 	groupedSubs := groupSubscriptionsByFeed(subscriptions)
-	var categories []string
+	categories := make([]string, 0, len(groupedSubs))
 	for k := range groupedSubs {
 		categories = append(categories, k)
 	}
 	sort.Strings(categories)
 
 	for _, categoryName := range categories {
-		category := opmlOutline{Text: categoryName}
+		category := opmlOutline{Text: categoryName, Outlines: make(opmlOutlineCollection, 0, len(groupedSubs[categoryName]))}
 		for _, subscription := range groupedSubs[categoryName] {
 			category.Outlines = append(category.Outlines, opmlOutline{
 				Title:   subscription.Title,


### PR DESCRIPTION
This should marginally increase performance when export a large amount of feeds to OPML.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
