### PR TITLE
reader/rewrite: add a rule for oglaf.com

### DIFF
--- a/internal/reader/rewrite/rules.go
+++ b/internal/reader/rewrite/rules.go
@@ -24,7 +24,7 @@ var predefinedRules = map[string]string{
 	"monkeyuser.com":         "add_image_title",
 	"mrlovenstein.com":       "add_image_title",
 	"nedroid.com":            "add_image_title",
-	"oglaf.com":              "add_image_title",
+	"oglaf.com":              `replace("media.oglaf.com/story/tt(.+).gif"|"media.oglaf.com/comic/$1.jpg"),add_image_title`,
 	"optipess.com":           "add_image_title",
 	"peebleslab.com":         "add_image_title",
 	"quantamagazine.org":     `add_youtube_video_from_id, remove("h6:not(.byline,.post__title__kicker), #comments, .next-post__content, .footer__section, figure .outer--content, script")`,


### PR DESCRIPTION
By default, Oglaf show some disclaimer/warning about its content, and this doesn't play well with rss readers, so let's rewrite it to show the actual comic instead of a placeholder.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
