### PR TITLE
Provide output when running migrations

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -32,7 +32,7 @@ func Migrate(db *sql.DB) error {
 	var currentVersion int
 	db.QueryRow(`SELECT version FROM schema_version`).Scan(&currentVersion)
 
-	slog.Debug("Running database migrations",
+	slog.Info("Running database migrations",
 		slog.Int("current_version", currentVersion),
 		slog.Int("latest_version", schemaVersion),
 	)


### PR DESCRIPTION
When upgrading my installation, I noticed that `miniflux -migrate` does not provide any output by default. This can be a bit confusing since one cannot be sure whether anything has happened. Use `Info` instead of `Debug` to provide some basic output by default.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [ ] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
