### PR TITLE
feat: add license info to js, for LibreJS compatibility

### DIFF
--- a/internal/ui/static_javascript.go
+++ b/internal/ui/static_javascript.go
@@ -6,6 +6,7 @@ package ui // import "miniflux.app/v2/internal/ui"
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"miniflux.app/v2/internal/http/request"
@@ -14,6 +15,9 @@ import (
 	"miniflux.app/v2/internal/http/route"
 	"miniflux.app/v2/internal/ui/static"
 )
+
+const licensePrefix = "//@license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0\n"
+const licenseSuffix = "\n//@license-end"
 
 func (h *handler) showJavascript(w http.ResponseWriter, r *http.Request) {
 	filename := request.RouteStringParam(r, "name")
@@ -30,6 +34,10 @@ func (h *handler) showJavascript(w http.ResponseWriter, r *http.Request) {
 			variables := fmt.Sprintf(`const OFFLINE_URL=%q;`, route.Path(h.router, "offline"))
 			contents = append([]byte(variables), contents...)
 		}
+
+		// cloning the prefix since `append` mutates its first argument
+		contents = append([]byte(strings.Clone(licensePrefix)), contents...)
+		contents = append(contents, []byte(licenseSuffix)...)
 
 		b.WithHeader("Content-Type", "text/javascript; charset=utf-8")
 		b.WithBody(contents)


### PR DESCRIPTION
[LibreJS][0] is a browser extension developed by GNU which ensures only Free (libre) JavaScript is run. To determine whether given JavaScript is Free, LibreJS consults metadata included in the JavaScript file. Since Miniflux is Free Software, getting its JavaScript to work when LibreJS is installed is just a matter of adding license metadata to the returned JavaScript source.

[0]: https://www.gnu.org/software/librejs/index.html

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
