### PR TITLE
feat: bump linter and minifier from ECMAScript 2017 to 2020 (ES11)

### DIFF
--- a/internal/ui/static/js/.eslintrc.json
+++ b/internal/ui/static/js/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "env": {
         "browser": true,
-        "es2017": true
+        "es2020": true
     },
     "rules": {
         "indent": ["error", 4]

--- a/internal/ui/static/js/.jshintrc
+++ b/internal/ui/static/js/.jshintrc
@@ -1,16 +1,15 @@
 {
-  "esversion": 11,
   "bitwise": true,
+  "browser": true,
   "eqeqeq": true,
+  "esversion": 11,
   "freeze": true,
-  "nonew": true,
   "latedef": "nofunc",
   "noarg": true,
   "nocomma": true,
   "nonbsp": true,
   "nonew": true,
-  "browser": true,
+  "noreturnawait": true,
   "shadow": true,
-  "varstmt": true,
-  "noreturnawait": true
+  "varstmt": true
 }

--- a/internal/ui/static/static.go
+++ b/internal/ui/static/static.go
@@ -139,7 +139,7 @@ func GenerateJavascriptBundles() error {
 	JavascriptBundles = make(map[string][]byte)
 	JavascriptBundleChecksums = make(map[string]string)
 
-	jsMinifier := js.Minifier{Version: 2017}
+	jsMinifier := js.Minifier{Version: 2020}
 
 	minifier := minify.New()
 	minifier.AddFunc("text/javascript", jsMinifier.Minify)


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
