### PR TITLE
Allow multiple categories per feed

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -121,53 +121,53 @@ type Subscriptions []*Subscription
 
 // Feed represents a Miniflux feed.
 type Feed struct {
-	ID                          int64     `json:"id"`
-	UserID                      int64     `json:"user_id"`
-	FeedURL                     string    `json:"feed_url"`
-	SiteURL                     string    `json:"site_url"`
-	Title                       string    `json:"title"`
-	CheckedAt                   time.Time `json:"checked_at,omitempty"`
-	EtagHeader                  string    `json:"etag_header,omitempty"`
-	LastModifiedHeader          string    `json:"last_modified_header,omitempty"`
-	ParsingErrorMsg             string    `json:"parsing_error_message,omitempty"`
-	ParsingErrorCount           int       `json:"parsing_error_count,omitempty"`
-	Disabled                    bool      `json:"disabled"`
-	IgnoreHTTPCache             bool      `json:"ignore_http_cache"`
-	AllowSelfSignedCertificates bool      `json:"allow_self_signed_certificates"`
-	FetchViaProxy               bool      `json:"fetch_via_proxy"`
-	ScraperRules                string    `json:"scraper_rules"`
-	RewriteRules                string    `json:"rewrite_rules"`
-	BlocklistRules              string    `json:"blocklist_rules"`
-	KeeplistRules               string    `json:"keeplist_rules"`
-	Crawler                     bool      `json:"crawler"`
-	UserAgent                   string    `json:"user_agent"`
-	Cookie                      string    `json:"cookie"`
-	Username                    string    `json:"username"`
-	Password                    string    `json:"password"`
-	Category                    *Category `json:"category,omitempty"`
-	HideGlobally                bool      `json:"hide_globally"`
-	DisableHTTP2                bool      `json:"disable_http2"`
+	ID                          int64       `json:"id"`
+	UserID                      int64       `json:"user_id"`
+	FeedURL                     string      `json:"feed_url"`
+	SiteURL                     string      `json:"site_url"`
+	Title                       string      `json:"title"`
+	CheckedAt                   time.Time   `json:"checked_at,omitempty"`
+	EtagHeader                  string      `json:"etag_header,omitempty"`
+	LastModifiedHeader          string      `json:"last_modified_header,omitempty"`
+	ParsingErrorMsg             string      `json:"parsing_error_message,omitempty"`
+	ParsingErrorCount           int         `json:"parsing_error_count,omitempty"`
+	Disabled                    bool        `json:"disabled"`
+	IgnoreHTTPCache             bool        `json:"ignore_http_cache"`
+	AllowSelfSignedCertificates bool        `json:"allow_self_signed_certificates"`
+	FetchViaProxy               bool        `json:"fetch_via_proxy"`
+	ScraperRules                string      `json:"scraper_rules"`
+	RewriteRules                string      `json:"rewrite_rules"`
+	BlocklistRules              string      `json:"blocklist_rules"`
+	KeeplistRules               string      `json:"keeplist_rules"`
+	Crawler                     bool        `json:"crawler"`
+	UserAgent                   string      `json:"user_agent"`
+	Cookie                      string      `json:"cookie"`
+	Username                    string      `json:"username"`
+	Password                    string      `json:"password"`
+	Categories                  []*Category `json:"categories,omitempty"`
+	HideGlobally                bool        `json:"hide_globally"`
+	DisableHTTP2                bool        `json:"disable_http2"`
 }
 
 // FeedCreationRequest represents the request to create a feed.
 type FeedCreationRequest struct {
-	FeedURL                     string `json:"feed_url"`
-	CategoryID                  int64  `json:"category_id"`
-	UserAgent                   string `json:"user_agent"`
-	Cookie                      string `json:"cookie"`
-	Username                    string `json:"username"`
-	Password                    string `json:"password"`
-	Crawler                     bool   `json:"crawler"`
-	Disabled                    bool   `json:"disabled"`
-	IgnoreHTTPCache             bool   `json:"ignore_http_cache"`
-	AllowSelfSignedCertificates bool   `json:"allow_self_signed_certificates"`
-	FetchViaProxy               bool   `json:"fetch_via_proxy"`
-	ScraperRules                string `json:"scraper_rules"`
-	RewriteRules                string `json:"rewrite_rules"`
-	BlocklistRules              string `json:"blocklist_rules"`
-	KeeplistRules               string `json:"keeplist_rules"`
-	HideGlobally                bool   `json:"hide_globally"`
-	DisableHTTP2                bool   `json:"disable_http2"`
+	FeedURL                     string  `json:"feed_url"`
+	CategoryIDs                 []int64 `json:"category_ids"`
+	UserAgent                   string  `json:"user_agent"`
+	Cookie                      string  `json:"cookie"`
+	Username                    string  `json:"username"`
+	Password                    string  `json:"password"`
+	Crawler                     bool    `json:"crawler"`
+	Disabled                    bool    `json:"disabled"`
+	IgnoreHTTPCache             bool    `json:"ignore_http_cache"`
+	AllowSelfSignedCertificates bool    `json:"allow_self_signed_certificates"`
+	FetchViaProxy               bool    `json:"fetch_via_proxy"`
+	ScraperRules                string  `json:"scraper_rules"`
+	RewriteRules                string  `json:"rewrite_rules"`
+	BlocklistRules              string  `json:"blocklist_rules"`
+	KeeplistRules               string  `json:"keeplist_rules"`
+	HideGlobally                bool    `json:"hide_globally"`
+	DisableHTTP2                bool    `json:"disable_http2"`
 }
 
 // FeedModificationRequest represents the request to update a feed.
