### PR TITLE
Get rid of a test-only variable

### DIFF
--- a/internal/locale/catalog_test.go
+++ b/internal/locale/catalog_test.go
@@ -90,6 +90,26 @@ func TestMissingTranslations(t *testing.T) {
 }
 
 func TestTranslationFilePluralForms(t *testing.T) {
+	var numberOfPluralFormsPerLanguage = map[string]int{
+		"en_US": 2,
+		"es_ES": 2,
+		"fr_FR": 2,
+		"de_DE": 2,
+		"pl_PL": 3,
+		"pt_BR": 2,
+		"zh_CN": 1,
+		"zh_TW": 1,
+		"nl_NL": 2,
+		"ru_RU": 3,
+		"it_IT": 2,
+		"ja_JP": 1,
+		"tr_TR": 2,
+		"el_EL": 2,
+		"fi_FI": 2,
+		"hi_IN": 2,
+		"uk_UA": 3,
+		"id_ID": 1,
+	}
 	for language := range AvailableLanguages() {
 		messages, err := loadTranslationFile(language)
 		if err != nil {

--- a/internal/locale/locale.go
+++ b/internal/locale/locale.go
@@ -3,27 +3,6 @@
 
 package locale // import "miniflux.app/v2/internal/locale"
 
-var numberOfPluralFormsPerLanguage = map[string]int{
-	"en_US": 2,
-	"es_ES": 2,
-	"fr_FR": 2,
-	"de_DE": 2,
-	"pl_PL": 3,
-	"pt_BR": 2,
-	"zh_CN": 1,
-	"zh_TW": 1,
-	"nl_NL": 2,
-	"ru_RU": 3,
-	"it_IT": 2,
-	"ja_JP": 1,
-	"tr_TR": 2,
-	"el_EL": 2,
-	"fi_FI": 2,
-	"hi_IN": 2,
-	"uk_UA": 3,
-	"id_ID": 1,
-}
-
 // AvailableLanguages returns the list of available languages.
 func AvailableLanguages() map[string]string {
 	return map[string]string{


### PR DESCRIPTION
The `numberOfPluralFormsPerLanguage` variable is only used for tests, so it should be declared in the test file.