### PR TITLE
Use modern javascript construct for KeyboardHandler.getKey

### DIFF
--- a/internal/ui/static/js/keyboard_handler.js
+++ b/internal/ui/static/js/keyboard_handler.js
@@ -63,13 +63,6 @@ class KeyboardHandler {
             'Left': 'ArrowLeft',
             'Right': 'ArrowRight'
         };
-
-        for (let key in mapping) {
-            if (mapping.hasOwnProperty(key) && key === event.key) {
-                return mapping[key];
-            }
-        }
-
-        return event.key;
+	return mapping[event.key]??event.key;
     }
 }


### PR DESCRIPTION
No need to use a loop and perform introspection to filter the object's parent properties. Since mapping doesn't inherit from anything else but `Object`, it won't have polluting properties. Moreover, instead of using a loop and a return value outside of it, ECMAScript 2020 provides a handy nullish coalescing operator.

- [x] I have tested my changes
- [x] I read this document: https://miniflux.app/faq.html#pull-request
