### PR TITLE
api tests: use intSize-agnostic random integers

### DIFF
--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"os"
 	"strings"
@@ -58,7 +57,7 @@ func (c *integrationTestConfig) isConfigured() bool {
 }
 
 func (c *integrationTestConfig) genRandomUsername() string {
-	return fmt.Sprintf("%s_%10d", c.testRegularUsername, rand.Intn(math.MaxInt64))
+	return fmt.Sprintf("%s_%10d", c.testRegularUsername, rand.Int())
 }
 
 func TestIncorrectEndpoint(t *testing.T) {


### PR DESCRIPTION
rand.Intn(math.MaxInt64) causes tests to fail on 32-bit architectures. Use the simpler rand.Int() instead, which still provides plenty of room for generating pseudo-random test usernames.

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
