### PR TITLE
Improve the `rewrite` regex

### DIFF
--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -25,7 +25,7 @@ import (
 	"github.com/tdewolff/minify/v2/html"
 )
 
-var customReplaceRuleRegex = regexp.MustCompile(`rewrite\("(.*)"\|"(.*)"\)`)
+var customReplaceRuleRegex = regexp.MustCompile(`rewrite\("([^"]+)"\|"([^"]+)"\)`)
 
 // ProcessFeedEntries downloads original web page for entries and apply filters.
 func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, user *model.User, forceRefresh bool) {


### PR DESCRIPTION
- Use `[^"]` instead of `.`, to help the regex engine to determine boundaries, instead of having it bruteforce its way to find them
- Use `+` instead of `*`, as empty rules don't make sense