### PR TITLE
Bump devcontainer version to go 1.23

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   app:
-    image: mcr.microsoft.com/devcontainers/go:1.22
+    image: mcr.microsoft.com/devcontainers/go:1.23
     volumes:
       - ..:/workspace:cached
     command: sleep infinity


### PR DESCRIPTION
This has been bumped in `go.mod` in 70f126fc5a8c93109ff1ddd8f7e0782d3457360d and is now required to build the software.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
