### PR TITLE
fix: remove enclosure progression save data on shared entry

### DIFF
--- a/internal/template/templates/views/entry.html
+++ b/internal/template/templates/views/entry.html
@@ -171,12 +171,12 @@
     {{ if hasPrefix .MimeType "audio/" }}
     <div class="enclosure-audio" >
         <audio controls preload="metadata"
-            data-last-position="{{ .MediaProgression }}"
+            {{ if $.user }}data-last-position="{{ .MediaProgression }}"{{ end }}
             {{ if $.user.MediaPlaybackRate }}data-playback-rate="{{ $.user.MediaPlaybackRate }}"{{ end }}
             {{ if $.user.MarkReadOnMediaPlayerCompletion }}
                data-mark-read-on-completion="0.9"
             {{ end }}
-            data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"
+            {{ if $.user }}data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"{{ end }}
             data-enclosure-id="{{.ID}}"
             >
             {{ if (and $.user (mustBeProxyfied "audio")) }}
@@ -190,12 +190,12 @@
         {{ else if hasPrefix .MimeType "video/" }}
         <div class="enclosure-video">
             <video controls preload="metadata"
-                data-last-position="{{ .MediaProgression }}"
+                {{ if $.user }}data-last-position="{{ .MediaProgression }}"{{ end }}
                 {{ if $.user.MediaPlaybackRate }}data-playback-rate="{{ $.user.MediaPlaybackRate }}"{{ end }}
                 {{ if $.user.MarkReadOnMediaPlayerCompletion }}
                     data-mark-read-on-completion="0.9"
                 {{ end }}
-                data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"
+                {{ if $.user }}data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"{{ end }}
                 data-enclosure-id="{{.ID}}"
                 >
                 {{ if (and $.user (mustBeProxyfied "video")) }}
@@ -225,12 +225,12 @@
         {{ if hasPrefix .MimeType "audio/" }}
         <div class="enclosure-audio">
             <audio controls preload="metadata"
-                data-last-position="{{ .MediaProgression }}"
+                {{ if $.user }}data-last-position="{{ .MediaProgression }}"{{ end }}
                 {{ if $.user.MediaPlaybackRate }}data-playback-rate="{{ $.user.MediaPlaybackRate }}"{{ end }}
                 {{ if $.user.MarkReadOnMediaPlayerCompletion }}
                     data-mark-read-on-completion="0.9"
                 {{ end }}
-                data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"
+                {{ if $.user }}data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"{{ end }}
                 data-enclosure-id="{{.ID}}"
                 >
                 {{ if (and $.user (mustBeProxyfied "audio")) }}
@@ -244,12 +244,12 @@
         {{ else if hasPrefix .MimeType "video/" }}
         <div class="enclosure-video">
             <video controls preload="metadata"
-                data-last-position="{{ .MediaProgression }}"
+                {{ if $.user }}data-last-position="{{ .MediaProgression }}"{{ end }}
                 {{ if $.user.MediaPlaybackRate }}data-playback-rate="{{ $.user.MediaPlaybackRate }}"{{ end }}
                 {{ if $.user.MarkReadOnMediaPlayerCompletion }}
                     data-mark-read-on-completion="0.9"
                 {{ end }}
-                data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"
+                {{ if $.user }}data-save-url="{{ route "saveEnclosureProgression" "enclosureID" .ID }}"{{ end }}
                 data-enclosure-id="{{.ID}}"
                 >
                 {{ if (and $.user (mustBeProxyfied "video")) }}


### PR DESCRIPTION
Shared entry does not link to any user and therefore should not display any saved progression. Curiously, the progression of a user (the one that shared ?) was still integrated in the page. This does not make sens regarding the sharing feature itself. It is also a leak of user personal information onto a public page.

I simply removed the data from the template when the user object is not present. I tested the change on "regular" entry page, ensuring the save progression feature still works, and on shared page checking if any error happened in the JavaScript console. Everything seems in order.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
