### PR TITLE
fix(integration): define content encoding explicitly when sending article body to Readeck

### DIFF
--- a/internal/integration/readeck/readeck.go
+++ b/internal/integration/readeck/readeck.go
@@ -91,7 +91,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string, entryContent string
 
 		contentBodyHeader, err := json.Marshal(&partContentHeader{
 			Url:           entryURL,
-			ContentHeader: contentHeader{ContentType: "text/html"},
+			ContentHeader: contentHeader{ContentType: "text/html; charset=utf-8"},
 		})
 		if err != nil {
 			return fmt.Errorf("readeck: unable to encode request body (entry content header): %v", err)


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [X] I really tested my changes and there is no regression
- [X] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [X] I read this document: https://miniflux.app/faq.html#pull-request
