### PR TITLE
Simplify removeDuplicates

### DIFF
--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"miniflux.app/v2/internal/crypto"
@@ -615,15 +616,7 @@ func (s *Storage) UnshareEntry(userID int64, entryID int64) (err error) {
 	return
 }
 
-// removeDuplicate removes duplicate entries from a slice
-func removeDuplicates[T string | int](sliceList []T) []T {
-	allKeys := make(map[T]bool)
-	list := []T{}
-	for _, item := range sliceList {
-		if _, value := allKeys[item]; !value {
-			allKeys[item] = true
-			list = append(list, item)
-		}
-	}
-	return list
+func removeDuplicates(l []string) []string {
+	slices.Sort(l)
+	return slices.Compact(l)
 }


### PR DESCRIPTION
Use a sort+compact construct instead of doing it by hand with a hashmap. The time complexity is now O(nlogn+n) instead of O(n), and space complexity around O(logn) instead of O(n+uniq(n)), but it shouldn't matter anyway, since removeDuplicates is only called to deduplicate tags.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] I read this document: https://miniflux.app/faq.html#pull-request
