### PR TITLE
fix: Use `FORCE_REFRESH_INTERVAL` config for category refresh

### DIFF
--- a/internal/ui/category_refresh.go
+++ b/internal/ui/category_refresh.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response/html"
 	"miniflux.app/v2/internal/http/route"
@@ -32,8 +33,9 @@ func (h *handler) refreshCategory(w http.ResponseWriter, r *http.Request) int64 
 	sess := session.New(h.store, request.SessionID(r))
 
 	// Avoid accidental and excessive refreshes.
-	if time.Now().UTC().Unix()-request.LastForceRefresh(r) < 1800 {
-		sess.NewFlashErrorMessage(printer.Print("alert.too_many_feeds_refresh"))
+	if time.Now().UTC().Unix()-request.LastForceRefresh(r) < int64(config.Opts.ForceRefreshInterval())*60 {
+		time := config.Opts.ForceRefreshInterval()
+		sess.NewFlashErrorMessage(printer.Plural("alert.too_many_feeds_refresh", time, time))
 	} else {
 		// We allow the end-user to force refresh all its feeds in this category
 		// without taking into consideration the number of errors.


### PR DESCRIPTION
Do you follow the guidelines?

- [ ] I have tested my changes
- [x] There is no breaking changes
- [ ] I really tested my changes and there is no regression
- [ ] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request

I haven't tested the changes since they seem trivial (just copy-pasted from https://github.com/miniflux/v2/blob/main/internal/ui/feed_refresh.go#L41-L43) and I'm not set up to easily test them. Let me know if I need to do that anyways.