### PR TITLE
timezone: make sure the tests run when the timezone database is not installed on the host

### DIFF
--- a/internal/timezone/timezone_test.go
+++ b/internal/timezone/timezone_test.go
@@ -6,6 +6,9 @@ package timezone // import "miniflux.app/v2/internal/timezone"
 import (
 	"testing"
 	"time"
+
+	// Make sure these tests pass when the timezone database is not installed on the host system.
+	_ "time/tzdata"
 )
 
 func TestNow(t *testing.T) {


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [X] I really tested my changes and there is no regression
- [X] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [X] I read this document: https://miniflux.app/faq.html#pull-request
