### PR TITLE
fix: `<img>` aspect ratio w/ `height: auto`

### DIFF
--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -1038,6 +1038,10 @@ article.category-has-unread {
     max-width: 100%;
 }
 
+.entry-content img {
+    height: auto;
+}
+
 .entry-content figure {
     margin-top: 15px;
     margin-bottom: 15px;


### PR DESCRIPTION
Complement the `max-width: 100%` with a `height: auto` to preserve `<img>` aspect ratios, particularly when it's not wrapped in a block parent e.g. `<p>` or `<figure>` most commonly.

Related: https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/

An example scenario that this fixes: https://reader.miniflux.app/share/8bd2c1ae6b6577ef9c81106964f9a9e9865edb0d

Before:

<img width="416" alt="image" src="https://github.com/miniflux/v2/assets/6335792/fdd9028f-3baa-4138-bda2-4358f3172c20">

After:

<img width="403" alt="image" src="https://github.com/miniflux/v2/assets/6335792/54675fd1-56a2-4b71-9508-657595c87ec2">


Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
