### PR TITLE
Attempt publishing docker images only if `PUBLISH_DOCKER_IMAGE_ENABLED` variable is set to `true`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,14 +54,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' && vars.PUBLISH_DOCKER_IMAGE_ENABLED == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && vars.PUBLISH_DOCKER_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name != 'pull_request' && vars.PUBLISH_DOCKER_IMAGE_ENABLED == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && vars.PUBLISH_DOCKER_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -69,7 +69,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Quay Container Registry
-        if: ${{ github.event_name != 'pull_request' && vars.PUBLISH_DOCKER_IMAGE_ENABLED == 'true' }}
+        if: ${{ github.event_name != 'pull_request' && vars.PUBLISH_DOCKER_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and Push Alpine images
         uses: docker/build-push-action@v6
-        if: ${{ vars.PUBLISH_DOCKER_IMAGE_ENABLED == 'true' }}
+        if: ${{ vars.PUBLISH_DOCKER_IMAGES == 'true' }}
         with:
           context: .
           file: ./packaging/docker/alpine/Dockerfile
@@ -88,7 +88,7 @@ jobs:
 
       - name: Build and Push Distroless images
         uses: docker/build-push-action@v6
-        if: ${{ vars.PUBLISH_DOCKER_IMAGE_ENABLED == 'true' }}
+        if: ${{ vars.PUBLISH_DOCKER_IMAGES == 'true' }}
         with:
           context: .
           file: ./packaging/docker/distroless/Dockerfile


### PR DESCRIPTION
This PR tries to resolve this issue: https://github.com/miniflux/v2/issues/2714. It would build the docker images but will try pushing them only if repository action variable `PUBLISH_DOCKER_IMAGE_ENABLED` is set to `true`

Do you follow the guidelines?

- [x] I have tested my changes
- [ ] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [ ] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [ ] I read this document: https://miniflux.app/faq.html#pull-request
