### PR TITLE
fix(css): `--entry-content-aside-border-color` is missing from `system.css`

### DIFF
--- a/internal/ui/static/css/system.css
+++ b/internal/ui/static/css/system.css
@@ -96,6 +96,7 @@
     --entry-content-code-border-color: #ddd;
     --entry-content-quote-color: #666;
     --entry-content-abbr-border-color: #999;
+    --entry-content-aside-border-color: #D3D3D3;
     --entry-enclosure-border-color: #333;
 
     --parsing-error-color: #333;
@@ -218,6 +219,7 @@ html {
         --entry-content-code-border-color: #888;
         --entry-content-quote-color: #777;
         --entry-content-abbr-border-color: #777;
+        --entry-content-aside-border-color: #777;
         --entry-enclosure-border-color: #333;
 
         --parsing-error-color: #eee;


### PR DESCRIPTION
Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
