### PR TITLE
feat(apprise): add title in notification request body

### DIFF
--- a/internal/integration/apprise/apprise.go
+++ b/internal/integration/apprise/apprise.go
@@ -38,8 +38,9 @@ func (c *Client) SendNotification(entry *model.Entry) error {
 	}
 
 	requestBody, err := json.Marshal(map[string]any{
-		"urls": c.servicesURL,
-		"body": message,
+		"urls":  c.servicesURL,
+		"body":  message,
+		"title": entry.Feed.Title,
 	})
 	if err != nil {
 		return fmt.Errorf("apprise: unable to encode request body: %v", err)


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request

---

> Below descritions are generated by Copilot

This pull request includes a small but important change to the `internal/integration/apprise/apprise.go` file. The change involves adding the feed title to the notification request body, which ensures that the notifications sent include the title of the feed entry.

* [`internal/integration/apprise/apprise.go`](diffhunk://#diff-152c4721f639803365244c356d90e4b42583994153d43eacaa295c98efea9d5aR43): Added the `title` field to the JSON request body in the `SendNotification` function to include the feed title in notifications.

---

This title is useful in mobile notifications, or it's "Apprise Notifications".

This is the first PR I submitted to miniflux. Please forgive me if there are any shortcomings.