### PR TITLE
align min-width for the logo to disappear with the width of the menu to collapse

### DIFF
--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -281,7 +281,7 @@ a:hover {
 }
 
 /* Hide the logo when there is not enough space to display menus when using languages more verbose than English */
-@media (min-width: 625px) and (max-width: 830px) {
+@media (min-width: 620px) and (max-width: 830px) {
     .logo {
         display: none;
     }


### PR DESCRIPTION
The code comment says:

> Hide the logo when there is not enough space to display menus when using languages more verbose than English

However, it only disappeared at the minimum width of 625px, while the menu collapses at <620px. So in that tiny range of 5px the logo *was* seen and sort of destroyed everything.

I am pretty sure this was not meant, so here is the fix.