### PR TITLE
Update translations to clarify Readeck URL instead of Readeck API Endpoint

### DIFF
--- a/internal/locale/translations/en_US.json
+++ b/internal/locale/translations/en_US.json
@@ -488,7 +488,7 @@
     "form.integration.raindrop_collection_id": "Collection ID",
     "form.integration.raindrop_tags": "Tags (comma-separated)",
     "form.integration.readeck_activate": "Save entries to readeck",
-    "form.integration.readeck_endpoint": "Readeck API Endpoint",
+    "form.integration.readeck_endpoint": "Readeck URL",
     "form.integration.readeck_api_key": "Readeck API key",
     "form.integration.readeck_labels": "Readeck Labels",
     "form.integration.readeck_only_url": "Send only URL (instead of full content)",

--- a/internal/locale/translations/hi_IN.json
+++ b/internal/locale/translations/hi_IN.json
@@ -490,7 +490,7 @@
     "form.integration.raindrop_collection_id": "Collection ID",
     "form.integration.raindrop_tags": "Tags (comma-separated)",
     "form.integration.readeck_activate": "Readeck में विषयवस्तु सहेजें",
-    "form.integration.readeck_endpoint": "Readeck·एपीआई·समापन·बिंदु",
+    "form.integration.readeck_endpoint": "Readeck यूआरएल",
     "form.integration.readeck_api_key": "Readeck एपीआई कुंजी",
     "form.integration.readeck_labels": "Readeck Labels",
     "form.integration.readeck_only_url": "केवल URL भेजें (पूर्ण सामग्री के बजाय)",

--- a/internal/locale/translations/uk_UA.json
+++ b/internal/locale/translations/uk_UA.json
@@ -500,7 +500,7 @@
     "form.integration.raindrop_collection_id": "Collection ID",
     "form.integration.raindrop_tags": "Tags (comma-separated)",
     "form.integration.readeck_activate": "Зберігати статті до Readeck",
-    "form.integration.readeck_endpoint": "Readeck API Endpoint",
+    "form.integration.readeck_endpoint": "Readeck URL",
     "form.integration.readeck_api_key": "Ключ API Readeck",
     "form.integration.readeck_labels": "Readeck Labels",
     "form.integration.readeck_only_url": "Надіслати лише URL (замість повного вмісту)",


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request

In order for the Readeck integration to work, user needs to enter the URL of their Readeck instance. Current translations wrongly mention 'Readeck API Endpoint'.
This PR fixes it for en_US, uk_UA (same text as en_US) and hi_IN. Translations for other languages will also need to be fixed.
