### PR TITLE
ux: add an star icon next to the "starred" nav menu item

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -93,7 +93,7 @@
                     </a>
                 </li>
                 <li {{ if eq .menu "starred" }}class="active"{{ end }} title="{{ t "tooltip.keyboard_shortcuts" "g b" }}">
-                    <a href="{{ route "starred" }}" data-page="starred">{{ t "menu.starred" }}</a>
+                    <a href="{{ route "starred" }}" data-page="starred">{{ t "menu.starred" }} ★</a>
                 </li>
                 <li {{ if eq .menu "history" }}class="active"{{ end }} title="{{ t "tooltip.keyboard_shortcuts" "g h" }}">
                     <a href="{{ route "history" }}" data-page="history">{{ t "menu.history" }}</a>


### PR DESCRIPTION
This is somewhat of a follow-up of https://github.com/miniflux/v2/pull/1371.

It looks like this:

<img width="714" alt="image" src="https://github.com/user-attachments/assets/bb308091-3a86-46b3-a112-5d58ec069d65" />

And with hover:

<img width="260" alt="image" src="https://github.com/user-attachments/assets/ec719002-f2d0-4898-9696-0f1bec9497b0" />

Initially I added the emoji star (⭐️) but it stood out too much. I find that the unicode star blends in well with the rest of the menu.

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
