### PR TITLE
fix(client): Return nil if endpoint is empty string

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -28,6 +28,10 @@ func NewClient(endpoint string, credentials ...string) *Client {
 	// Trim trailing slashes and /v1 from the endpoint.
 	endpoint = strings.TrimSuffix(endpoint, "/")
 	endpoint = strings.TrimSuffix(endpoint, "/v1")
+	// If we end up with an empty string as an endpoint, it's an user input error
+	if endpoint == "" {
+		return nil
+	}
 	switch len(credentials) {
 	case 2:
 		return &Client{request: &request{endpoint: endpoint, username: credentials[0], password: credentials[1]}}


### PR DESCRIPTION
Why:
Passing an empty string as an endpoint to Client when instantiating a new client might seem like something that should never happen but I managed to trigger it while parsing some input files to register feeds in bulk.

What:
Check if the endpoint passed to NewClient is `""` and then return immediately nil.

Arguably, the function should instead be altered to return an error, but that would change the signature of the function, introducing a backwards incompatible change and break the API

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
