### PR TITLE
Don't run `go vet ./...` as it's run as part of golangci-lint

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23.x"
-      - run: "go vet ./..."
       - uses: golangci/golangci-lint-action@v6
         with:
           args: >


### PR DESCRIPTION
See https://golangci-lint.run/usage/linters/#govet