### PR TITLE
finder: Find feed from YouTube playlist

### DIFF
--- a/internal/reader/subscription/finder_test.go
+++ b/internal/reader/subscription/finder_test.go
@@ -8,6 +8,28 @@ import (
 	"testing"
 )
 
+func TestFindYoutubePlaylistFeed(t *testing.T) {
+	scenarios := map[string]string{
+		"https://www.youtube.com/playlist?list=PLOOwEPgFWm_NHcQd9aCi5JXWASHO_n5uR": "https://www.youtube.com/feeds/videos.xml?playlist_id=PLOOwEPgFWm_NHcQd9aCi5JXWASHO_n5uR",
+		"https://www.youtube.com/playlist?list=PLOOwEPgFWm_N42HlCLhqyJ0ZBWr5K1QDM": "https://www.youtube.com/feeds/videos.xml?playlist_id=PLOOwEPgFWm_N42HlCLhqyJ0ZBWr5K1QDM",
+	}
+
+	for websiteURL, expectedFeedURL := range scenarios {
+		subscriptions, localizedError := NewSubscriptionFinder(nil).FindSubscriptionsFromYouTubePlaylistPage(websiteURL)
+		if localizedError != nil {
+			t.Fatalf(`Parsing a correctly formatted YouTube playlist page should not return any error: %v`, localizedError)
+		}
+
+		if len(subscriptions) != 1 {
+			t.Fatal(`Incorrect number of subscriptions returned`)
+		}
+
+		if subscriptions[0].URL != expectedFeedURL {
+			t.Errorf(`Unexpected Feed, got %s, instead of %s`, subscriptions[0].URL, expectedFeedURL)
+		}
+	}
+}
+
 func TestFindYoutubeChannelFeed(t *testing.T) {
 	scenarios := map[string]string{
 		"https://www.youtube.com/channel/UC-Qj80avWItNRjkZ41rzHyw": "https://www.youtube.com/feeds/videos.xml?channel_id=UC-Qj80avWItNRjkZ41rzHyw",


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request

YouTube playlists also have feeds, which can be obtained in a manner very similar to the YouTube channel page.