### PR TITLE
fix(sanitizer): non-allowed attributes are not properly stripped

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -127,9 +127,11 @@ func Sanitize(baseURL, input string) string {
 				attrNames, htmlAttributes := sanitizeAttributes(baseURL, tagName, token.Attr)
 				if hasRequiredAttributes(tagName, attrNames) {
 					if len(attrNames) > 0 {
+						// Rewrite the start tag with allowed attributes.
 						buffer.WriteString("<" + tagName + " " + htmlAttributes + ">")
 					} else {
-						buffer.WriteString(token.String())
+						// Rewrite the start tag without any attributes.
+						buffer.WriteString("<" + tagName + ">")
 					}
 
 					tagStack = append(tagStack, tagName)
@@ -138,7 +140,7 @@ func Sanitize(baseURL, input string) string {
 		case html.EndTagToken:
 			if len(blockedStack) == 0 {
 				if isValidTag(tagName) && slices.Contains(tagStack, tagName) {
-					buffer.WriteString(token.String())
+					buffer.WriteString("</" + tagName + ">")
 				}
 			} else {
 				if blockedStack[len(blockedStack)-1] == tagName {
@@ -155,7 +157,7 @@ func Sanitize(baseURL, input string) string {
 					if len(attrNames) > 0 {
 						buffer.WriteString("<" + tagName + " " + htmlAttributes + "/>")
 					} else {
-						buffer.WriteString(token.String())
+						buffer.WriteString("<" + tagName + "/>")
 					}
 				}
 			}

--- a/internal/reader/sanitizer/sanitizer_test.go
+++ b/internal/reader/sanitizer/sanitizer_test.go
@@ -685,3 +685,13 @@ func TestHiddenParagraph(t *testing.T) {
 		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
 	}
 }
+
+func TestAttributesAreStripped(t *testing.T) {
+	input := `<p style="color: red;">Some text.<hr style="color: blue"/>Test.</p>`
+	expected := `<p>Some text.<hr/>Test.</p>`
+
+	output := Sanitize("http://example.org/", input)
+	if expected != output {
+		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
+	}
+}


### PR DESCRIPTION
Regression introduced in commit 58178d90cbb502a3dcb992e619d8e6c44be4d0df

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
