### PR TITLE
Optimize internal/reader/sanitizer/strip_tags.go

### DIFF
--- a/internal/reader/sanitizer/strip_tags.go
+++ b/internal/reader/sanitizer/strip_tags.go
@@ -4,8 +4,8 @@
 package sanitizer // import "miniflux.app/v2/internal/reader/sanitizer"
 
 import (
-	"bytes"
 	"io"
+	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -13,8 +13,8 @@ import (
 // StripTags removes all HTML/XML tags from the input string.
 // This function must *only* be used for cosmetic purposes, not to prevent code injections like XSS.
 func StripTags(input string) string {
-	tokenizer := html.NewTokenizer(bytes.NewBufferString(input))
-	var buffer bytes.Buffer
+	tokenizer := html.NewTokenizer(strings.NewReader(input))
+	var buffer strings.Builder
 
 	for {
 		if tokenizer.Next() == html.ErrorToken {


### PR DESCRIPTION
- Use strings instead of doing string->bytes->string
- Use a strings.Builder to build the output