### PR TITLE
Latest Shiori integration API update

### DIFF
--- a/internal/integration/shiori/shiori.go
+++ b/internal/integration/shiori/shiori.go
@@ -31,7 +31,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 		return fmt.Errorf("shiori: missing base URL, username or password")
 	}
 
-	sessionID, err := c.authenticate()
+	token, err := c.authenticate()
 	if err != nil {
 		return fmt.Errorf("shiori: unable to authenticate: %v", err)
 	}
@@ -44,7 +44,11 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 	requestBody, err := json.Marshal(&addBookmarkRequest{
 		URL:           entryURL,
 		Title:         entryTitle,
+		Excerpt:       "",
 		CreateArchive: true,
+		CreateEbook:   false,
+		Public:        0,
+		Tags:          make([]string, 0),
 	})
 
 	if err != nil {
@@ -58,7 +62,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("User-Agent", "Miniflux/"+version.Version)
-	request.Header.Set("X-Session-Id", sessionID)
+	request.Header.Set("Authorization", "Bearer "+token)
 
 	httpClient := &http.Client{Timeout: defaultClientTimeout}
 
@@ -75,13 +79,13 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 	return nil
 }
 
-func (c *Client) authenticate() (sessionID string, err error) {
-	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/login")
+func (c *Client) authenticate() (token string, err error) {
+	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/v1/auth/login")
 	if err != nil {
 		return "", fmt.Errorf("shiori: invalid API endpoint: %v", err)
 	}
 
-	requestBody, err := json.Marshal(&authRequest{Username: c.username, Password: c.password})
+	requestBody, err := json.Marshal(&authRequest{Username: c.username, Password: c.password, RememberMe: false})
 	if err != nil {
 		return "", fmt.Errorf("shiori: unable to encode request body: %v", err)
 	}
@@ -111,21 +115,31 @@ func (c *Client) authenticate() (sessionID string, err error) {
 	if err := json.NewDecoder(response.Body).Decode(&authResponse); err != nil {
 		return "", fmt.Errorf("shiori: unable to decode response: %v", err)
 	}
-
-	return authResponse.SessionID, nil
+	return authResponse.Message.Token, nil
 }
 
 type authRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username   string `json:"username"`
+	Password   string `json:"password"`
+	RememberMe bool   `json:"remember_me"`
 }
 
 type authResponse struct {
+	OK      bool                `json:"ok"`
+	Message authResponseMessage `json:"message"`
+}
+
+type authResponseMessage struct {
 	SessionID string `json:"session"`
+	Token     string `json:"token"`
 }
 
 type addBookmarkRequest struct {
-	URL           string `json:"url"`
-	Title         string `json:"title"`
-	CreateArchive bool   `json:"createArchive"`
+	URL           string   `json:"url"`
+	Title         string   `json:"title"`
+	CreateArchive bool     `json:"create_archive"`
+	CreateEbook   bool     `json:"create_ebook"`
+	Public        int      `json:"public"`
+	Excerpt       string   `json:"excerpt"`
+	Tags          []string `json:"tags"`
 }


### PR DESCRIPTION
# Guidelines

- [x] I have tested my changes
- [x] There is no breaking changes **(kindof, the breaking change is in Shiori)**
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request

# Pull request motivation

Shiori is [udating its API](https://github.com/go-shiori/shiori/issues/640) to make it RESTful and is adopting the new endpoints gradually. The Login/Auth flow has changed, and the old API is not available in latest stable Shiori, making the integration fail to login with a 404 error.

This Pull Request updates the auth flow in the Shiori integration with new API endpoints and new fields in the API.

This version works against latest stable Shiori API.

**Please note :** Unfortunately, the `/api/bookmarks` API has not been migrated yet, and another pull request will be necessary if/when the old API is removed. Until then, this pull request fixes the current Shiori integration.