### PR TITLE
Fix enclosure playback speed indicator precision

### DIFF
--- a/internal/ui/static/js/bootstrap.js
+++ b/internal/ui/static/js/bootstrap.js
@@ -172,7 +172,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 // Could not do it backend side because I didn't know how to do it because of the template inclusion and
                 // the way the initial playback speed is handled. See enclosure_media_controls.html if you want to try to fix this
                 document.querySelectorAll(`span.speed-indicator[data-enclosure-id="${element.dataset.enclosureId}"]`).forEach((speedI)=>{
-                    speedI.innerText = `${element.dataset.playbackRate}x`;
+                    speedI.innerText = `${parseFloat(element.dataset.playbackRate).toFixed(2)}x`;
                 });
             }
         }


### PR DESCRIPTION
The original idea was to have two digit precision at all time in order to ensure the length of the string is always the same. This prevents the UI button to move when pressed.
I completely missed the first press as the precision was not right upon first click.

Before:
![Speed indicator is 1x](https://github.com/miniflux/v2/assets/988094/c716d33a-4a14-4a5f-bcd4-27b32c6ff3e7)

After:
![Speed indicator is not 1.00x](https://github.com/miniflux/v2/assets/988094/08a8e6b4-3464-4dd4-aec9-3ad3ba7ea0e9)


Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
