### PR TITLE
fix(ui): reading preferences are reset if the form values are incorrect

### DIFF
--- a/internal/template/templates/views/settings.html
+++ b/internal/template/templates/views/settings.html
@@ -115,14 +115,14 @@
 
         <label><input type="checkbox" name="show_reading_time" value="1" {{ if .form.ShowReadingTime }}checked{{ end }}> {{ t "form.prefs.label.show_reading_time" }}</label>
 
-        <label><input type="radio" name="mark_read_behavior" value="{{ .const.NoAutoMarkAsRead }}"
-                      {{ if eq .form.MarkReadBehavior .const.NoAutoMarkAsRead }}checked{{end}}                          > {{ t "form.prefs.label.mark_read_manually" }}</label>
-        <label><input type="radio" name="mark_read_behavior" value="{{ .const.MarkAsReadOnView }}"
-                      {{ if eq .form.MarkReadBehavior .const.MarkAsReadOnView }}checked{{end}}                          > {{ t "form.prefs.label.mark_read_on_view" }}</label>
-        <label><input type="radio" name="mark_read_behavior" value="{{ .const.MarkAsReadOnViewButWaitForPlayerCompletion }}"
-                      {{ if eq .form.MarkReadBehavior .const.MarkAsReadOnViewButWaitForPlayerCompletion }}checked{{end}}> {{ t "form.prefs.label.mark_read_on_view_or_media_completion" }}</label>
-        <label><input type="radio" name="mark_read_behavior" value="{{ .const.MarkAsReadOnlyOnPlayerCompletion }}"
-                      {{ if eq .form.MarkReadBehavior .const.MarkAsReadOnlyOnPlayerCompletion }}checked{{end}}          > {{ t "form.prefs.label.mark_read_on_media_completion" }}</label>
+        <label><input type="radio" name="mark_read_behavior" value="{{ .readBehaviors.NoAutoMarkAsRead }}"
+                      {{ if eq .form.MarkReadBehavior .readBehaviors.NoAutoMarkAsRead }}checked{{end}}                          > {{ t "form.prefs.label.mark_read_manually" }}</label>
+        <label><input type="radio" name="mark_read_behavior" value="{{ .readBehaviors.MarkAsReadOnView }}"
+                      {{ if eq .form.MarkReadBehavior .readBehaviors.MarkAsReadOnView }}checked{{end}}                          > {{ t "form.prefs.label.mark_read_on_view" }}</label>
+        <label><input type="radio" name="mark_read_behavior" value="{{ .readBehaviors.MarkAsReadOnViewButWaitForPlayerCompletion }}"
+                      {{ if eq .form.MarkReadBehavior .readBehaviors.MarkAsReadOnViewButWaitForPlayerCompletion }}checked{{end}}> {{ t "form.prefs.label.mark_read_on_view_or_media_completion" }}</label>
+        <label><input type="radio" name="mark_read_behavior" value="{{ .readBehaviors.MarkAsReadOnlyOnPlayerCompletion }}"
+                      {{ if eq .form.MarkReadBehavior .readBehaviors.MarkAsReadOnlyOnPlayerCompletion }}checked{{end}}          > {{ t "form.prefs.label.mark_read_on_media_completion" }}</label>
 
         <div class="buttons">
             <button type="submit" class="button button-primary" data-label-loading="{{ t "form.submit.saving" }}">{{ t "action.update" }}</button>

--- a/internal/ui/form/settings.go
+++ b/internal/ui/form/settings.go
@@ -16,7 +16,7 @@ import (
 // MarkReadBehavior list all possible behaviors for automatically marking an entry as read
 type MarkReadBehavior string
 
-var (
+const (
 	NoAutoMarkAsRead                           MarkReadBehavior = "no-auto"
 	MarkAsReadOnView                           MarkReadBehavior = "on-view"
 	MarkAsReadOnViewButWaitForPlayerCompletion MarkReadBehavior = "on-view-but-wait-for-player-completion"

--- a/internal/ui/settings_show.go
+++ b/internal/ui/settings_show.go
@@ -63,8 +63,7 @@ func (h *handler) showSettingsPage(w http.ResponseWriter, r *http.Request) {
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)
 	view.Set("form", settingsForm)
-	// In order to keep the continuity between form and model, I pass adhoc constants to the view
-	view.Set("const", map[string]interface{}{
+	view.Set("readBehaviors", map[string]any{
 		"NoAutoMarkAsRead":                           form.NoAutoMarkAsRead,
 		"MarkAsReadOnView":                           form.MarkAsReadOnView,
 		"MarkAsReadOnViewButWaitForPlayerCompletion": form.MarkAsReadOnViewButWaitForPlayerCompletion,

--- a/internal/ui/settings_update.go
+++ b/internal/ui/settings_update.go
@@ -43,6 +43,12 @@ func (h *handler) updateSettings(w http.ResponseWriter, r *http.Request) {
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)
 	view.Set("form", settingsForm)
+	view.Set("readBehaviors", map[string]any{
+		"NoAutoMarkAsRead":                           form.NoAutoMarkAsRead,
+		"MarkAsReadOnView":                           form.MarkAsReadOnView,
+		"MarkAsReadOnViewButWaitForPlayerCompletion": form.MarkAsReadOnViewButWaitForPlayerCompletion,
+		"MarkAsReadOnlyOnPlayerCompletion":           form.MarkAsReadOnlyOnPlayerCompletion,
+	})
 	view.Set("themes", model.Themes())
 	view.Set("languages", locale.AvailableLanguages)
 	view.Set("timezones", timezones)


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
