### PR TITLE
Minor improvements to internal/storage/

### DIFF
--- a/internal/storage/api_key.go
+++ b/internal/storage/api_key.go
@@ -40,10 +40,10 @@ func (s *Storage) APIKeys(userID int64) (model.APIKeys, error) {
 		ORDER BY description ASC
 	`
 	rows, err := s.db.Query(query, userID)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch API Keys: %v`, err)
 	}
-	defer rows.Close()
 
 	apiKeys := make(model.APIKeys, 0)
 	for rows.Next() {

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -60,23 +60,21 @@ func (b *BatchBuilder) WithoutDisabledFeeds() *BatchBuilder {
 }
 
 func (b *BatchBuilder) FetchJobs() (jobs model.JobList, err error) {
-	var parts []string
-	parts = append(parts, `SELECT id, user_id FROM feeds`)
+	query := `SELECT id, user_id FROM feeds`
 
 	if len(b.conditions) > 0 {
-		parts = append(parts, fmt.Sprintf("WHERE %s", strings.Join(b.conditions, " AND ")))
+		query += fmt.Sprintf(" WHERE %s", strings.Join(b.conditions, " AND "))
 	}
 
 	if b.limit > 0 {
-		parts = append(parts, fmt.Sprintf("ORDER BY next_check_at ASC LIMIT %d", b.limit))
+		query += fmt.Sprintf(" ORDER BY next_check_at ASC LIMIT %d", b.limit)
 	}
 
-	query := strings.Join(parts, " ")
 	rows, err := b.db.Query(query, b.args...)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch batch of jobs: %v`, err)
 	}
-	defer rows.Close()
 
 	for rows.Next() {
 		var job model.Job

--- a/internal/storage/category.go
+++ b/internal/storage/category.go
@@ -91,18 +91,17 @@ func (s *Storage) CategoryByTitle(userID int64, title string) (*model.Category, 
 func (s *Storage) Categories(userID int64) (model.Categories, error) {
 	query := `SELECT id, user_id, title, hide_globally FROM categories WHERE user_id=$1 ORDER BY title ASC`
 	rows, err := s.db.Query(query, userID)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch categories: %v`, err)
 	}
-	defer rows.Close()
 
-	categories := make(model.Categories, 0)
+	var categories model.Categories
 	for rows.Next() {
 		var category model.Category
 		if err := rows.Scan(&category.ID, &category.UserID, &category.Title, &category.HideGlobally); err != nil {
 			return nil, fmt.Errorf(`store: unable to fetch category row: %v`, err)
 		}
-
 		categories = append(categories, &category)
 	}
 
@@ -146,18 +145,17 @@ func (s *Storage) CategoriesWithFeedCount(userID int64) (model.Categories, error
 	}
 
 	rows, err := s.db.Query(query, model.EntryStatusUnread, userID)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch categories: %v`, err)
 	}
-	defer rows.Close()
 
-	categories := make(model.Categories, 0)
+	var categories model.Categories
 	for rows.Next() {
 		var category model.Category
 		if err := rows.Scan(&category.ID, &category.UserID, &category.Title, &category.HideGlobally, &category.FeedCount, &category.TotalUnread); err != nil {
 			return nil, fmt.Errorf(`store: unable to fetch category row: %v`, err)
 		}
-
 		categories = append(categories, &category)
 	}
 

--- a/internal/storage/enclosure.go
+++ b/internal/storage/enclosure.go
@@ -32,12 +32,12 @@ func (s *Storage) GetEnclosures(entryID int64) (model.EnclosureList, error) {
 	`
 
 	rows, err := s.db.Query(query, entryID)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch enclosures: %v`, err)
 	}
-	defer rows.Close()
 
-	enclosures := make(model.EnclosureList, 0)
+	var enclosures model.EnclosureList
 	for rows.Next() {
 		var enclosure model.Enclosure
 		err := rows.Scan(

--- a/internal/storage/feed_query_builder.go
+++ b/internal/storage/feed_query_builder.go
@@ -180,10 +180,10 @@ func (f *FeedQueryBuilder) GetFeeds() (model.Feeds, error) {
 	query = fmt.Sprintf(query, f.buildCondition(), f.buildSorting())
 
 	rows, err := f.store.db.Query(query, f.args...)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch feeds: %w`, err)
 	}
-	defer rows.Close()
 
 	readCounters, unreadCounters, err := f.fetchFeedCounter()
 	if err != nil {

--- a/internal/storage/icon.go
+++ b/internal/storage/icon.go
@@ -130,10 +130,10 @@ func (s *Storage) Icons(userID int64) (model.Icons, error) {
 			feeds.user_id=$1
 	`
 	rows, err := s.db.Query(query, userID)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch icons: %v`, err)
 	}
-	defer rows.Close()
 
 	var icons model.Icons
 	for rows.Next() {

--- a/internal/storage/timezone.go
+++ b/internal/storage/timezone.go
@@ -12,10 +12,10 @@ import (
 func (s *Storage) Timezones() (map[string]string, error) {
 	timezones := make(map[string]string)
 	rows, err := s.db.Query(`SELECT name FROM pg_timezone_names() ORDER BY name ASC`)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch timezones: %v`, err)
 	}
-	defer rows.Close()
 
 	for rows.Next() {
 		var timezone string

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -536,10 +536,10 @@ func (s *Storage) RemoveUserAsync(userID int64) {
 
 func (s *Storage) deleteUserFeeds(userID int64) error {
 	rows, err := s.db.Query(`SELECT id FROM feeds WHERE user_id=$1`, userID)
+	defer rows.Close()
 	if err != nil {
 		return fmt.Errorf(`store: unable to get user feeds: %v`, err)
 	}
-	defer rows.Close()
 
 	for rows.Next() {
 		var feedID int64
@@ -592,10 +592,10 @@ func (s *Storage) Users() (model.Users, error) {
 		ORDER BY username ASC
 	`
 	rows, err := s.db.Query(query)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch users: %v`, err)
 	}
-	defer rows.Close()
 
 	var users model.Users
 	for rows.Next() {

--- a/internal/storage/user_session.go
+++ b/internal/storage/user_session.go
@@ -27,10 +27,10 @@ func (s *Storage) UserSessions(userID int64) (model.UserSessions, error) {
 			user_id=$1 ORDER BY id DESC
 	`
 	rows, err := s.db.Query(query, userID)
+	defer rows.Close()
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch user sessions: %v`, err)
 	}
-	defer rows.Close()
 
 	var sessions model.UserSessions
 	for rows.Next() {

--- a/internal/storage/webauthn.go
+++ b/internal/storage/webauthn.go
@@ -102,10 +102,10 @@ func (s *Storage) WebAuthnCredentialsByUserID(userID int64) ([]model.WebAuthnCre
 			user_id = $1
 	`
 	rows, err := s.db.Query(query, userID)
+	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	var creds []model.WebAuthnCredential
 	var nullName sql.NullString


### PR DESCRIPTION
- Properly close the rows in case of SQL errors, instead of having the `defer` called _after_ the `return` in the error condition.
- Use a string concatenation instead of joining an array for a sql query
- Reduce nested indentation by inverting some conditions
- Use a `var` construct instead of a `make` with a size of zero.
- Create the map in CountAllEntries with its values inline, instead of adding them one by one.
- Use a sort+compact construct to remove duplicates from a slice, instead of doing it by hand with a hashmap. The time complexity is now O(nlogn+n) instead of O(n), and space complexity around O(logn) instead of O(n+uniq(n)), but it shouldn't matter anyway, since `removeDuplicates` is only called to deduplicate tags.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] I read this document: https://miniflux.app/faq.html#pull-request
