### PR TITLE
Use a home-made implementation of `Titelize`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	golang.org/x/net v0.33.0
 	golang.org/x/oauth2 v0.24.0
 	golang.org/x/term v0.27.0
-	golang.org/x/text v0.21.0
 )
 
 require (
@@ -42,6 +41,7 @@ require (
 	github.com/tdewolff/parse/v2 v2.7.19 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )
 

--- a/internal/reader/rewrite/rewriter.go
+++ b/internal/reader/rewrite/rewriter.go
@@ -8,12 +8,11 @@ import (
 	"strconv"
 	"strings"
 	"text/scanner"
+	"unicode"
+	"unicode/utf8"
 
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/urllib"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type rule struct {
@@ -94,8 +93,16 @@ func (rule rule) applyRule(entryURL string, entry *model.Entry) {
 	case "remove_tables":
 		entry.Content = removeTables(entry.Content)
 	case "remove_clickbait":
-		entry.Title = cases.Title(language.English).String(strings.ToLower(entry.Title))
+		entry.Title = titlelize(entry.Title)
 	}
+}
+
+// titlelize lowercases the parameter and uppercases its first character..
+func titlelize(str string) string {
+	if r, size := utf8.DecodeRuneInString(str); r != utf8.RuneError {
+		return string(unicode.ToUpper(r)) + strings.ToLower(str[size:])
+	}
+	return str
 }
 
 // Rewriter modify item contents with a set of rewriting rules.


### PR DESCRIPTION
The implementation is equivalent to
`cases.Title(language.English).String(strings.ToLower(…))`, and this is the only place in miniflux where
"golang.org/x/text/cases" and "golang.org/x/text/language" are (directly) used.

This reduces the binary size from 27015590 to
26686112 on my machine.

Kudos to https://gsa.zxilly.dev for making it straightforward to catch things like this.