### PR TITLE
googelreader: set CrawlTimeMsec at the correct precision

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -1021,10 +1021,10 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 			ID:            fmt.Sprintf(EntryIDLong, entry.ID),
 			Title:         entry.Title,
 			Author:        entry.Author,
-			TimestampUsec: fmt.Sprintf("%d", entry.Date.UnixNano()/(int64(time.Microsecond)/int64(time.Nanosecond))),
-			CrawlTimeMsec: fmt.Sprintf("%d", entry.Date.UnixNano()/(int64(time.Microsecond)/int64(time.Nanosecond))),
+			TimestampUsec: fmt.Sprintf("%d", entry.Date.UnixMicro()),
+			CrawlTimeMsec: fmt.Sprintf("%d", entry.CreatedAt.UnixMilli()),
 			Published:     entry.Date.Unix(),
-			Updated:       entry.Date.Unix(),
+			Updated:       entry.ChangedAt.Unix(),
 			Categories:    categories,
 			Canonical: []contentHREF{
 				{


### PR DESCRIPTION
Fixes #2669

Fixes #2670

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
