### PR TITLE
Only run `-race -cover` on ubuntu in the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,12 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Run unit tests
+    - name: Run unit tests with coverage and race conditions checking
+      if: matrix.os == 'ubuntu-latest'
       run: make test
+    - name: Run unit tests without coverage and race conditions checking
+      if: matrix.os != 'ubuntu-latest'
+      run: go test -count=1 ./...
 
   integration-tests:
     name: Integration Tests


### PR DESCRIPTION
The coverage information isn't used anywhere in the CI, so no need to have it for every OS. As for `-race`, there is no point in using it everywhere, one time should be enough, especially since it's taking a lot of time on Windows.