### PR TITLE
ci: use `docker/metadata-action` instead of deprecated shell-scripts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,35 +8,8 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  test-docker-images:
-    if: github.event.pull_request
-    name: Test Images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build Alpine image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./packaging/docker/alpine/Dockerfile
-          push: false
-          tags: ${{ github.repository_owner }}/miniflux:alpine-dev
-      - name: Test Alpine Docker image
-        run: docker run --rm ${{ github.repository_owner }}/miniflux:alpine-dev miniflux -i
-      - name: Build Distroless image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./packaging/docker/distroless/Dockerfile
-          push: false
-          tags: ${{ github.repository_owner }}/miniflux:distroless-dev
-      - name: Test Distroless Docker image
-        run: docker run --rm ${{ github.repository_owner }}/miniflux:distroless-dev miniflux -i
-
-  publish-docker-images:
-    if: ${{ ! github.event.pull_request }}
-    name: Publish Images
+  docker-images:
+    name: Docker Images
     permissions:
       packages: write
     runs-on: ubuntu-latest
@@ -46,33 +19,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate Alpine Docker tag
-        id: docker_alpine_tag
-        run: |
-          DOCKER_IMAGE=${{ github.repository_owner }}/miniflux
-          DOCKER_VERSION=dev
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-          DOCKER_VERSION=nightly
-          TAGS="docker.io/${DOCKER_IMAGE}:${DOCKER_VERSION},ghcr.io/${DOCKER_IMAGE}:${DOCKER_VERSION},quay.io/${DOCKER_IMAGE}:${DOCKER_VERSION}"
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-          DOCKER_VERSION=${GITHUB_REF#refs/tags/}
-          TAGS="docker.io/${DOCKER_IMAGE}:${DOCKER_VERSION},ghcr.io/${DOCKER_IMAGE}:${DOCKER_VERSION},quay.io/${DOCKER_IMAGE}:${DOCKER_VERSION},docker.io/${DOCKER_IMAGE}:latest,ghcr.io/${DOCKER_IMAGE}:latest,quay.io/${DOCKER_IMAGE}:latest"
-          fi
-          echo ::set-output name=tags::${TAGS}
+      - name: Generate Alpine Docker tags
+        id: docker_alpine_tags
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/miniflux/miniflux
+            ghcr.io/miniflux/miniflux
+            quay.io/miniflux/miniflux
+          tags: |
+            type=ref,event=pr
+            type=schedule,pattern=nightly
+            type=semver,pattern={{raw}}
 
-      - name: Generate Distroless Docker tag
-        id: docker_distroless_tag
-        run: |
-          DOCKER_IMAGE=${{ github.repository_owner }}/miniflux
-          DOCKER_VERSION=dev-distroless
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-          DOCKER_VERSION=nightly-distroless
-          TAGS="docker.io/${DOCKER_IMAGE}:${DOCKER_VERSION},ghcr.io/${DOCKER_IMAGE}:${DOCKER_VERSION},quay.io/${DOCKER_IMAGE}:${DOCKER_VERSION}"
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-          DOCKER_VERSION=${GITHUB_REF#refs/tags/}-distroless
-          TAGS="docker.io/${DOCKER_IMAGE}:${DOCKER_VERSION},ghcr.io/${DOCKER_IMAGE}:${DOCKER_VERSION},quay.io/${DOCKER_IMAGE}:${DOCKER_VERSION},docker.io/${DOCKER_IMAGE}:latest-distroless,ghcr.io/${DOCKER_IMAGE}:latest-distroless,quay.io/${DOCKER_IMAGE}:latest-distroless"
-          fi
-          echo ::set-output name=tags::${TAGS}
+      - name: Generate Distroless Docker tags
+        id: docker_distroless_tags
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/miniflux/miniflux
+            ghcr.io/miniflux/miniflux
+            quay.io/miniflux/miniflux
+          tags: |
+            type=ref,event=pr,suffix=-distroless
+            type=schedule,pattern=nightly,suffix=-distroless
+            type=semver,pattern={{raw}},suffix=-distroless
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -81,12 +52,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -94,6 +67,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Quay Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -106,8 +80,8 @@ jobs:
           context: .
           file: ./packaging/docker/alpine/Dockerfile
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
-          push: true
-          tags: ${{ steps.docker_alpine_tag.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_alpine_tags.outputs.tags }}
 
       - name: Build and Push Distroless images
         uses: docker/build-push-action@v5
@@ -115,5 +89,5 @@ jobs:
           context: .
           file: ./packaging/docker/distroless/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker_distroless_tag.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_distroless_tags.outputs.tags }}


### PR DESCRIPTION
Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking changes
- [ ] I really tested my changes and there is no regression
- [ ] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [ ] I read this document: https://miniflux.app/faq.html#pull-request
