### PR TITLE
fix: replace timezone function call with view

### DIFF
--- a/internal/storage/timezone.go
+++ b/internal/storage/timezone.go
@@ -11,7 +11,7 @@ import (
 // Timezones returns all timezones supported by the database.
 func (s *Storage) Timezones() (map[string]string, error) {
 	timezones := make(map[string]string)
-	rows, err := s.db.Query(`SELECT name FROM pg_timezone_names() ORDER BY name ASC`)
+	rows, err := s.db.Query(`SELECT name FROM pg_timezone_names ORDER BY name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch timezones: %v`, err)
 	}


### PR DESCRIPTION
The `pg_timezone_names` view was added in 8.2.
It should be equivalent to the function query.
See: https://pgpedia.info/p/pg_timezone_names.html

This small change allows `miniflux` to run on postgres-compatible databases like CockroachDB, which don't have this function.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
