### PR TITLE
Telegram: add feed name to message

### DIFF
--- a/internal/integration/telegrambot/telegrambot.go
+++ b/internal/integration/telegrambot/telegrambot.go
@@ -11,7 +11,8 @@ import (
 
 func PushEntry(feed *model.Feed, entry *model.Entry, botToken, chatID string, topicID *int64, disableWebPagePreview, disableNotification bool, disableButtons bool) error {
 	formattedText := fmt.Sprintf(
-		`<a href=%q>%s</a>`,
+		`<b>%s</b> - <a href=%q>%s</a>`,
+		feed.Title,
 		entry.URL,
 		entry.Title,
 	)


### PR DESCRIPTION
39d752c removed a link to the feed name to solve a web preview issue. This change brings back the feed name without the link, thus restoring the feed name without bringing back the issue.

Fixes #2620

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request
