### PR TITLE
chore: remove `blog.laravel.com` rewrite rule

### DIFF
--- a/internal/reader/rewrite/rules.go
+++ b/internal/reader/rewrite/rules.go
@@ -12,7 +12,6 @@ var predefinedRules = map[string]string{
 	"abstrusegoose.com":      "add_image_title",
 	"amazingsuperpowers.com": "add_image_title",
 	"blog.cloudflare.com":    `add_image_title,remove("figure.kg-image-card figure.kg-image + img")`,
-	"blog.laravel.com":       "parse_markdown",
 	"cowbirdsinlove.com":     "add_image_title",
 	"drawingboardcomic.com":  "add_image_title",
 	"exocomics.com":          "add_image_title",


### PR DESCRIPTION
I added the Laravel blog rewrite rule in #1513, but since then they have changed their feed format. Now, the feed contains a small summary instead of the full markdown body. This PR removes the redundant rewrite rule.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
