### PR TITLE
Add a rewrite rule translators_title("zh-cn") so that when fetching the feed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.20.5
+	github.com/sashabaranov/go-openai v1.32.5
 	github.com/tdewolff/minify/v2 v2.21.1
 	github.com/yuin/goldmark v1.7.8
 	golang.org/x/crypto v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/sashabaranov/go-openai v1.32.5 h1:/eNVa8KzlE7mJdKPZDj6886MUzZQjoVHyn0sLvIt5qA=
+github.com/sashabaranov/go-openai v1.32.5/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tdewolff/minify/v2 v2.21.1 h1:AAf5iltw6+KlUvjRNPAPrANIXl3XEJNBBzuZom5iCAM=

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -89,6 +89,8 @@ const (
 	defaultWatchdog                           = true
 	defaultInvidiousInstance                  = "yewtu.be"
 	defaultWebAuthn                           = false
+	defaultChatGTPToken                       = ""
+	defaultChatGTPBaseURL                     = "https://api.openai.com/v1"
 )
 
 var defaultHTTPClientUserAgent = "Mozilla/5.0 (compatible; Miniflux/" + version.Version + "; +https://miniflux.app)"
@@ -177,6 +179,8 @@ type Options struct {
 	invidiousInstance                  string
 	mediaProxyPrivateKey               []byte
 	webAuthn                           bool
+	chatgptUrl                         string
+	chatgptToken                       string
 }
 
 // NewOptions returns Options with default values.
@@ -256,6 +260,8 @@ func NewOptions() *Options {
 		invidiousInstance:                  defaultInvidiousInstance,
 		mediaProxyPrivateKey:               crypto.GenerateRandomBytes(16),
 		webAuthn:                           defaultWebAuthn,
+		chatgptUrl:                         defaultChatGTPBaseURL,
+		chatgptToken:                       defaultChatGTPToken,
 	}
 }
 
@@ -652,6 +658,13 @@ func (o *Options) WebAuthn() bool {
 // FilterEntryMaxAgeDays returns the number of days after which entries should be retained.
 func (o *Options) FilterEntryMaxAgeDays() int {
 	return o.filterEntryMaxAgeDays
+}
+
+func (o *Options) GetChatGPTToken() string {
+	return o.chatgptToken
+}
+func (o *Options) GetChatGPTUrl() string {
+	return o.chatgptUrl
 }
 
 // SortedOptions returns options as a list of key value pairs, sorted by keys.

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -279,6 +279,10 @@ func (p *Parser) parseLines(lines []string) (err error) {
 			p.opts.invidiousInstance = parseString(value, defaultInvidiousInstance)
 		case "WEBAUTHN":
 			p.opts.webAuthn = parseBool(value, defaultWebAuthn)
+		case "CHAT_GTP_URL":
+			p.opts.chatgptUrl = parseString(value, defaultChatGTPBaseURL)
+		case "CHAT_GTP_TOKEN":
+			p.opts.chatgptToken = parseString(value, defaultChatGTPToken)
 		}
 	}
 


### PR DESCRIPTION
Add a rewrite rule translators_title("zh-cn") so that when fetching the feed, the title is translated. This greatly helps us when reading the feed list, significantly enhancing our information filtering capability. On the other hand, since the title contains few tokens, the cost and usage are minimal. Currently, only ChatGPT is supported.

#2914 

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There is no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
