### PR TITLE
rewriter: add a `compress` rule

### DIFF
--- a/internal/reader/rewrite/rewriter.go
+++ b/internal/reader/rewrite/rewriter.go
@@ -14,6 +14,9 @@ import (
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/tdewolff/minify/v2"
+	"github.com/tdewolff/minify/v2/html"
 )
 
 type rule struct {
@@ -97,6 +100,12 @@ func (rule rule) applyRule(entryURL string, entry *model.Entry) {
 		entry.Content = removeTables(entry.Content)
 	case "remove_clickbait":
 		entry.Title = cases.Title(language.English).String(strings.ToLower(entry.Title))
+	case "compress":
+		minifier := minify.New()
+		minifier.AddFunc("text/html", html.Minify)
+		if minifiedHTML, err := minifier.String("text/html", entry.Content); err == nil {
+			entry.Content = minifiedHTML
+		}
 	}
 }
 

--- a/internal/reader/rewrite/rewriter_test.go
+++ b/internal/reader/rewrite/rewriter_test.go
@@ -703,3 +703,22 @@ func TestAddImageTitle(t *testing.T) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
 	}
 }
+
+func TestCompress(t *testing.T) {
+	testEntry := &model.Entry{
+		Title: `A title`,
+		Content: `
+		<img src="pif"          title="pouf" >
+		`,
+	}
+
+	controlEntry := &model.Entry{
+		Title:   `A title`,
+		Content: `<img src=pif title=pouf>`,
+	}
+	Rewriter("https://example.org/article", testEntry, `compress`)
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}

--- a/internal/reader/rewrite/rules.go
+++ b/internal/reader/rewrite/rules.go
@@ -3,9 +3,7 @@
 
 package rewrite // import "miniflux.app/v2/internal/reader/rewrite"
 
-// List of predefined rewrite rules (alphabetically sorted)
-// Available rules: "add_image_title", "add_youtube_video"
-// domain => rule name
+// Alphabetically sorted list of predefined rewrite rules
 var predefinedRules = map[string]string{
 	"abstrusegoose.com":      "add_image_title",
 	"amazingsuperpowers.com": "add_image_title",


### PR DESCRIPTION
Since some html pages might be a tad heavy, having a `compress` rule can be handy to mitigate the disaster.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
