### PR TITLE
Fix filter rules for carriage returns windows

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response/json"
@@ -86,9 +87,13 @@ func (h *handler) updateUser(w http.ResponseWriter, r *http.Request) {
 	cleanEnd := regexp.MustCompile(`(?m)\r\n\s*$`)
 	if userModificationRequest.BlockFilterEntryRules != nil {
 		*userModificationRequest.BlockFilterEntryRules = cleanEnd.ReplaceAllLiteralString(*userModificationRequest.BlockFilterEntryRules, "")
+		// Clean carriage returns for Windows environments
+		*userModificationRequest.BlockFilterEntryRules = strings.ReplaceAll(*userModificationRequest.BlockFilterEntryRules, "\r\n", "\n")
 	}
 	if userModificationRequest.KeepFilterEntryRules != nil {
 		*userModificationRequest.KeepFilterEntryRules = cleanEnd.ReplaceAllLiteralString(*userModificationRequest.KeepFilterEntryRules, "")
+		// Clean carriage returns for Windows environments
+		*userModificationRequest.KeepFilterEntryRules = strings.ReplaceAll(*userModificationRequest.KeepFilterEntryRules, "\r\n", "\n")
 	}
 
 	if validationErr := validator.ValidateUserModification(h.store, originalUser.ID, &userModificationRequest); validationErr != nil {

--- a/internal/ui/settings_update.go
+++ b/internal/ui/settings_update.go
@@ -6,6 +6,7 @@ package ui // import "miniflux.app/v2/internal/ui"
 import (
 	"net/http"
 	"regexp"
+	"strings"
 
 	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response/html"
@@ -58,6 +59,9 @@ func (h *handler) updateSettings(w http.ResponseWriter, r *http.Request) {
 	cleanEnd := regexp.MustCompile(`(?m)\r\n\s*$`)
 	settingsForm.BlockFilterEntryRules = cleanEnd.ReplaceAllLiteralString(settingsForm.BlockFilterEntryRules, "")
 	settingsForm.KeepFilterEntryRules = cleanEnd.ReplaceAllLiteralString(settingsForm.KeepFilterEntryRules, "")
+	// Clean carriage returns for Windows environments
+	settingsForm.BlockFilterEntryRules = strings.ReplaceAll(settingsForm.BlockFilterEntryRules, "\r\n", "\n")
+	settingsForm.KeepFilterEntryRules = strings.ReplaceAll(settingsForm.KeepFilterEntryRules, "\r\n", "\n")
 
 	if validationErr := settingsForm.Validate(); validationErr != nil {
 		view.Set("errorMessage", validationErr.Translate(loggedUser.Language))

--- a/internal/validator/user.go
+++ b/internal/validator/user.go
@@ -212,7 +212,7 @@ func validateMediaPlaybackRate(mediaPlaybackRate float64) *locale.LocalizedError
 }
 
 func isValidFilterRules(filterEntryRules string, filterType string) *locale.LocalizedError {
-	// Valid Format: FieldName(RegEx)~FieldName(RegEx)~...
+	// Valid Format: FieldName=RegEx\nFieldName=RegEx...
 	fieldNames := []string{"EntryTitle", "EntryURL", "EntryCommentsURL", "EntryContent", "EntryAuthor", "EntryTag"}
 
 	rules := strings.Split(filterEntryRules, "\n")


### PR DESCRIPTION
- Sanitize the filter rules to remove "\r" (Might be a windows-only fix)
- Update the comment in the Rule Validator specifying the Rule format (FieldName=RegEx\nFieldName=RegEx...)

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [X] I really tested my changes and there is no regression
- [X] Ideally, my commit messages use the same convention as the Go project: https://go.dev/doc/contribute#commit_messages
- [X] I read this document: https://miniflux.app/faq.html#pull-request
