### PR TITLE
Refactor RDF parser to use an adapter

### DIFF
--- a/internal/reader/dublincore/dublincore.go
+++ b/internal/reader/dublincore/dublincore.go
@@ -3,29 +3,13 @@
 
 package dublincore // import "miniflux.app/v2/internal/reader/dublincore"
 
-import (
-	"strings"
-
-	"miniflux.app/v2/internal/reader/sanitizer"
-)
-
-// DublinCoreFeedElement represents Dublin Core feed XML elements.
-type DublinCoreFeedElement struct {
-	DublinCoreCreator string `xml:"http://purl.org/dc/elements/1.1/ channel>creator"`
+type DublinCoreChannelElement struct {
+	DublinCoreCreator string `xml:"http://purl.org/dc/elements/1.1/ creator"`
 }
 
-func (feed *DublinCoreFeedElement) GetSanitizedCreator() string {
-	return strings.TrimSpace(sanitizer.StripTags(feed.DublinCoreCreator))
-}
-
-// DublinCoreItemElement represents Dublin Core entry XML elements.
 type DublinCoreItemElement struct {
 	DublinCoreTitle   string `xml:"http://purl.org/dc/elements/1.1/ title"`
 	DublinCoreDate    string `xml:"http://purl.org/dc/elements/1.1/ date"`
 	DublinCoreCreator string `xml:"http://purl.org/dc/elements/1.1/ creator"`
 	DublinCoreContent string `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
-}
-
-func (item *DublinCoreItemElement) GetSanitizedCreator() string {
-	return strings.TrimSpace(sanitizer.StripTags(item.DublinCoreCreator))
 }

--- a/internal/reader/rdf/adapter.go
+++ b/internal/reader/rdf/adapter.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package rdf // import "miniflux.app/v2/internal/reader/rdf"
+
+import (
+	"html"
+	"log/slog"
+	"strings"
+	"time"
+
+	"miniflux.app/v2/internal/crypto"
+	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/reader/date"
+	"miniflux.app/v2/internal/reader/sanitizer"
+	"miniflux.app/v2/internal/urllib"
+)
+
+type RDFAdapter struct {
+	rdf *RDF
+}
+
+func NewRDFAdapter(rdf *RDF) *RDFAdapter {
+	return &RDFAdapter{rdf}
+}
+
+func (r *RDFAdapter) BuildFeed(feedURL string) *model.Feed {
+	feed := &model.Feed{
+		Title:   stripTags(r.rdf.Channel.Title),
+		FeedURL: feedURL,
+	}
+
+	if feed.Title == "" {
+		feed.Title = feedURL
+	}
+
+	if siteURL, err := urllib.AbsoluteURL(feedURL, r.rdf.Channel.Link); err != nil {
+		feed.SiteURL = r.rdf.Channel.Link
+	} else {
+		feed.SiteURL = siteURL
+	}
+
+	for _, item := range r.rdf.Items {
+		entry := model.NewEntry()
+		itemLink := strings.TrimSpace(item.Link)
+
+		// Populate the entry URL.
+		if itemLink == "" {
+			entry.URL = feed.SiteURL // Fallback to the feed URL if the entry URL is empty.
+		} else if entryURL, err := urllib.AbsoluteURL(feed.SiteURL, itemLink); err == nil {
+			entry.URL = entryURL
+		} else {
+			entry.URL = itemLink
+		}
+
+		// Populate the entry title.
+		for _, title := range []string{item.Title, item.DublinCoreTitle} {
+			title = strings.TrimSpace(title)
+			if title != "" {
+				entry.Title = html.UnescapeString(title)
+				break
+			}
+		}
+
+		// If the entry title is empty, we use the entry URL as a fallback.
+		if entry.Title == "" {
+			entry.Title = entry.URL
+		}
+
+		// Populate the entry content.
+		if item.DublinCoreContent != "" {
+			entry.Content = item.DublinCoreContent
+		} else {
+			entry.Content = item.Description
+		}
+
+		// Generate the entry hash.
+		hashValue := itemLink
+		if hashValue == "" {
+			hashValue = item.Title + item.Description // Fallback to the title and description if the link is empty.
+		}
+
+		entry.Hash = crypto.Hash(hashValue)
+
+		// Populate the entry date.
+		entry.Date = time.Now()
+		if item.DublinCoreDate != "" {
+			if itemDate, err := date.Parse(item.DublinCoreDate); err != nil {
+				slog.Debug("Unable to parse date from RDF feed",
+					slog.String("date", item.DublinCoreDate),
+					slog.String("link", itemLink),
+					slog.Any("error", err),
+				)
+			} else {
+				entry.Date = itemDate
+			}
+		}
+
+		// Populate the entry author.
+		switch {
+		case item.DublinCoreCreator != "":
+			entry.Author = stripTags(item.DublinCoreCreator)
+		case r.rdf.Channel.DublinCoreCreator != "":
+			entry.Author = stripTags(r.rdf.Channel.DublinCoreCreator)
+		}
+
+		feed.Entries = append(feed.Entries, entry)
+	}
+
+	return feed
+}
+
+func stripTags(value string) string {
+	return strings.TrimSpace(sanitizer.StripTags(value))
+}

--- a/internal/reader/rdf/parser.go
+++ b/internal/reader/rdf/parser.go
@@ -13,10 +13,10 @@ import (
 
 // Parse returns a normalized feed struct from a RDF feed.
 func Parse(baseURL string, data io.ReadSeeker) (*model.Feed, error) {
-	feed := new(rdfFeed)
-	if err := xml.NewXMLDecoder(data).Decode(feed); err != nil {
+	xmlFeed := new(RDF)
+	if err := xml.NewXMLDecoder(data).Decode(xmlFeed); err != nil {
 		return nil, fmt.Errorf("rdf: unable to parse feed: %w", err)
 	}
 
-	return feed.Transform(baseURL), nil
+	return NewRDFAdapter(xmlFeed).BuildFeed(baseURL), nil
 }

--- a/internal/reader/rdf/rdf.go
+++ b/internal/reader/rdf/rdf.go
@@ -5,130 +5,27 @@ package rdf // import "miniflux.app/v2/internal/reader/rdf"
 
 import (
 	"encoding/xml"
-	"html"
-	"log/slog"
-	"strings"
-	"time"
 
-	"miniflux.app/v2/internal/crypto"
-	"miniflux.app/v2/internal/model"
-	"miniflux.app/v2/internal/reader/date"
 	"miniflux.app/v2/internal/reader/dublincore"
-	"miniflux.app/v2/internal/reader/sanitizer"
-	"miniflux.app/v2/internal/urllib"
 )
 
-type rdfFeed struct {
-	XMLName xml.Name  `xml:"RDF"`
-	Title   string    `xml:"channel>title"`
-	Link    string    `xml:"channel>link"`
-	Items   []rdfItem `xml:"item"`
-	dublincore.DublinCoreFeedElement
+// RDF sepcs: https://web.resource.org/rss/1.0/spec
+type RDF struct {
+	XMLName xml.Name   `xml:"http://www.w3.org/1999/02/22-rdf-syntax-ns# RDF"`
+	Channel RDFChannel `xml:"channel"`
+	Items   []RDFItem  `xml:"item"`
 }
 
-func (r *rdfFeed) Transform(baseURL string) *model.Feed {
-	var err error
-	feed := new(model.Feed)
-	feed.Title = sanitizer.StripTags(r.Title)
-	feed.FeedURL = baseURL
-	feed.SiteURL, err = urllib.AbsoluteURL(baseURL, r.Link)
-	if err != nil {
-		feed.SiteURL = r.Link
-	}
-
-	for _, item := range r.Items {
-		entry := item.Transform()
-		if entry.Author == "" && r.DublinCoreCreator != "" {
-			entry.Author = r.GetSanitizedCreator()
-		}
-
-		if entry.URL == "" {
-			entry.URL = feed.SiteURL
-		} else {
-			entryURL, err := urllib.AbsoluteURL(feed.SiteURL, entry.URL)
-			if err == nil {
-				entry.URL = entryURL
-			}
-		}
-
-		feed.Entries = append(feed.Entries, entry)
-	}
-
-	return feed
+type RDFChannel struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+	dublincore.DublinCoreChannelElement
 }
 
-type rdfItem struct {
+type RDFItem struct {
 	Title       string `xml:"http://purl.org/rss/1.0/ title"`
 	Link        string `xml:"link"`
 	Description string `xml:"description"`
 	dublincore.DublinCoreItemElement
-}
-
-func (r *rdfItem) Transform() *model.Entry {
-	entry := model.NewEntry()
-	entry.Title = r.entryTitle()
-	entry.Author = r.entryAuthor()
-	entry.URL = r.entryURL()
-	entry.Content = r.entryContent()
-	entry.Hash = r.entryHash()
-	entry.Date = r.entryDate()
-
-	if entry.Title == "" {
-		entry.Title = entry.URL
-	}
-	return entry
-}
-
-func (r *rdfItem) entryTitle() string {
-	for _, title := range []string{r.Title, r.DublinCoreTitle} {
-		title = strings.TrimSpace(title)
-		if title != "" {
-			return html.UnescapeString(title)
-		}
-	}
-	return ""
-}
-
-func (r *rdfItem) entryContent() string {
-	switch {
-	case r.DublinCoreContent != "":
-		return r.DublinCoreContent
-	default:
-		return r.Description
-	}
-}
-
-func (r *rdfItem) entryAuthor() string {
-	return r.GetSanitizedCreator()
-}
-
-func (r *rdfItem) entryURL() string {
-	return strings.TrimSpace(r.Link)
-}
-
-func (r *rdfItem) entryDate() time.Time {
-	if r.DublinCoreDate != "" {
-		result, err := date.Parse(r.DublinCoreDate)
-		if err != nil {
-			slog.Debug("Unable to parse date from RDF feed",
-				slog.String("date", r.DublinCoreDate),
-				slog.String("link", r.Link),
-				slog.Any("error", err),
-			)
-			return time.Now()
-		}
-
-		return result
-	}
-
-	return time.Now()
-}
-
-func (r *rdfItem) entryHash() string {
-	value := r.Link
-	if value == "" {
-		value = r.Title + r.Description
-	}
-
-	return crypto.Hash(value)
 }


### PR DESCRIPTION
Avoid tight coupling between `model.Feed` and the original XML RDF feed.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] I read this document: https://miniflux.app/faq.html#pull-request
