### PR TITLE
feat(api): Allow filtering globally hidden entries

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -685,6 +685,10 @@ func buildFilterQueryString(path string, filter *Filter) string {
 			values.Set("feed_id", strconv.FormatInt(filter.FeedID, 10))
 		}
 
+		if filter.GloballyVisible {
+			values.Set("globally_visible", "true")
+		}
+
 		for _, status := range filter.Statuses {
 			values.Add("status", status)
 		}

--- a/client/model.go
+++ b/client/model.go
@@ -278,6 +278,7 @@ type Filter struct {
 	CategoryID      int64
 	FeedID          int64
 	Statuses        []string
+	GloballyVisible bool
 }
 
 // EntryResultSet represents the response when fetching entries.

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -2011,6 +2011,16 @@ func TestGetGlobalEntriesEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	feedIDEntry, err := regularUserClient.Feed(feedID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feedIDEntry.HideGlobally != true {
+		t.Fatalf(`Expected feed to have globally_hidden set to true, was false.`)
+	}
+
 	/* Not filtering on GloballyVisible should return all entries */
 	feedEntries, err := regularUserClient.Entries(&miniflux.Filter{FeedID: feedID})
 

--- a/internal/api/entry.go
+++ b/internal/api/entry.go
@@ -149,6 +149,15 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 	builder.WithLimit(limit)
 	builder.WithTags(tags)
 	builder.WithEnclosures()
+
+	if request.HasQueryParam(r, "globally_visible") {
+		globallyVisible := request.QueryBoolParam(r, "globally_visible", true)
+
+		if globallyVisible {
+			builder.WithGloballyVisible()
+		}
+	}
+
 	configureFilters(builder, r)
 
 	entries, err := builder.GetEntries()

--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -169,6 +169,7 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 	subscription.BlocklistRules = feedCreationRequest.BlocklistRules
 	subscription.KeeplistRules = feedCreationRequest.KeeplistRules
 	subscription.UrlRewriteRules = feedCreationRequest.UrlRewriteRules
+	subscription.HideGlobally = feedCreationRequest.HideGlobally
 	subscription.EtagHeader = responseHandler.ETag()
 	subscription.LastModifiedHeader = responseHandler.LastModified()
 	subscription.FeedURL = responseHandler.EffectiveURL()


### PR DESCRIPTION
The API doesn't provide the methods to simulate the Unread page, i.e. unread entries from globally visible feeds.
This can now be done through `/v1/entries?status=unread&globally_visible=true`.

Extended the filtering structure for the client library to support this as well. While writing integration tests I noticed that the CreateFeed handler doesn't update `subscription.HideGlobally` from the CreateFeedRequest, fixed that as well.

----

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
