### PR TITLE
Golf a bit internal/ui/static/js/modal_handler.js

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         sudo npm install -g jshint@2.13.6 eslint@8.57.0
     - name: Run jshint
-      run: jshint internal/ui/static/js/*.js
+      run: jshint --config .jshintrc internal/ui/static/js/*.js
     - name: Run ESLint
       run: eslint internal/ui/static/js/*.js
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "esversion": 11,
+  "nonew": true,
+  "nocomma": true,
+  "browser": true
+}

--- a/internal/ui/static/js/modal_handler.js
+++ b/internal/ui/static/js/modal_handler.js
@@ -1,15 +1,6 @@
 class ModalHandler {
-    static exists() {
-        return document.getElementById("modal-container") !== null;
-    }
-
-    static getModalContainer() {
-        return document.getElementById("modal-container");
-    }
-
     static getFocusableElements() {
-        const container = this.getModalContainer();
-
+        const container =  document.getElementById("modal-container");
         if (container === null) {
             return null;
         }
@@ -19,15 +10,14 @@ class ModalHandler {
 
     static setupFocusTrap() {
         const focusableElements = this.getFocusableElements();
-
         if (focusableElements === null) {
             return;
         }
 
         const firstFocusableElement = focusableElements[0];
-        const lastFocusableElement = focusableElements[focusableElements.length - 1];
+        const lastFocusableElement = focusableElements.at(-1);
 
-        this.getModalContainer().onkeydown = (e) => {
+        document.getElementById("modal-container").onkeydown = (e) => {
             if (e.key !== 'Tab') {
                 return;
             }
@@ -51,7 +41,7 @@ class ModalHandler {
     }
 
     static open(fragment, initialFocusElementId) {
-        if (ModalHandler.exists()) {
+        if (document.getElementById("modal-container") !== null) {
             return;
         }
 
@@ -89,7 +79,7 @@ class ModalHandler {
     }
 
     static close() {
-        const container = this.getModalContainer();
+        const container = document.getElementById("modal-container");
         if (container !== null) {
             container.parentNode.removeChild(container);
         }


### PR DESCRIPTION
- Re-use an existing function instead of copy-pasting its code
- Use optional chaining instead of a condition
- Use the modern `.at` method instead of `[focusableElements.length - 1]`, as it's supported on all browsers since 2016: https://caniuse.com/mdn-javascript_builtins_string_at