### PR TITLE
ci: avoid building Linux packages for each pull-request to speedup the CI

### DIFF
--- a/.github/workflows/debian_packages.yml
+++ b/.github/workflows/debian_packages.yml
@@ -5,11 +5,11 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 1,4'  # Runs at 00:00 UTC on Monday and Thursday
 jobs:
   test-packages:
-    if: github.event.pull_request
+    if: github.event_name == 'schedule'
     name: Test Packages
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
     - name: List generated files
       run: ls -l *.deb
   build-packages-manually:
-    if: github.event_name != 'pull_request' && github.event_name != 'push'
+    if: github.event_name == 'workflow_dispatch'
     name: Build Packages Manually
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rpm_packages.yml
+++ b/.github/workflows/rpm_packages.yml
@@ -5,11 +5,11 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 1,4'  # Runs at 00:00 UTC on Monday and Thursday
 jobs:
   test-package:
-    if: github.event.pull_request
+    if: github.event_name == 'schedule'
     name: Test Packages
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +21,7 @@ jobs:
     - name: List generated files
       run: ls -l *.rpm
   build-package-manually:
-    if: github.event_name != 'pull_request' && github.event_name != 'push'
+    if: github.event_name == 'workflow_dispatch'
     name: Build Packages Manually
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
See https://github.com/miniflux/v2/issues/3029#issuecomment-2563024081

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
