### PR TITLE
Don't specify languages for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,8 +22,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'go', 'javascript' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
As stated in the [documentation](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed):

> CodeQL code scanning automatically detects code written in the supported languages.

This will also reduce the number of CodeQL jobs from two to one.

See #3029