### PR TITLE
fix(greader): set CrawlTimeMsec at the correct precision

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -1022,7 +1022,7 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 			Title:         entry.Title,
 			Author:        entry.Author,
 			TimestampUsec: fmt.Sprintf("%d", entry.Date.UnixNano()/(int64(time.Microsecond)/int64(time.Nanosecond))),
-			CrawlTimeMsec: fmt.Sprintf("%d", entry.Date.UnixNano()/(int64(time.Microsecond)/int64(time.Nanosecond))),
+			CrawlTimeMsec: fmt.Sprintf("%d", entry.Date.UnixNano()/(int64(time.Millisecond)/int64(time.Nanosecond))),
 			Published:     entry.Date.Unix(),
 			Updated:       entry.Date.Unix(),
 			Categories:    categories,


### PR DESCRIPTION
Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking changes
- [ ] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request

This PR is a quick and simple fix for #2669, where you can find a full writeup.