### PR TITLE
Use ETag as a strong validator over Last-Modified

### DIFF
--- a/internal/reader/fetcher/response_handler.go
+++ b/internal/reader/fetcher/response_handler.go
@@ -56,12 +56,12 @@ func (r *ResponseHandler) IsModified(lastEtagValue, lastModifiedValue string) bo
 		return false
 	}
 
-	if r.ETag() != "" && r.ETag() == lastEtagValue {
-		return false
+	if r.ETag() != "" {
+		return r.ETag() != lastEtagValue
 	}
 
-	if r.LastModified() != "" && r.LastModified() == lastModifiedValue {
-		return false
+	if r.LastModified() != "" {
+		return r.LastModified() != lastModifiedValue
 	}
 
 	return true

--- a/internal/reader/fetcher/response_handler_test.go
+++ b/internal/reader/fetcher/response_handler_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher // import "miniflux.app/v2/internal/reader/fetcher"
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsModified(t *testing.T) {
+	var cachedEtag = "abc123"
+	var cachedLastModified = "Wed, 21 Oct 2015 07:28:00 GMT"
+
+	var testCases = map[string]struct {
+		Status       int
+		LastModified string
+		ETag         string
+		IsModified   bool
+	}{
+		"Unmodified 304": {
+			Status:       304,
+			LastModified: cachedLastModified,
+			ETag:         cachedEtag,
+			IsModified:   false,
+		},
+		"Unmodified 200": {
+			Status:       200,
+			LastModified: cachedLastModified,
+			ETag:         cachedEtag,
+			IsModified:   false,
+		},
+		// This case is invalid per RFC9110 8.8.1, so ETag takes precedence.
+		"Last-Modified changed only": {
+			Status:       200,
+			LastModified: "Thu, 22 Oct 2015 07:28:00 GMT",
+			ETag:         cachedEtag,
+			IsModified:   false,
+		},
+		"ETag changed only": {
+			Status:       200,
+			LastModified: cachedLastModified,
+			ETag:         "xyz789",
+			IsModified:   true,
+		},
+		"ETag and Last-Modified changed": {
+			Status:       200,
+			LastModified: "Thu, 22 Oct 2015 07:28:00 GMT",
+			ETag:         "xyz789",
+			IsModified:   true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(tt *testing.T) {
+			header := http.Header{}
+			header.Add("Last-Modified", tc.LastModified)
+			header.Add("ETag", tc.ETag)
+			rh := ResponseHandler{
+				httpResponse: &http.Response{
+					StatusCode: tc.Status,
+					Header:     header,
+				},
+			}
+			if tc.IsModified != rh.IsModified(cachedEtag, cachedLastModified) {
+				tt.Error(name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [x] I read this document: https://miniflux.app/faq.html#pull-request

As per the [MDN article on HTTP caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching):

> During cache revalidation, if both If-Modified-Since and If-None-Match are present, then If-None-Match takes precedence for the validator.

Previously Miniflux would consider a resource unmodified if the Last-Modified header had not changed, even if the ETag had changed.

With this commit, Miniflux will consider a resource modified if the ETag header has changed, even if Last-Modified has not.

This fixes Bug 1 in https://rachelbythebay.com/w/2024/06/11/fsr/