### PR TITLE
feat: Add API route /v1/enclosures/{enclosureId}

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -72,6 +72,8 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	sr.HandleFunc("/entries/{entryID}/fetch-content", handler.fetchContent).Methods(http.MethodGet)
 	sr.HandleFunc("/flush-history", handler.flushHistory).Methods(http.MethodPut, http.MethodDelete)
 	sr.HandleFunc("/icons/{iconID}", handler.getIconByIconID).Methods(http.MethodGet)
+	sr.HandleFunc("/enclosures/{enclosureID}", handler.getEnclosureById).Methods(http.MethodGet)
+	sr.HandleFunc("/enclosures/{enclosureID}", handler.updateEnclosureById).Methods(http.MethodPut)
 	sr.HandleFunc("/version", handler.versionHandler).Methods(http.MethodGet)
 }
 

--- a/internal/api/enclosure.go
+++ b/internal/api/enclosure.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package api // import "miniflux.app/v2/internal/api"
+
+import (
+	json_parser "encoding/json"
+	"net/http"
+
+	"miniflux.app/v2/internal/http/request"
+	"miniflux.app/v2/internal/http/response/json"
+	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/validator"
+)
+
+func (h *handler) getEnclosureById(w http.ResponseWriter, r *http.Request) {
+	enclosureID := request.RouteInt64Param(r, "enclosureID")
+
+	enclosure, err := h.store.GetEnclosure(enclosureID)
+
+	if err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	if enclosure == nil {
+		json.NotFound(w, r)
+		return
+	}
+
+	userID := request.UserID(r)
+
+	if enclosure.UserID != userID {
+		json.NotFound(w, r)
+		return
+	}
+
+	enclosure.ProxifyEnclosureURL(h.router)
+
+	json.OK(w, r, enclosure)
+}
+
+func (h *handler) updateEnclosureById(w http.ResponseWriter, r *http.Request) {
+	enclosureID := request.RouteInt64Param(r, "enclosureID")
+
+	var enclosureUpdateRequest model.EnclosureUpdateRequest
+
+	if err := json_parser.NewDecoder(r.Body).Decode(&enclosureUpdateRequest); err != nil {
+		json.BadRequest(w, r, err)
+		return
+	}
+
+	if err := validator.ValidateEnclosureUpdateRequest(&enclosureUpdateRequest); err != nil {
+		json.BadRequest(w, r, err)
+		return
+	}
+
+	enclosure, err := h.store.GetEnclosure(enclosureID)
+
+	if err != nil {
+		json.BadRequest(w, r, err)
+		return
+	}
+
+	if enclosure == nil {
+		json.NotFound(w, r)
+		return
+	}
+
+	userID := request.UserID(r)
+
+	if enclosure.UserID != userID {
+		json.NotFound(w, r)
+		return
+	}
+
+	enclosure.MediaProgression = enclosureUpdateRequest.MediaProgression
+
+	if err := h.store.UpdateEnclosure(enclosure); err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	json.NoContent(w, r)
+}

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -24,7 +24,6 @@ import (
 	mff "miniflux.app/v2/internal/reader/handler"
 	mfs "miniflux.app/v2/internal/reader/subscription"
 	"miniflux.app/v2/internal/storage"
-	"miniflux.app/v2/internal/urllib"
 	"miniflux.app/v2/internal/validator"
 
 	"github.com/gorilla/mux"
@@ -1004,18 +1003,8 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 		}
 
 		entry.Content = mediaproxy.RewriteDocumentWithAbsoluteProxyURL(h.router, entry.Content)
-		proxyOption := config.Opts.MediaProxyMode()
 
-		for i := range entry.Enclosures {
-			if proxyOption == "all" || proxyOption != "none" && !urllib.IsHTTPS(entry.Enclosures[i].URL) {
-				for _, mediaType := range config.Opts.MediaProxyResourceTypes() {
-					if strings.HasPrefix(entry.Enclosures[i].MimeType, mediaType+"/") {
-						entry.Enclosures[i].URL = mediaproxy.ProxifyAbsoluteURL(h.router, entry.Enclosures[i].URL)
-						break
-					}
-				}
-			}
-		}
+		entry.Enclosures.ProxifyEnclosureURL(h.router)
 
 		contentItems[i] = contentItem{
 			ID:            fmt.Sprintf(EntryIDLong, entry.ID),

--- a/internal/validator/enclosure.go
+++ b/internal/validator/enclosure.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"fmt"
+
+	"miniflux.app/v2/internal/model"
+)
+
+func ValidateEnclosureUpdateRequest(request *model.EnclosureUpdateRequest) error {
+	if request.MediaProgression < 0 {
+		return fmt.Errorf(`media progression must an positive integer`)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The GET method exposes individual enclosures by their ID. The PUT method allows external clients to update media_progression, similar to the internal API used by the UI.

The media proxy code was refactored to a method on the Enclosure and EnclosureList structures to avoid duplicate code and risking diverging behavior between googlereader and the API.


Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
