### PR TITLE
Update last modified timestamp without content update

### DIFF
--- a/internal/reader/fetcher/response_handler_test.go
+++ b/internal/reader/fetcher/response_handler_test.go
@@ -30,7 +30,7 @@ func TestIsModified(t *testing.T) {
 			ETag:         cachedEtag,
 			IsModified:   false,
 		},
-		// This case is invalid per RFC9110 8.8.1, so ETag takes precedence.
+		// ETag takes precedence per RFC9110 8.8.1.
 		"Last-Modified changed only": {
 			Status:       200,
 			LastModified: "Thu, 22 Oct 2015 07:28:00 GMT",


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request

RFC9111 sections [3.2](https://www.rfc-editor.org/rfc/rfc9111.html#name-updating-stored-header-fiel) and [4.3.4](https://www.rfc-editor.org/rfc/rfc9111.html#freshening.responses) describe how stored headers such as `Last-Modified` must be updated even when `ETag` doesn't change. This PR implements that behaviour, fixing the Miniflux bug described in [this blog post](https://rachelbythebay.com/w/2024/09/13/fs/).