### PR TITLE
Add missing properties when reloading page after error

### DIFF
--- a/internal/ui/settings_update.go
+++ b/internal/ui/settings_update.go
@@ -30,6 +30,12 @@ func (h *handler) updateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	creds, err := h.store.WebAuthnCredentialsByUserID(loggedUser.ID)
+	if err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
 	settingsForm := form.NewSettingsForm(r)
 
 	sess := session.New(h.store, request.SessionID(r))
@@ -42,6 +48,10 @@ func (h *handler) updateSettings(w http.ResponseWriter, r *http.Request) {
 	view.Set("user", loggedUser)
 	view.Set("countUnread", h.store.CountUnreadEntries(loggedUser.ID))
 	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(loggedUser.ID))
+	view.Set("default_home_pages", model.HomePages())
+	view.Set("categories_sorting_options", model.CategoriesSortingOptions())
+	view.Set("countWebAuthnCerts", h.store.CountWebAuthnCredentialsByUserID(loggedUser.ID))
+	view.Set("webAuthnCerts", creds)
 
 	if validationErr := settingsForm.Validate(); validationErr != nil {
 		view.Set("errorMessage", validationErr.Translate(loggedUser.Language))


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [?] I really tested my changes and there is no regression
- [X] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [X] I read this document: https://miniflux.app/faq.html#pull-request

I copied over the view populating code from `settings_show.go`

Fixes #2665 

I would recommend to refactor out the View populating code so that it will never get "out of sync", in the future.