### PR TITLE
Use a `Set` instead of an array in a KeyboardHandler's member

### DIFF
--- a/internal/ui/static/js/keyboard_handler.js
+++ b/internal/ui/static/js/keyboard_handler.js
@@ -2,12 +2,12 @@ class KeyboardHandler {
     constructor() {
         this.queue = [];
         this.shortcuts = {};
-        this.triggers = [];
+        this.triggers = new Set();
     }
 
     on(combination, callback) {
         this.shortcuts[combination] = callback;
-        this.triggers.push(combination.split(" ")[0]);
+        this.triggers.add(combination.split(" ")[0]);
     }
 
     listen() {
@@ -48,7 +48,7 @@ class KeyboardHandler {
     isEventIgnored(event, key) {
         return event.target.tagName === "INPUT" ||
             event.target.tagName === "TEXTAREA" ||
-            (this.queue.length < 1 && !this.triggers.includes(key));
+            (this.queue.length < 1 && !this.triggers.has(key));
     }
 
     isModifierKeyDown(event) {


### PR DESCRIPTION
The variable `triggers` is only used to check if in contains a particular value. Given that the number of keyboard shortcuts is starting to be significant, let's future-proof the performances and use a `Set` instead of an `Array` instead.


- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
