### PR TITLE
Structure embedding in internal/model/feed.go

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -772,7 +772,7 @@ func subscribe(newFeed Stream, category Stream, title string, store *storage.Sto
 
 	if title != "" {
 		feedModification := model.FeedModificationRequest{
-			Title: &title,
+			Title: title,
 		}
 		feedModification.Patch(created)
 		if err := store.UpdateFeed(created); err != nil {
@@ -806,7 +806,7 @@ func rename(stream Stream, title string, store *storage.Storage, userID int64) e
 		return err
 	}
 	feedModification := model.FeedModificationRequest{
-		Title: &title,
+		Title: title,
 	}
 	feedModification.Patch(feed)
 	return store.UpdateFeed(feed)
@@ -822,7 +822,7 @@ func move(stream Stream, destination Stream, store *storage.Storage, userID int6
 		return err
 	}
 	feedModification := model.FeedModificationRequest{
-		CategoryID: &category.ID,
+		CategoryID: category.ID,
 	}
 	feedModification.Patch(feed)
 	return store.UpdateFeed(feed)

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -131,36 +131,15 @@ func (f *Feed) ScheduleNextCheck(weeklyCount int, newTTL int) {
 	f.NextCheckAt = time.Now().Add(time.Minute * time.Duration(intervalMinutes))
 }
 
-// FeedCreationRequest represents the request to create a feed.
-type FeedCreationRequest struct {
-	FeedURL                     string `json:"feed_url"`
-	CategoryID                  int64  `json:"category_id"`
-	UserAgent                   string `json:"user_agent"`
-	Cookie                      string `json:"cookie"`
-	Username                    string `json:"username"`
-	Password                    string `json:"password"`
-	Crawler                     bool   `json:"crawler"`
-	Disabled                    bool   `json:"disabled"`
-	NoMediaPlayer               bool   `json:"no_media_player"`
-	IgnoreHTTPCache             bool   `json:"ignore_http_cache"`
-	AllowSelfSignedCertificates bool   `json:"allow_self_signed_certificates"`
-	FetchViaProxy               bool   `json:"fetch_via_proxy"`
-	ScraperRules                string `json:"scraper_rules"`
-	RewriteRules                string `json:"rewrite_rules"`
-	BlocklistRules              string `json:"blocklist_rules"`
-	KeeplistRules               string `json:"keeplist_rules"`
-	HideGlobally                bool   `json:"hide_globally"`
-	UrlRewriteRules             string `json:"urlrewrite_rules"`
-	DisableHTTP2                bool   `json:"disable_http2"`
-}
-
-type FeedCreationRequestFromSubscriptionDiscovery struct {
+type feedRequest struct {
 	Content      io.ReadSeeker
 	ETag         string
 	LastModified string
 
 	FeedURL                     string `json:"feed_url"`
+	SiteURL                     string `json:"site_url"`
 	CategoryID                  int64  `json:"category_id"`
+	Title                       string `json:"title"`
 	UserAgent                   string `json:"user_agent"`
 	Cookie                      string `json:"cookie"`
 	Username                    string `json:"username"`
@@ -181,29 +160,13 @@ type FeedCreationRequestFromSubscriptionDiscovery struct {
 }
 
 // FeedModificationRequest represents the request to update a feed.
-type FeedModificationRequest struct {
-	FeedURL                     string `json:"feed_url"`
-	SiteURL                     string `json:"site_url"`
-	Title                       string `json:"title"`
-	ScraperRules                string `json:"scraper_rules"`
-	RewriteRules                string `json:"rewrite_rules"`
-	BlocklistRules              string `json:"blocklist_rules"`
-	KeeplistRules               string `json:"keeplist_rules"`
-	UrlRewriteRules             string `json:"urlrewrite_rules"`
-	Crawler                     bool   `json:"crawler"`
-	UserAgent                   string `json:"user_agent"`
-	Cookie                      string `json:"cookie"`
-	Username                    string `json:"username"`
-	Password                    string `json:"password"`
-	CategoryID                  int64  `json:"category_id"`
-	Disabled                    bool   `json:"disabled"`
-	NoMediaPlayer               bool   `json:"no_media_player"`
-	IgnoreHTTPCache             bool   `json:"ignore_http_cache"`
-	AllowSelfSignedCertificates bool   `json:"allow_self_signed_certificates"`
-	FetchViaProxy               bool   `json:"fetch_via_proxy"`
-	HideGlobally                bool   `json:"hide_globally"`
-	DisableHTTP2                bool   `json:"disable_http2"`
-}
+type FeedModificationRequest feedRequest
+
+// FeedCreationRequest represents the request to create a feed.
+type FeedCreationRequest feedRequest
+
+// FeedCreationRequestFromSubscriptionDiscovery represents the request to create a feed from a subscription discovery.
+type FeedCreationRequestFromSubscriptionDiscovery feedRequest
 
 // Patch updates a feed with modified values.
 func (f *FeedModificationRequest) Patch(feed *Feed) {
@@ -239,7 +202,7 @@ func (f *FeedModificationRequest) Patch(feed *Feed) {
 		feed.BlocklistRules = f.BlocklistRules
 	}
 
-	if f.Crawler != false {
+	if f.Crawler {
 		feed.Crawler = f.Crawler
 	}
 
@@ -263,31 +226,31 @@ func (f *FeedModificationRequest) Patch(feed *Feed) {
 		feed.Category.ID = f.CategoryID
 	}
 
-	if f.Disabled != false {
+	if f.Disabled {
 		feed.Disabled = f.Disabled
 	}
 
-	if f.NoMediaPlayer != false {
+	if f.NoMediaPlayer {
 		feed.NoMediaPlayer = f.NoMediaPlayer
 	}
 
-	if f.IgnoreHTTPCache != false {
+	if f.IgnoreHTTPCache {
 		feed.IgnoreHTTPCache = f.IgnoreHTTPCache
 	}
 
-	if f.AllowSelfSignedCertificates != false {
+	if f.AllowSelfSignedCertificates {
 		feed.AllowSelfSignedCertificates = f.AllowSelfSignedCertificates
 	}
 
-	if f.FetchViaProxy != false {
+	if f.FetchViaProxy {
 		feed.FetchViaProxy = f.FetchViaProxy
 	}
 
-	if f.HideGlobally != false {
+	if f.HideGlobally {
 		feed.HideGlobally = f.HideGlobally
 	}
 
-	if f.DisableHTTP2 != false {
+	if f.DisableHTTP2 {
 		feed.DisableHTTP2 = f.DisableHTTP2
 	}
 }

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -182,113 +182,113 @@ type FeedCreationRequestFromSubscriptionDiscovery struct {
 
 // FeedModificationRequest represents the request to update a feed.
 type FeedModificationRequest struct {
-	FeedURL                     *string `json:"feed_url"`
-	SiteURL                     *string `json:"site_url"`
-	Title                       *string `json:"title"`
-	ScraperRules                *string `json:"scraper_rules"`
-	RewriteRules                *string `json:"rewrite_rules"`
-	BlocklistRules              *string `json:"blocklist_rules"`
-	KeeplistRules               *string `json:"keeplist_rules"`
-	UrlRewriteRules             *string `json:"urlrewrite_rules"`
-	Crawler                     *bool   `json:"crawler"`
-	UserAgent                   *string `json:"user_agent"`
-	Cookie                      *string `json:"cookie"`
-	Username                    *string `json:"username"`
-	Password                    *string `json:"password"`
-	CategoryID                  *int64  `json:"category_id"`
-	Disabled                    *bool   `json:"disabled"`
-	NoMediaPlayer               *bool   `json:"no_media_player"`
-	IgnoreHTTPCache             *bool   `json:"ignore_http_cache"`
-	AllowSelfSignedCertificates *bool   `json:"allow_self_signed_certificates"`
-	FetchViaProxy               *bool   `json:"fetch_via_proxy"`
-	HideGlobally                *bool   `json:"hide_globally"`
-	DisableHTTP2                *bool   `json:"disable_http2"`
+	FeedURL                     string `json:"feed_url"`
+	SiteURL                     string `json:"site_url"`
+	Title                       string `json:"title"`
+	ScraperRules                string `json:"scraper_rules"`
+	RewriteRules                string `json:"rewrite_rules"`
+	BlocklistRules              string `json:"blocklist_rules"`
+	KeeplistRules               string `json:"keeplist_rules"`
+	UrlRewriteRules             string `json:"urlrewrite_rules"`
+	Crawler                     bool   `json:"crawler"`
+	UserAgent                   string `json:"user_agent"`
+	Cookie                      string `json:"cookie"`
+	Username                    string `json:"username"`
+	Password                    string `json:"password"`
+	CategoryID                  int64  `json:"category_id"`
+	Disabled                    bool   `json:"disabled"`
+	NoMediaPlayer               bool   `json:"no_media_player"`
+	IgnoreHTTPCache             bool   `json:"ignore_http_cache"`
+	AllowSelfSignedCertificates bool   `json:"allow_self_signed_certificates"`
+	FetchViaProxy               bool   `json:"fetch_via_proxy"`
+	HideGlobally                bool   `json:"hide_globally"`
+	DisableHTTP2                bool   `json:"disable_http2"`
 }
 
 // Patch updates a feed with modified values.
 func (f *FeedModificationRequest) Patch(feed *Feed) {
-	if f.FeedURL != nil && *f.FeedURL != "" {
-		feed.FeedURL = *f.FeedURL
+	if f.FeedURL != "" {
+		feed.FeedURL = f.FeedURL
 	}
 
-	if f.SiteURL != nil && *f.SiteURL != "" {
-		feed.SiteURL = *f.SiteURL
+	if f.SiteURL != "" {
+		feed.SiteURL = f.SiteURL
 	}
 
-	if f.Title != nil && *f.Title != "" {
-		feed.Title = *f.Title
+	if f.Title != "" {
+		feed.Title = f.Title
 	}
 
-	if f.ScraperRules != nil {
-		feed.ScraperRules = *f.ScraperRules
+	if f.ScraperRules != "" {
+		feed.ScraperRules = f.ScraperRules
 	}
 
-	if f.RewriteRules != nil {
-		feed.RewriteRules = *f.RewriteRules
+	if f.RewriteRules != "" {
+		feed.RewriteRules = f.RewriteRules
 	}
 
-	if f.KeeplistRules != nil {
-		feed.KeeplistRules = *f.KeeplistRules
+	if f.KeeplistRules != "" {
+		feed.KeeplistRules = f.KeeplistRules
 	}
 
-	if f.UrlRewriteRules != nil {
-		feed.UrlRewriteRules = *f.UrlRewriteRules
+	if f.UrlRewriteRules != "" {
+		feed.UrlRewriteRules = f.UrlRewriteRules
 	}
 
-	if f.BlocklistRules != nil {
-		feed.BlocklistRules = *f.BlocklistRules
+	if f.BlocklistRules != "" {
+		feed.BlocklistRules = f.BlocklistRules
 	}
 
-	if f.Crawler != nil {
-		feed.Crawler = *f.Crawler
+	if f.Crawler != false {
+		feed.Crawler = f.Crawler
 	}
 
-	if f.UserAgent != nil {
-		feed.UserAgent = *f.UserAgent
+	if f.UserAgent != "" {
+		feed.UserAgent = f.UserAgent
 	}
 
-	if f.Cookie != nil {
-		feed.Cookie = *f.Cookie
+	if f.Cookie != "" {
+		feed.Cookie = f.Cookie
 	}
 
-	if f.Username != nil {
-		feed.Username = *f.Username
+	if f.Username != "" {
+		feed.Username = f.Username
 	}
 
-	if f.Password != nil {
-		feed.Password = *f.Password
+	if f.Password != "" {
+		feed.Password = f.Password
 	}
 
-	if f.CategoryID != nil && *f.CategoryID > 0 {
-		feed.Category.ID = *f.CategoryID
+	if f.CategoryID > 0 {
+		feed.Category.ID = f.CategoryID
 	}
 
-	if f.Disabled != nil {
-		feed.Disabled = *f.Disabled
+	if f.Disabled != false {
+		feed.Disabled = f.Disabled
 	}
 
-	if f.NoMediaPlayer != nil {
-		feed.NoMediaPlayer = *f.NoMediaPlayer
+	if f.NoMediaPlayer != false {
+		feed.NoMediaPlayer = f.NoMediaPlayer
 	}
 
-	if f.IgnoreHTTPCache != nil {
-		feed.IgnoreHTTPCache = *f.IgnoreHTTPCache
+	if f.IgnoreHTTPCache != false {
+		feed.IgnoreHTTPCache = f.IgnoreHTTPCache
 	}
 
-	if f.AllowSelfSignedCertificates != nil {
-		feed.AllowSelfSignedCertificates = *f.AllowSelfSignedCertificates
+	if f.AllowSelfSignedCertificates != false {
+		feed.AllowSelfSignedCertificates = f.AllowSelfSignedCertificates
 	}
 
-	if f.FetchViaProxy != nil {
-		feed.FetchViaProxy = *f.FetchViaProxy
+	if f.FetchViaProxy != false {
+		feed.FetchViaProxy = f.FetchViaProxy
 	}
 
-	if f.HideGlobally != nil {
-		feed.HideGlobally = *f.HideGlobally
+	if f.HideGlobally != false {
+		feed.HideGlobally = f.HideGlobally
 	}
 
-	if f.DisableHTTP2 != nil {
-		feed.DisableHTTP2 = *f.DisableHTTP2
+	if f.DisableHTTP2 != false {
+		feed.DisableHTTP2 = f.DisableHTTP2
 	}
 }
 

--- a/internal/ui/feed_update.go
+++ b/internal/ui/feed_update.go
@@ -56,13 +56,13 @@ func (h *handler) updateFeed(w http.ResponseWriter, r *http.Request) {
 	view.Set("defaultUserAgent", config.Opts.HTTPClientUserAgent())
 
 	feedModificationRequest := &model.FeedModificationRequest{
-		FeedURL:         model.OptionalString(feedForm.FeedURL),
-		SiteURL:         model.OptionalString(feedForm.SiteURL),
-		Title:           model.OptionalString(feedForm.Title),
-		CategoryID:      model.OptionalNumber(feedForm.CategoryID),
-		BlocklistRules:  model.OptionalString(feedForm.BlocklistRules),
-		KeeplistRules:   model.OptionalString(feedForm.KeeplistRules),
-		UrlRewriteRules: model.OptionalString(feedForm.UrlRewriteRules),
+		FeedURL:         *model.OptionalString(feedForm.FeedURL),
+		SiteURL:         *model.OptionalString(feedForm.SiteURL),
+		Title:           *model.OptionalString(feedForm.Title),
+		CategoryID:      *model.OptionalNumber(feedForm.CategoryID),
+		BlocklistRules:  *model.OptionalString(feedForm.BlocklistRules),
+		KeeplistRules:   *model.OptionalString(feedForm.KeeplistRules),
+		UrlRewriteRules: *model.OptionalString(feedForm.UrlRewriteRules),
 	}
 
 	if validationErr := validator.ValidateFeedModification(h.store, loggedUser.ID, feed.ID, feedModificationRequest); validationErr != nil {

--- a/internal/ui/feed_update.go
+++ b/internal/ui/feed_update.go
@@ -56,13 +56,13 @@ func (h *handler) updateFeed(w http.ResponseWriter, r *http.Request) {
 	view.Set("defaultUserAgent", config.Opts.HTTPClientUserAgent())
 
 	feedModificationRequest := &model.FeedModificationRequest{
-		FeedURL:         *model.OptionalString(feedForm.FeedURL),
-		SiteURL:         *model.OptionalString(feedForm.SiteURL),
-		Title:           *model.OptionalString(feedForm.Title),
-		CategoryID:      *model.OptionalNumber(feedForm.CategoryID),
-		BlocklistRules:  *model.OptionalString(feedForm.BlocklistRules),
-		KeeplistRules:   *model.OptionalString(feedForm.KeeplistRules),
-		UrlRewriteRules: *model.OptionalString(feedForm.UrlRewriteRules),
+		FeedURL:         feedForm.FeedURL,
+		SiteURL:         feedForm.SiteURL,
+		Title:           feedForm.Title,
+		CategoryID:      feedForm.CategoryID,
+		BlocklistRules:  feedForm.BlocklistRules,
+		KeeplistRules:   feedForm.KeeplistRules,
+		UrlRewriteRules: feedForm.UrlRewriteRules,
 	}
 
 	if validationErr := validator.ValidateFeedModification(h.store, loggedUser.ID, feed.ID, feedModificationRequest); validationErr != nil {

--- a/internal/validator/feed.go
+++ b/internal/validator/feed.go
@@ -40,50 +40,50 @@ func ValidateFeedCreation(store *storage.Storage, userID int64, request *model.F
 
 // ValidateFeedModification validates feed modification.
 func ValidateFeedModification(store *storage.Storage, userID, feedID int64, request *model.FeedModificationRequest) *locale.LocalizedError {
-	if request.FeedURL != nil {
-		if *request.FeedURL == "" {
+	if request.FeedURL != "" {
+		if request.FeedURL == "" {
 			return locale.NewLocalizedError("error.feed_url_not_empty")
 		}
 
-		if !IsValidURL(*request.FeedURL) {
+		if !IsValidURL(request.FeedURL) {
 			return locale.NewLocalizedError("error.invalid_feed_url")
 		}
 
-		if store.AnotherFeedURLExists(userID, feedID, *request.FeedURL) {
+		if store.AnotherFeedURLExists(userID, feedID, request.FeedURL) {
 			return locale.NewLocalizedError("error.feed_already_exists")
 		}
 	}
 
-	if request.SiteURL != nil {
-		if *request.SiteURL == "" {
+	if request.SiteURL != "" {
+		if request.SiteURL == "" {
 			return locale.NewLocalizedError("error.site_url_not_empty")
 		}
 
-		if !IsValidURL(*request.SiteURL) {
+		if !IsValidURL(request.SiteURL) {
 			return locale.NewLocalizedError("error.invalid_site_url")
 		}
 	}
 
-	if request.Title != nil {
-		if *request.Title == "" {
+	if request.Title != "" {
+		if request.Title == "" {
 			return locale.NewLocalizedError("error.feed_title_not_empty")
 		}
 	}
 
-	if request.CategoryID != nil {
-		if !store.CategoryIDExists(userID, *request.CategoryID) {
+	if request.CategoryID > 0 {
+		if !store.CategoryIDExists(userID, request.CategoryID) {
 			return locale.NewLocalizedError("error.feed_category_not_found")
 		}
 	}
 
-	if request.BlocklistRules != nil {
-		if !IsValidRegex(*request.BlocklistRules) {
+	if request.BlocklistRules != "" {
+		if !IsValidRegex(request.BlocklistRules) {
 			return locale.NewLocalizedError("error.feed_invalid_blocklist_rule")
 		}
 	}
 
-	if request.KeeplistRules != nil {
-		if !IsValidRegex(*request.KeeplistRules) {
+	if request.KeeplistRules != "" {
+		if !IsValidRegex(request.KeeplistRules) {
 			return locale.NewLocalizedError("error.feed_invalid_keeplist_rule")
 		}
 	}


### PR DESCRIPTION
Factorise structures used to create/update feeds into a single one in `internal/model/feed.go`. While some fields of the new resulting structure might be unused in some cases, it's still a massive improvement over having 3 times the sam-ish gigantic structure.

Note to reviewers: I'm a bit unsure about my changes for the `Patch` method.

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] I read this document: https://miniflux.app/faq.html#pull-request
