### PR TITLE
feat: remove YouTube video page subscription finder because `meta[itemprop="channelId"]` no longer exists

### DIFF
--- a/internal/reader/subscription/finder_test.go
+++ b/internal/reader/subscription/finder_test.go
@@ -32,13 +32,6 @@ func TestFindYoutubePlaylistFeed(t *testing.T) {
 	}
 }
 
-func TestItDoesNotConsiderPlaylistWatchPageAsVideoWatchPage(t *testing.T) {
-	_, localizedError := NewSubscriptionFinder(nil).FindSubscriptionsFromYouTubeVideoPage("https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLOOwEPgFWm_N42HlCLhqyJ0ZBWr5K1QDM")
-	if localizedError != nil {
-		t.Fatalf(`Should not consider a playlist watch page as a video watch page`)
-	}
-}
-
 func TestYoutubeIdExtractor(t *testing.T) {
 	type testResult struct {
 		ID    string
@@ -46,21 +39,6 @@ func TestYoutubeIdExtractor(t *testing.T) {
 		error error
 	}
 	urls := map[string]testResult{
-		"https://www.youtube.com/watch?v=dQw4w9WgXcQ": {
-			ID:    "dQw4w9WgXcQ",
-			Kind:  youtubeIDKindVideo,
-			error: nil,
-		},
-		"https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=1": {
-			ID:    "dQw4w9WgXcQ",
-			Kind:  youtubeIDKindVideo,
-			error: nil,
-		},
-		"https://www.youtube.com/watch?t=1&v=dQw4w9WgXcQ": {
-			ID:    "dQw4w9WgXcQ",
-			Kind:  youtubeIDKindVideo,
-			error: nil,
-		},
 		"https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLOOwEPgFWm_N42HlCLhqyJ0ZBWr5K1QDM": {
 			ID:    "PLOOwEPgFWm_N42HlCLhqyJ0ZBWr5K1QDM",
 			Kind:  youtubeIDKindPlaylist,


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [X] I really tested my changes and there is no regression
- [X] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [X] I read this document: https://miniflux.app/faq.html#pull-request
