### PR TITLE
reader/processor: minifier is breaking HTML entry content

### DIFF
--- a/internal/reader/processor/processor_test.go
+++ b/internal/reader/processor/processor_test.go
@@ -117,3 +117,12 @@ func TestIsRecentEntry(t *testing.T) {
 		}
 	}
 }
+
+func TestMinifyEntryContent(t *testing.T) {
+	input := `<p>    Some text with a <a href="http://example.org/"> link   </a>    </p>`
+	expected := `<p>Some text with a <a href="http://example.org/">link</a></p>`
+	result := minifyEntryContent(input)
+	if expected != result {
+		t.Errorf(`Unexpected result, got %q`, result)
+	}
+}


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [X] I really tested my changes and there is no regression
- [X] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [X] I read this document: https://miniflux.app/faq.html#pull-request
