### PR TITLE
Fix Enclosure playback speed indicator on shared entries

### DIFF
--- a/internal/template/templates/common/enclosure_media_controls.html
+++ b/internal/template/templates/common/enclosure_media_controls.html
@@ -9,7 +9,7 @@
     </div>
     <div class="media-speed-control">
 
-        <div class="media-control-label">{{ t "enclosure_media_controls.speed" }} (<span class="speed-indicator" data-enclosure-id="{{.ID}}">x.xxx</span>)</div> <!-- Need JS to display the current speed unfortunately -->
+        <div class="media-control-label">{{ t "enclosure_media_controls.speed" }} (<span class="speed-indicator" data-enclosure-id="{{.ID}}">1.00x</span>)</div> <!-- Need JS to display the current speed unfortunately -->
         <button class="page-button" data-enclosure-id="{{.ID}}" data-enclosure-action="speed" data-action-value="-0.25" title="{{ t "enclosure_media_controls.speed.slower.title" "0.25" }}"><span class="icon-label" >{{ t "enclosure_media_controls.speed.slower" }}</span></button>
         <button class="page-button" data-enclosure-id="{{.ID}}" data-enclosure-action="speed-reset" data-action-value="1" title="{{ t "enclosure_media_controls.speed.reset.title"}}"><span class="icon-label" >{{ t "enclosure_media_controls.speed.reset" }}</span></button>
         <button class="page-button" data-enclosure-id="{{.ID}}" data-enclosure-action="speed" data-action-value="+0.25" title="{{ t "enclosure_media_controls.speed.faster.title" "0.25" }}"><span class="icon-label" >{{ t "enclosure_media_controls.speed.faster" }}</span></button>


### PR DESCRIPTION
On shared entries, there is no speed configured as this is bound to the user. Shared entries are displayed without user config.

I've changed the default view to reflect the
actual default playback speed in this case. 1x.

Before:
![Speed indicator was x.xxx](https://github.com/miniflux/v2/assets/988094/265f2808-947c-4afb-a7d9-2fbe5b22ce1e)

After:
![Speed indicator is now 1.00x](https://github.com/miniflux/v2/assets/988094/9cd2e299-a2e6-47b9-9d5a-7e8c5f8ec844)


Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