@@ -184,7 +184,7 @@ type FeedModificationRequest struct {
 	Cookie                      *string `json:"cookie"`
 	Username                    *string `json:"username"`
 	Password                    *string `json:"password"`
-	CategoryID                  *int64  `json:"category_id"`
+	CategoryIDs                 []int64 `json:"category_ids"`
 	Disabled                    *bool   `json:"disabled"`
 	IgnoreHTTPCache             *bool   `json:"ignore_http_cache"`
 	AllowSelfSignedCertificates *bool   `json:"allow_self_signed_certificates"`

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -973,8 +973,8 @@ func TestMarkCategoryAsReadEndpoint(t *testing.T) {
 	}
 
 	feedID, err := regularUserClient.CreateFeed(&miniflux.FeedCreationRequest{
-		FeedURL:    testConfig.testFeedURL,
-		CategoryID: category.ID,
+		FeedURL:     testConfig.testFeedURL,
+		CategoryIDs: []int64{category.ID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1017,8 +1017,8 @@ func TestCreateFeedEndpoint(t *testing.T) {
 	}
 
 	feedID, err := regularUserClient.CreateFeed(&miniflux.FeedCreationRequest{
-		FeedURL:    testConfig.testFeedURL,
-		CategoryID: category.ID,
+		FeedURL:     testConfig.testFeedURL,
+		CategoryIDs: []int64{category.ID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1081,8 +1081,8 @@ func TestCreateFeedWithInexistingCategory(t *testing.T) {
 	regularUserClient := miniflux.NewClient(testConfig.testBaseURL, regularTestUser.Username, testConfig.testRegularPassword)
 
 	_, err = regularUserClient.CreateFeed(&miniflux.FeedCreationRequest{
-		FeedURL:    testConfig.testFeedURL,
-		CategoryID: 123456789,
+		FeedURL:     testConfig.testFeedURL,
+		CategoryIDs: []int64{123456789},
 	})
 
 	if err == nil {
@@ -1319,7 +1319,7 @@ func TestUpdateFeedWithInvalidCategory(t *testing.T) {
 	}
 
 	feedUpdateRequest := &miniflux.FeedModificationRequest{
-		CategoryID: miniflux.SetOptionalField(int64(123456789)),
+		CategoryIDs: []int64{int64(123456789)},
 	}
 
 	if _, err := regularUserClient.UpdateFeed(feedID, feedUpdateRequest); err == nil {
@@ -1659,8 +1659,8 @@ func TestGetCategoryFeedsEndpoint(t *testing.T) {
 	}
 
 	feedID, err := regularUserClient.CreateFeed(&miniflux.FeedCreationRequest{
-		FeedURL:    testConfig.testFeedURL,
-		CategoryID: category.ID,
+		FeedURL:     testConfig.testFeedURL,
+		CategoryIDs: []int64{category.ID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1870,8 +1870,8 @@ func TestGetAllCategoryEntriesEndpoint(t *testing.T) {
 	}
 
 	feedID, err := regularUserClient.CreateFeed(&miniflux.FeedCreationRequest{
-		FeedURL:    testConfig.testFeedURL,
-		CategoryID: category.ID,
+		FeedURL:     testConfig.testFeedURL,
+		CategoryIDs: []int64{category.ID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -2214,7 +2214,7 @@ func TestGetEntryEndpoints(t *testing.T) {
 		t.Fatalf(`Invalid entryID, got %d`, entry.ID)
 	}
 
-	entry, err = regularUserClient.CategoryEntry(result.Entries[0].Feed.Category.ID, result.Entries[0].ID)
+	entry, err = regularUserClient.CategoryEntry(result.Entries[0].Feed.Categories[0].ID, result.Entries[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/category.go
+++ b/internal/api/category.go
@@ -120,7 +120,7 @@ func (h *handler) removeCategory(w http.ResponseWriter, r *http.Request) {
 	userID := request.UserID(r)
 	categoryID := request.RouteInt64Param(r, "categoryID")
 
-	if !h.store.CategoryIDExists(userID, categoryID) {
+	if !h.store.CategoryIDsExists(userID, []int64{categoryID}) {
 		json.NotFound(w, r)
 		return
 	}

--- a/internal/api/entry.go
+++ b/internal/api/entry.go
@@ -114,7 +114,7 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 
 	userID := request.UserID(r)
 	categoryID = request.QueryInt64Param(r, "category_id", categoryID)
-	if categoryID > 0 && !h.store.CategoryIDExists(userID, categoryID) {
+	if categoryID > 0 && !h.store.CategoryIDsExists(userID, []int64{categoryID}) {
 		json.BadRequest(w, r, errors.New("invalid category ID"))
 		return
 	}

--- a/internal/api/feed.go
+++ b/internal/api/feed.go
@@ -26,16 +26,6 @@ func (h *handler) createFeed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Make the feed category optional for clients who don't support categories.
-	if feedCreationRequest.CategoryID == 0 {
-		category, err := h.store.FirstCategory(userID)
-		if err != nil {
-			json.ServerError(w, r, err)
-			return
-		}
-		feedCreationRequest.CategoryID = category.ID
-	}
-
 	if validationErr := validator.ValidateFeedCreation(h.store, userID, &feedCreationRequest); validationErr != nil {
 		json.BadRequest(w, r, validationErr.Error())
 		return

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -942,4 +942,21 @@ var migrations = []func(tx *sql.Tx) error{
 		_, err = tx.Exec(sql)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		sql := `
+			CREATE TABLE feed_categories (
+				feed_id bigint not null,
+				category_id bigint not null,
+				primary key(feed_id, category_id),
+				foreign key (feed_id) references feeds(id) on delete cascade,
+				foreign key (category_id) references categories(id) on delete cascade
+			);
+
+			INSERT INTO feed_categories (feed_id, category_id) SELECT id AS feed_id, category_id FROM feeds;
+
+			ALTER TABLE feeds DROP COLUMN category_id;
+		`
+		_, err = tx.Exec(sql)
+		return err
+	},
 }

--- a/internal/fever/handler.go
+++ b/internal/fever/handler.go
@@ -570,7 +570,9 @@ A feeds_group object has the following members:
 func (h *handler) buildFeedGroups(feeds model.Feeds) []feedsGroups {
 	feedsGroupedByCategory := make(map[int64][]string)
 	for _, feed := range feeds {
-		feedsGroupedByCategory[feed.Category.ID] = append(feedsGroupedByCategory[feed.Category.ID], strconv.FormatInt(feed.ID, 10))
+		for _, category := range feed.Categories {
+			feedsGroupedByCategory[category.ID] = append(feedsGroupedByCategory[category.ID], strconv.FormatInt(feed.ID, 10))
+		}
 	}
 
 	result := make([]feedsGroups, 0)

--- a/internal/integration/webhook/webhook.go
+++ b/internal/integration/webhook/webhook.go
@@ -32,6 +32,12 @@ func NewClient(webhookURL, webhookSecret string) *Client {
 }
 
 func (c *Client) SendSaveEntryWebhookEvent(entry *model.Entry) error {
+	var categoryIDs []int64
+	var categories []*WebhookCategory
+	for _, category := range entry.Feed.Categories {
+		categoryIDs = append(categoryIDs, category.ID)
+		categories = append(categories, &WebhookCategory{ID: category.ID, Title: category.Title})
+	}
 	return c.makeRequest(SaveEntryEventType, &WebhookSaveEntryEvent{
 		EventType: SaveEntryEventType,
 		Entry: &WebhookEntry{
@@ -54,14 +60,14 @@ func (c *Client) SendSaveEntryWebhookEvent(entry *model.Entry) error {
 			Enclosures:  entry.Enclosures,
 			Tags:        entry.Tags,
 			Feed: &WebhookFeed{
-				ID:         entry.Feed.ID,
-				UserID:     entry.Feed.UserID,
-				CategoryID: entry.Feed.Category.ID,
-				Category:   &WebhookCategory{ID: entry.Feed.Category.ID, Title: entry.Feed.Category.Title},
-				FeedURL:    entry.Feed.FeedURL,
-				SiteURL:    entry.Feed.SiteURL,
-				Title:      entry.Feed.Title,
-				CheckedAt:  entry.Feed.CheckedAt,
+				ID:          entry.Feed.ID,
+				UserID:      entry.Feed.UserID,
+				CategoryIDs: categoryIDs,
+				Categories:  categories,
+				FeedURL:     entry.Feed.FeedURL,
+				SiteURL:     entry.Feed.SiteURL,
+				Title:       entry.Feed.Title,
+				CheckedAt:   entry.Feed.CheckedAt,
 			},
 		},
 	})
@@ -95,17 +101,23 @@ func (c *Client) SendNewEntriesWebhookEvent(feed *model.Feed, entries model.Entr
 			Tags:        entry.Tags,
 		})
 	}
+	var categoryIDs []int64
+	var categories []*WebhookCategory
+	for _, category := range feed.Categories {
+		categoryIDs = append(categoryIDs, category.ID)
+		categories = append(categories, &WebhookCategory{ID: category.ID, Title: category.Title})
+	}
 	return c.makeRequest(NewEntriesEventType, &WebhookNewEntriesEvent{
 		EventType: NewEntriesEventType,
 		Feed: &WebhookFeed{
-			ID:         feed.ID,
-			UserID:     feed.UserID,
-			CategoryID: feed.Category.ID,
-			Category:   &WebhookCategory{ID: feed.Category.ID, Title: feed.Category.Title},
-			FeedURL:    feed.FeedURL,
-			SiteURL:    feed.SiteURL,
-			Title:      feed.Title,
-			CheckedAt:  feed.CheckedAt,
+			ID:          feed.ID,
+			UserID:      feed.UserID,
+			CategoryIDs: categoryIDs,
+			Categories:  categories,
+			FeedURL:     feed.FeedURL,
+			SiteURL:     feed.SiteURL,
+			Title:       feed.Title,
+			CheckedAt:   feed.CheckedAt,
 		},
 		Entries: webhookEntries,
 	})
@@ -146,14 +158,14 @@ func (c *Client) makeRequest(eventType string, payload any) error {
 }
 
 type WebhookFeed struct {
-	ID         int64            `json:"id"`
-	UserID     int64            `json:"user_id"`
-	CategoryID int64            `json:"category_id"`
-	Category   *WebhookCategory `json:"category,omitempty"`
-	FeedURL    string           `json:"feed_url"`
-	SiteURL    string           `json:"site_url"`
-	Title      string           `json:"title"`
-	CheckedAt  time.Time        `json:"checked_at"`
+	ID          int64              `json:"id"`
+	UserID      int64              `json:"user_id"`
+	CategoryIDs []int64            `json:"category_ids"`
+	Categories  []*WebhookCategory `json:"categories,omitempty"`
+	FeedURL     string             `json:"feed_url"`
+	SiteURL     string             `json:"site_url"`
+	Title       string             `json:"title"`
+	CheckedAt   time.Time          `json:"checked_at"`
 }
 
 type WebhookCategory struct {

--- a/internal/model/entry.go
+++ b/internal/model/entry.go
@@ -44,8 +44,8 @@ func NewEntry() *Entry {
 		Enclosures: make(EnclosureList, 0),
 		Tags:       make([]string, 0),
 		Feed: &Feed{
-			Category: &Category{},
-			Icon:     &FeedIcon{},
+			Categories: nil,
+			Icon:       &FeedIcon{},
 		},
 	}
 }

--- a/internal/model/feed_test.go
+++ b/internal/model/feed_test.go
@@ -19,14 +19,18 @@ const (
 
 func TestFeedCategorySetter(t *testing.T) {
 	feed := &Feed{}
-	feed.WithCategoryID(int64(123))
+	feed.WithCategoryIDs([]int64{int64(123)})
 
-	if feed.Category == nil {
-		t.Fatal(`The category field should not be null`)
+	if feed.Categories == nil {
+		t.Fatal(`The categories field should not be null`)
 	}
 
-	if feed.Category.ID != int64(123) {
-		t.Error(`The category ID must be set`)
+	if len(feed.Categories) != 1 {
+		t.Error(`The categories field must have exactly one entry`)
+	}
+
+	if feed.Categories[0].ID != int64(123) {
+		t.Error(`The categories ID must be set`)
 	}
 }
 

--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -36,7 +36,7 @@ func CreateFeedFromSubscriptionDiscovery(store *storage.Storage, userID int64, f
 		return nil, locale.NewLocalizedErrorWrapper(storeErr, "error.database_error", storeErr)
 	}
 
-	if !store.CategoryIDExists(userID, feedCreationRequest.CategoryID) {
+	if !store.CategoryIDsExists(userID, feedCreationRequest.CategoryIDs) {
 		return nil, locale.NewLocalizedErrorWrapper(ErrCategoryNotFound, "error.category_not_found")
 	}
 
@@ -68,7 +68,7 @@ func CreateFeedFromSubscriptionDiscovery(store *storage.Storage, userID int64, f
 	subscription.LastModifiedHeader = feedCreationRequest.LastModified
 	subscription.FeedURL = feedCreationRequest.FeedURL
 	subscription.DisableHTTP2 = feedCreationRequest.DisableHTTP2
-	subscription.WithCategoryID(feedCreationRequest.CategoryID)
+	subscription.WithCategoryIDs(feedCreationRequest.CategoryIDs)
 	subscription.CheckedNow()
 
 	processor.ProcessFeedEntries(store, subscription, user, true)
@@ -116,7 +116,7 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 		return nil, locale.NewLocalizedErrorWrapper(storeErr, "error.database_error", storeErr)
 	}
 
-	if !store.CategoryIDExists(userID, feedCreationRequest.CategoryID) {
+	if !store.CategoryIDsExists(userID, feedCreationRequest.CategoryIDs) {
 		return nil, locale.NewLocalizedErrorWrapper(ErrCategoryNotFound, "error.category_not_found")
 	}
 
@@ -173,7 +173,7 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 	subscription.EtagHeader = responseHandler.ETag()
 	subscription.LastModifiedHeader = responseHandler.LastModified()
 	subscription.FeedURL = responseHandler.EffectiveURL()
-	subscription.WithCategoryID(feedCreationRequest.CategoryID)
+	subscription.WithCategoryIDs(feedCreationRequest.CategoryIDs)
 	subscription.CheckedNow()
 
 	processor.ProcessFeedEntries(store, subscription, user, true)

--- a/internal/reader/opml/handler.go
+++ b/internal/reader/opml/handler.go
@@ -25,12 +25,16 @@ func (h *Handler) Export(userID int64) (string, error) {
 
 	subscriptions := make(SubcriptionList, 0, len(feeds))
 	for _, feed := range feeds {
+		var categoryNames CategoryNameList
+		for _, category := range feed.Categories {
+			categoryNames = append(categoryNames, category.Title)
+		}
 		subscriptions = append(subscriptions, &Subcription{
-			Title:        feed.Title,
-			FeedURL:      feed.FeedURL,
-			SiteURL:      feed.SiteURL,
-			Description:  feed.Description,
-			CategoryName: feed.Category.Title,
+			Title:         feed.Title,
+			FeedURL:       feed.FeedURL,
+			SiteURL:       feed.SiteURL,
+			Description:   feed.Description,
+			CategoryNames: categoryNames,
 		})
 	}
 
@@ -45,39 +49,36 @@ func (h *Handler) Import(userID int64, data io.Reader) error {
 	}
 
 	for _, subscription := range subscriptions {
-		if !h.store.FeedURLExists(userID, subscription.FeedURL) {
+		var categories []*model.Category
+		for _, categoryName := range subscription.CategoryNames {
 			var category *model.Category
 			var err error
-
-			if subscription.CategoryName == "" {
-				category, err = h.store.FirstCategory(userID)
-				if err != nil {
-					return fmt.Errorf("opml: unable to find first category: %w", err)
-				}
-			} else {
-				category, err = h.store.CategoryByTitle(userID, subscription.CategoryName)
-				if err != nil {
-					return fmt.Errorf("opml: unable to search category by title: %w", err)
-				}
-
-				if category == nil {
-					category, err = h.store.CreateCategory(userID, &model.CategoryRequest{Title: subscription.CategoryName})
-					if err != nil {
-						return fmt.Errorf(`opml: unable to create this category: %q`, subscription.CategoryName)
-					}
-				}
+			category, err = h.store.CategoryByTitle(userID, categoryName)
+			if err != nil {
+				return fmt.Errorf("opml: unable to search category by title: %w", err)
 			}
 
-			feed := &model.Feed{
-				UserID:      userID,
-				Title:       subscription.Title,
-				FeedURL:     subscription.FeedURL,
-				SiteURL:     subscription.SiteURL,
-				Description: subscription.Description,
-				Category:    category,
+			if category == nil {
+				category, err = h.store.CreateCategory(userID, &model.CategoryRequest{Title: categoryName})
+				if err != nil {
+					return fmt.Errorf(`opml: unable to create this category: %q`, categoryName)
+				}
 			}
+			categories = append(categories, category)
+		}
 
+		feed := &model.Feed{
+			UserID:      userID,
+			Title:       subscription.Title,
+			FeedURL:     subscription.FeedURL,
+			SiteURL:     subscription.SiteURL,
+			Description: subscription.Description,
+			Categories:  categories,
+		}
+		if !h.store.FeedURLExists(userID, subscription.FeedURL) {
 			h.store.CreateFeed(feed)
+		} else {
+			h.store.UpdateFeed(feed) // TODO maybe only update categories?
 		}
 	}
 

--- a/internal/reader/opml/opml.go
+++ b/internal/reader/opml/opml.go
@@ -29,6 +29,7 @@ type opmlHeader struct {
 type opmlOutline struct {
 	Title       string                `xml:"title,attr,omitempty"`
 	Text        string                `xml:"text,attr"`
+	Type        string                `xml:"type,attr,omitempty"`
 	FeedURL     string                `xml:"xmlUrl,attr,omitempty"`
 	SiteURL     string                `xml:"htmlUrl,attr,omitempty"`
 	Description string                `xml:"description,attr,omitempty"`

--- a/internal/reader/opml/parser_test.go
+++ b/internal/reader/opml/parser_test.go
@@ -68,9 +68,9 @@ func TestParseOpmlWithCategories(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: "My Category 1"})
-	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryName: "My Category 1"})
-	expected = append(expected, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed3/", SiteURL: "http://example.org/3", CategoryName: "My Category 2"})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{"My Category 1"}})
+	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryNames: CategoryNameList{"My Category 1"}})
+	expected = append(expected, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed3/", SiteURL: "http://example.org/3", CategoryNames: CategoryNameList{"My Category 2"}})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {
@@ -102,8 +102,8 @@ func TestParseOpmlWithEmptyTitleAndEmptySiteURL(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "http://example.org/1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: ""})
-	expected = append(expected, &Subcription{Title: "http://example.org/feed2/", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/feed2/", CategoryName: ""})
+	expected = append(expected, &Subcription{Title: "http://example.org/1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{}})
+	expected = append(expected, &Subcription{Title: "http://example.org/feed2/", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/feed2/", CategoryNames: CategoryNameList{}})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {
@@ -140,8 +140,8 @@ func TestParseOpmlVersion1(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: "Category 1"})
-	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryName: "Category 2"})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{"Category 1"}})
+	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryNames: CategoryNameList{"Category 2"}})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {
@@ -174,8 +174,8 @@ func TestParseOpmlVersion1WithoutOuterOutline(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: ""})
-	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryName: ""})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{}})
+	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryNames: CategoryNameList{}})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {
@@ -215,9 +215,9 @@ func TestParseOpmlVersion1WithSeveralNestedOutlines(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryName: "Some Category"})
-	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryName: "Some Category"})
-	expected = append(expected, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed3/", SiteURL: "http://example.org/3", CategoryName: "Another Category"})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{"Some Category"}})
+	expected = append(expected, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed2/", SiteURL: "http://example.org/2", CategoryNames: CategoryNameList{"Some Category"}})
+	expected = append(expected, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed3/", SiteURL: "http://example.org/3", CategoryNames: CategoryNameList{"Another Category"}})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {
@@ -250,7 +250,7 @@ func TestParseOpmlWithInvalidCharacterEntity(t *testing.T) {
 	`
 
 	var expected SubcriptionList
-	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/a&b", SiteURL: "http://example.org/c&d", CategoryName: "Feed 1"})
+	expected = append(expected, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed1/a&b", SiteURL: "http://example.org/c&d", CategoryNames: CategoryNameList{"Feed 1"}})
 
 	subscriptions, err := Parse(bytes.NewBufferString(data))
 	if err != nil {

--- a/internal/reader/opml/serializer.go
+++ b/internal/reader/opml/serializer.go
@@ -37,7 +37,7 @@ func convertSubscriptionsToOPML(subscriptions SubcriptionList) *opmlDocument {
 	opmlDocument.Header.Title = "Miniflux"
 	opmlDocument.Header.DateCreated = time.Now().Format("Mon, 02 Jan 2006 15:04:05 MST")
 
-	groupedSubs := groupSubscriptionsByFeed(subscriptions)
+	groupedSubs := groupSubscriptionsByCategory(subscriptions)
 	categories := make([]string, 0, len(groupedSubs))
 	for k := range groupedSubs {
 		categories = append(categories, k)
@@ -45,7 +45,7 @@ func convertSubscriptionsToOPML(subscriptions SubcriptionList) *opmlDocument {
 	sort.Strings(categories)
 
 	for _, categoryName := range categories {
-		category := opmlOutline{Text: categoryName, Outlines: make(opmlOutlineCollection, 0, len(groupedSubs[categoryName]))}
+		category := opmlOutline{Title: categoryName, Text: categoryName, Outlines: make(opmlOutlineCollection, 0, len(groupedSubs[categoryName]))}
 		for _, subscription := range groupedSubs[categoryName] {
 			category.Outlines = append(category.Outlines, opmlOutline{
 				Title:       subscription.Title,
@@ -62,11 +62,13 @@ func convertSubscriptionsToOPML(subscriptions SubcriptionList) *opmlDocument {
 	return opmlDocument
 }
 
-func groupSubscriptionsByFeed(subscriptions SubcriptionList) map[string]SubcriptionList {
+func groupSubscriptionsByCategory(subscriptions SubcriptionList) map[string]SubcriptionList {
 	groups := make(map[string]SubcriptionList)
 
 	for _, subscription := range subscriptions {
-		groups[subscription.CategoryName] = append(groups[subscription.CategoryName], subscription)
+		for _, categoryName := range subscription.CategoryNames {
+			groups[categoryName] = append(groups[categoryName], subscription)
+		}
 	}
 
 	return groups

--- a/internal/reader/opml/serializer_test.go
+++ b/internal/reader/opml/serializer_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestSerialize(t *testing.T) {
 	var subscriptions SubcriptionList
-	subscriptions = append(subscriptions, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed/1", SiteURL: "http://example.org/1", CategoryName: "Category 1"})
-	subscriptions = append(subscriptions, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed/2", SiteURL: "http://example.org/2", CategoryName: "Category 1"})
-	subscriptions = append(subscriptions, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed/3", SiteURL: "http://example.org/3", CategoryName: "Category 2"})
+	subscriptions = append(subscriptions, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed/1", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{"Category 1"}})
+	subscriptions = append(subscriptions, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed/2", SiteURL: "http://example.org/2", CategoryNames: CategoryNameList{"Category 1"}})
+	subscriptions = append(subscriptions, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed/3", SiteURL: "http://example.org/3", CategoryNames: CategoryNameList{"Category 2"}})
 
 	output := Serialize(subscriptions)
 	feeds, err := Parse(bytes.NewBufferString(output))
@@ -26,7 +26,7 @@ func TestSerialize(t *testing.T) {
 
 	found := false
 	for _, feed := range feeds {
-		if feed.Title == "Feed 1" && feed.CategoryName == "Category 1" &&
+		if feed.Title == "Feed 1" && feed.CategoryNames.Equals(&CategoryNameList{"Category 1"}) &&
 			feed.FeedURL == "http://example.org/feed/1" && feed.SiteURL == "http://example.org/1" {
 			found = true
 			break
@@ -49,9 +49,9 @@ func TestNormalizedCategoriesOrder(t *testing.T) {
 	}
 
 	var subscriptions SubcriptionList
-	subscriptions = append(subscriptions, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed/1", SiteURL: "http://example.org/1", CategoryName: orderTests[0].naturalOrderName})
-	subscriptions = append(subscriptions, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed/2", SiteURL: "http://example.org/2", CategoryName: orderTests[1].naturalOrderName})
-	subscriptions = append(subscriptions, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed/3", SiteURL: "http://example.org/3", CategoryName: orderTests[2].naturalOrderName})
+	subscriptions = append(subscriptions, &Subcription{Title: "Feed 1", FeedURL: "http://example.org/feed/1", SiteURL: "http://example.org/1", CategoryNames: CategoryNameList{orderTests[0].naturalOrderName}})
+	subscriptions = append(subscriptions, &Subcription{Title: "Feed 2", FeedURL: "http://example.org/feed/2", SiteURL: "http://example.org/2", CategoryNames: CategoryNameList{orderTests[1].naturalOrderName}})
+	subscriptions = append(subscriptions, &Subcription{Title: "Feed 3", FeedURL: "http://example.org/feed/3", SiteURL: "http://example.org/3", CategoryNames: CategoryNameList{orderTests[2].naturalOrderName}})
 
 	feeds := convertSubscriptionsToOPML(subscriptions)
 

--- a/internal/reader/opml/subscription.go
+++ b/internal/reader/opml/subscription.go
@@ -3,21 +3,45 @@
 
 package opml // import "miniflux.app/v2/internal/reader/opml"
 
+// TODO rename type to Subscription
 // Subcription represents a feed that will be imported or exported.
 type Subcription struct {
-	Title        string
-	SiteURL      string
-	FeedURL      string
-	CategoryName string
-	Description  string
+	Title         string
+	SiteURL       string
+	FeedURL       string
+	CategoryNames CategoryNameList
+	Description   string
+}
+
+type CategoryNameList []string
+
+// Equals compares two category lists
+func (c1s *CategoryNameList) Equals(c2s *CategoryNameList) bool {
+	if len(*c1s) != len(*c2s) {
+		return false
+	}
+	for _, c1 := range *c1s {
+		found := false
+		for _, c2 := range *c2s {
+			if c1 == c2 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // Equals compare two subscriptions.
 func (s Subcription) Equals(subscription *Subcription) bool {
 	return s.Title == subscription.Title && s.SiteURL == subscription.SiteURL &&
-		s.FeedURL == subscription.FeedURL && s.CategoryName == subscription.CategoryName &&
+		s.FeedURL == subscription.FeedURL && s.CategoryNames.Equals(&subscription.CategoryNames) &&
 		s.Description == subscription.Description
 }
 
+// TODO rename type to SubscriptionList
 // SubcriptionList is a list of subscriptions.
 type SubcriptionList []*Subcription

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -392,15 +392,17 @@ func (s *Storage) SetEntriesStatusCount(userID int64, entryIDs []int64, status s
 	}
 
 	query := `
-		SELECT count(*)
+		SELECT count(DISTINCT e.id)
 		FROM entries e
-		    JOIN feeds f ON (f.id = e.feed_id)
-		    JOIN categories c ON (c.id = f.category_id)
+		    LEFT JOIN feeds f ON (f.id = e.feed_id)
+				LEFT JOIN feed_categories fc ON fc.feed_id=f.id
+				LEFT JOIN categories c ON c.id=fc.category_id
 		WHERE e.user_id = $1
 			AND e.id = ANY($2)
 			AND NOT f.hide_globally
 			AND NOT c.hide_globally
 	`
+	fmt.Printf("QUERY: %s", query)
 	row := s.db.QueryRow(query, userID, pq.Array(entryIDs))
 	visible := 0
 	if err := row.Scan(&visible); err != nil {

--- a/internal/storage/entry_pagination_builder.go
+++ b/internal/storage/entry_pagination_builder.go
@@ -45,7 +45,7 @@ func (e *EntryPaginationBuilder) WithFeedID(feedID int64) {
 // WithCategoryID adds category_id to the condition.
 func (e *EntryPaginationBuilder) WithCategoryID(categoryID int64) {
 	if categoryID != 0 {
-		e.conditions = append(e.conditions, fmt.Sprintf("f.category_id = $%d", len(e.args)+1))
+		e.conditions = append(e.conditions, fmt.Sprintf("fc.category_id = $%d", len(e.args)+1))
 		e.args = append(e.args, categoryID)
 	}
 }
@@ -115,8 +115,9 @@ func (e *EntryPaginationBuilder) getPrevNextID(tx *sql.Tx) (prevID int64, nextID
 				lag(e.id) over (order by e.%[1]s asc, e.id desc) as prev_id,
 				lead(e.id) over (order by e.%[1]s asc, e.id desc) as next_id
 			FROM entries AS e
-			JOIN feeds AS f ON f.id=e.feed_id
-			JOIN categories c ON c.id = f.category_id
+			LEFT JOIN feeds AS f ON f.id=e.feed_id
+			LEFT JOIN feed_categories fc ON fc.feed_id=f.id
+			LEFT JOIN categories c ON c.id=fc.category_id
 			WHERE %[2]s
 			ORDER BY e.%[1]s asc, e.id desc
 		)

--- a/internal/template/templates/common/feed_list.html
+++ b/internal/template/templates/common/feed_list.html
@@ -25,14 +25,6 @@
                     <span aria-hidden="true">{{ .NumberOfVisibleEntries }}</span>
                     <span aria-hidden="true">)</span>
                 </span>
-                <span class="category">
-                    <a id="feed-category-{{ .ID }}"
-                       href="{{ route "categoryEntries" "categoryID" .Category.ID }}"
-                       aria-label="{{ t "page.category_label" .Category.Title }}"
-                    >
-                        {{ .Category.Title }}
-                    </a>
-                </span>
             </header>
             <div class="item-meta">
                 <ul class="item-meta-info">

--- a/internal/template/templates/views/bookmark_entries.html
+++ b/internal/template/templates/views/bookmark_entries.html
@@ -34,11 +34,6 @@
                         {{ .Title }}
                     </a>
                 </h2>
-                <span class="category">
-                    <a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">
-                        {{ .Feed.Category.Title }}
-                    </a>
-                </span>
             </header>
             {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry }}
         </article>

--- a/internal/template/templates/views/category_entries.html
+++ b/internal/template/templates/views/category_entries.html
@@ -96,9 +96,9 @@
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a
                         {{ if $.showOnlyUnreadEntries }}
-                        href="{{ route "unreadCategoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}"
+                        href="{{ route "unreadCategoryEntry" "categoryID" (index .Feed.Categories 0).ID "entryID" .ID }}"
                         {{ else }}
-                        href="{{ route "categoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}"
+                        href="{{ route "categoryEntry" "categoryID" (index .Feed.Categories 0).ID "entryID" .ID }}"
                         {{ end }}
                     >
                         {{ if ne .Feed.Icon.IconID 0 }}
@@ -107,11 +107,6 @@
                         {{ .Title }}
                     </a>
                 </h2>
-                <span class="category">
-                    <a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}" aria-label="{{ t "page.category_label" .Feed.Category.Title }}">
-                        {{ .Feed.Category.Title }}
-                    </a>
-                </span>
             </header>
             {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry  }}
         </article>

--- a/internal/template/templates/views/entry.html
+++ b/internal/template/templates/views/entry.html
@@ -126,11 +126,6 @@
                 {{ end }}
             </span>
             {{ end }}
-            {{ if .user }}
-            <span class="category">
-                <a href="{{ route "categoryEntries" "categoryID" .entry.Feed.Category.ID }}">{{ .entry.Feed.Category.Title }}</a>
-            </span>
-            {{ end }}
         </div>
         {{ if .entry.Tags }}
         <div class="entry-tags">

--- a/internal/template/templates/views/feed_entries.html
+++ b/internal/template/templates/views/feed_entries.html
@@ -118,14 +118,6 @@
                         {{ .Title }}
                     </a>
                 </h2>
-                <span class="category">
-                    <a
-                        href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}"
-                        aria-label="{{ t "page.category_label" .Feed.Category.Title }}"
-                    >
-                        {{ .Feed.Category.Title }}
-                    </a>
-                </span>
             </header>
             {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry }}
         </article>

--- a/internal/template/templates/views/history_entries.html
+++ b/internal/template/templates/views/history_entries.html
@@ -53,11 +53,6 @@
                         {{ .Title }}
                     </a>
                 </h2>
-                <span class="category">
-                    <a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">
-                        {{ .Feed.Category.Title }}
-                    </a>
-                </span>
             </header>
             {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry  }}
         </article>

--- a/internal/template/templates/views/search.html
+++ b/internal/template/templates/views/search.html
@@ -39,11 +39,6 @@
                             {{ .Title }}
                         </a>
                     </h2>
-                    <span class="category">
-                        <a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">
-                            {{ .Feed.Category.Title }}
-                        </a>
-                    </span>
                 </header>
                 {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry  }}
             </article>

--- a/internal/template/templates/views/shared_entries.html
+++ b/internal/template/templates/views/shared_entries.html
@@ -58,7 +58,6 @@
                         target="_blank">{{ icon "share" }}</a>
                     {{ end }}
                 </h2>
-                <span class="category"><a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">{{ .Feed.Category.Title }}</a></span>
             </header>
             <div class="item-meta">
                 <ul class="item-meta-info">

--- a/internal/template/templates/views/tag_entries.html
+++ b/internal/template/templates/views/tag_entries.html
@@ -34,11 +34,6 @@
                         {{ .Title }}
                     </a>
                 </h2>
-                <span class="category">
-                    <a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">
-                        {{ .Feed.Category.Title }}
-                    </a>
-                </span>
             </header>
             {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry }}
         </article>

--- a/internal/template/templates/views/unread_entries.html
+++ b/internal/template/templates/views/unread_entries.html
@@ -61,11 +61,6 @@
                         {{ .Title }}
                     </a>
                 </h2>
-                <span class="category">
-                    <a href="{{ route "categoryEntries" "categoryID" .Feed.Category.ID }}">
-                        {{ .Feed.Category.Title }}
-                    </a>
-                </span>
             </header>
             {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry }}
         </article>

--- a/internal/ui/feed_edit.go
+++ b/internal/ui/feed_edit.go
@@ -39,6 +39,15 @@ func (h *handler) showEditFeedPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var categoryIDs []int64
+	categoryHiddenGlobally := false
+	for _, category := range feed.Categories {
+		if category.HideGlobally {
+			categoryHiddenGlobally = true
+		}
+		categoryIDs = append(categoryIDs, category.ID)
+	}
+
 	feedForm := form.FeedForm{
 		SiteURL:                     feed.SiteURL,
 		FeedURL:                     feed.FeedURL,
@@ -52,7 +61,7 @@ func (h *handler) showEditFeedPage(w http.ResponseWriter, r *http.Request) {
 		Crawler:                     feed.Crawler,
 		UserAgent:                   feed.UserAgent,
 		Cookie:                      feed.Cookie,
-		CategoryID:                  feed.Category.ID,
+		CategoryIDs:                 categoryIDs,
 		Username:                    feed.Username,
 		Password:                    feed.Password,
 		IgnoreHTTPCache:             feed.IgnoreHTTPCache,
@@ -61,7 +70,7 @@ func (h *handler) showEditFeedPage(w http.ResponseWriter, r *http.Request) {
 		Disabled:                    feed.Disabled,
 		NoMediaPlayer:               feed.NoMediaPlayer,
 		HideGlobally:                feed.HideGlobally,
-		CategoryHidden:              feed.Category.HideGlobally,
+		CategoryHidden:              categoryHiddenGlobally,
 		AppriseServiceURLs:          feed.AppriseServiceURLs,
 		DisableHTTP2:                feed.DisableHTTP2,
 		NtfyEnabled:                 feed.NtfyEnabled,

--- a/internal/ui/feed_update.go
+++ b/internal/ui/feed_update.go
@@ -60,7 +60,7 @@ func (h *handler) updateFeed(w http.ResponseWriter, r *http.Request) {
 		SiteURL:         model.OptionalString(feedForm.SiteURL),
 		Title:           model.OptionalString(feedForm.Title),
 		Description:     model.OptionalString(feedForm.Description),
-		CategoryID:      model.OptionalNumber(feedForm.CategoryID),
+		CategoryIDs:     feedForm.CategoryIDs,
 		BlocklistRules:  model.OptionalString(feedForm.BlocklistRules),
 		KeeplistRules:   model.OptionalString(feedForm.KeeplistRules),
 		UrlRewriteRules: model.OptionalString(feedForm.UrlRewriteRules),

--- a/internal/ui/subscription_choose.go
+++ b/internal/ui/subscription_choose.go
@@ -48,7 +48,7 @@ func (h *handler) showChooseSubscriptionPage(w http.ResponseWriter, r *http.Requ
 	}
 
 	feed, localizedError := feedHandler.CreateFeed(h.store, user.ID, &model.FeedCreationRequest{
-		CategoryID:                  subscriptionForm.CategoryID,
+		CategoryIDs:                 []int64{subscriptionForm.CategoryID},
 		FeedURL:                     subscriptionForm.URL,
 		Crawler:                     subscriptionForm.Crawler,
 		AllowSelfSignedCertificates: subscriptionForm.AllowSelfSignedCertificates,

--- a/internal/ui/subscription_submit.go
+++ b/internal/ui/subscription_submit.go
@@ -90,7 +90,7 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 			ETag:         subscriptionFinder.FeedResponseInfo().ETag,
 			LastModified: subscriptionFinder.FeedResponseInfo().LastModified,
 			FeedCreationRequest: model.FeedCreationRequest{
-				CategoryID:                  subscriptionForm.CategoryID,
+				CategoryIDs:                 []int64{subscriptionForm.CategoryID},
 				FeedURL:                     subscriptions[0].URL,
 				AllowSelfSignedCertificates: subscriptionForm.AllowSelfSignedCertificates,
 				Crawler:                     subscriptionForm.Crawler,
@@ -117,7 +117,7 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 		html.Redirect(w, r, route.Path(h.router, "feedEntries", "feedID", feed.ID))
 	case n == 1 && !subscriptionFinder.IsFeedAlreadyDownloaded():
 		feed, localizedError := feedHandler.CreateFeed(h.store, user.ID, &model.FeedCreationRequest{
-			CategoryID:                  subscriptionForm.CategoryID,
+			CategoryIDs:                 []int64{subscriptionForm.CategoryID},
 			FeedURL:                     subscriptions[0].URL,
 			Crawler:                     subscriptionForm.Crawler,
 			AllowSelfSignedCertificates: subscriptionForm.AllowSelfSignedCertificates,

--- a/internal/validator/feed.go
+++ b/internal/validator/feed.go
@@ -11,7 +11,7 @@ import (
 
 // ValidateFeedCreation validates feed creation.
 func ValidateFeedCreation(store *storage.Storage, userID int64, request *model.FeedCreationRequest) *locale.LocalizedError {
-	if request.FeedURL == "" || request.CategoryID <= 0 {
+	if request.FeedURL == "" {
 		return locale.NewLocalizedError("error.feed_mandatory_fields")
 	}
 
@@ -23,7 +23,7 @@ func ValidateFeedCreation(store *storage.Storage, userID int64, request *model.F
 		return locale.NewLocalizedError("error.feed_already_exists")
 	}
 
-	if !store.CategoryIDExists(userID, request.CategoryID) {
+	if !store.CategoryIDsExists(userID, request.CategoryIDs) {
 		return locale.NewLocalizedError("error.feed_category_not_found")
 	}
 
@@ -70,8 +70,8 @@ func ValidateFeedModification(store *storage.Storage, userID, feedID int64, requ
 		}
 	}
 
-	if request.CategoryID != nil {
-		if !store.CategoryIDExists(userID, *request.CategoryID) {
+	if request.CategoryIDs != nil {
+		if !store.CategoryIDsExists(userID, request.CategoryIDs) {
 			return locale.NewLocalizedError("error.feed_category_not_found")
 		}
 	}


### PR DESCRIPTION
Allow multiple categories per feed. Motivation can be found in #375.

- Add a new table for the multiple-to-multiple relation and migrate existing data
- Use a list of categories everywhere in the code
- Tested main UI windows and OPML import

TODO
- UI feed creation and edit need another interface to select multiple categories.
- Can we simplify some queries? With an ORM such a change would have been so much easier.
- Decide when to show categories in the UI. Showing multiple categories for every article clutters the view and distracts from the article. So I tend towards removing them from the lists views and maybe also for single feeds/entries. This will make the UI, the queries and the code much simpler, which is a goal of this project.

Do you follow the guidelines?

- [ ] I have tested my changes
- [ ] There is no breaking changes
- [ ] I really tested my changes and there is no regression
- [ ] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [ ] I read this document: https://miniflux.app/faq.html#pull-request

Fixes #375