### PR TITLE
Add back removed other repo owners in GH docker actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,9 +24,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            docker.io/miniflux/miniflux
-            ghcr.io/miniflux/miniflux
-            quay.io/miniflux/miniflux
+            docker.io/${{ github.repository_owner }}/miniflux
+            ghcr.io/${{ github.repository_owner }}/miniflux
+            quay.io/${{ github.repository_owner }}/miniflux
           tags: |
             type=ref,event=pr
             type=schedule,pattern=nightly
@@ -37,9 +37,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            docker.io/miniflux/miniflux
-            ghcr.io/miniflux/miniflux
-            quay.io/miniflux/miniflux
+            docker.io/${{ github.repository_owner }}/miniflux
+            ghcr.io/${{ github.repository_owner }}/miniflux
+            quay.io/${{ github.repository_owner }}/miniflux
           tags: |
             type=ref,event=pr,suffix=-distroless
             type=schedule,pattern=nightly,suffix=-distroless


### PR DESCRIPTION
In cf96ab45c198fbdc, support was added for using Docker related Github actions in repositories of other owners. This was pretty helpful as it allowed running modified forks off of main in a nightly fashion before patches were pushed upstream. This was removed in 6e870cdccc9ac845b678b, add it back

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
