### PR TITLE
fix: use root URL to generate absolute proxy URL

### DIFF
--- a/internal/mediaproxy/url.go
+++ b/internal/mediaproxy/url.go
@@ -40,9 +40,9 @@ func ProxifyAbsoluteURL(router *mux.Router, mediaURL string) string {
 		return proxifyURLWithCustomProxy(mediaURL, customProxyURL)
 	}
 
+	// Note that the proxyified URL is relative to the root URL.
 	proxifiedUrl := ProxifyRelativeURL(router, mediaURL)
-
-	absoluteURL, err := url.JoinPath(config.Opts.BaseURL(), proxifiedUrl)
+	absoluteURL, err := url.JoinPath(config.Opts.RootURL(), proxifiedUrl)
 	if err != nil {
 		return mediaURL
 	}


### PR DESCRIPTION
When using `BASE_URL` with a subfolder, the root URL must be used to avoid the base folder appearing twice in the generated URL.

Do you follow the guidelines?

- [X] I have tested my changes
- [X] There is no breaking changes
- [X] I really tested my changes and there is no regression
- [X] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [X] I read this document: https://miniflux.app/faq.html#pull-request
