### PR TITLE
fix(ui): Redirect correctly post feed removal from category feeds list

### DIFF
--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -40,6 +40,14 @@ func (s *Storage) FeedExists(userID, feedID int64) bool {
 	return result
 }
 
+// CategoryFeedExists returns true if the given feed exists that belongs to the given category.
+func (s *Storage) CategoryFeedExists(userID, categoryID, feedID int64) bool {
+	var result bool
+	query := `SELECT true FROM feeds WHERE user_id=$1 AND category_id=$2 AND id=$3`
+	s.db.QueryRow(query, userID, categoryID, feedID).Scan(&result)
+	return result
+}
+
 // FeedURLExists checks if feed URL already exists.
 func (s *Storage) FeedURLExists(userID int64, feedURL string) bool {
 	var result bool

--- a/internal/template/templates/common/feed_list.html
+++ b/internal/template/templates/common/feed_list.html
@@ -66,7 +66,11 @@
                             data-label-yes="{{ t "confirm.yes" }}"
                             data-label-no="{{ t "confirm.no" }}"
                             data-label-loading="{{ t "confirm.loading" }}"
-                            data-url="{{ route "removeFeed" "feedID" .ID }}">{{ icon "delete" }}<span class="icon-label">{{ t "action.remove" }}</span></button>
+                            {{ if $.categoryID }}
+                                data-url="{{ route "removeCategoryFeed" "categoryID" $.categoryID "feedID" .ID }}"
+                            {{ else }}
+                                data-url="{{ route "removeFeed" "feedID" .ID }}"
+                            {{ end }}>{{ icon "delete" }}<span class="icon-label">{{ t "action.remove" }}</span></button>
                     </li>
                     {{ if .UnreadCount }}
                       <li class="item-meta-icons-mark-as-read">

--- a/internal/template/templates/views/category_feeds.html
+++ b/internal/template/templates/views/category_feeds.html
@@ -53,7 +53,7 @@
 {{ if not .feeds }}
     <p role="alert" class="alert">{{ t "alert.no_feed_in_category" }}</p>
 {{ else }}
-    {{ template "feed_list" dict "user" .user "feeds" .feeds "ParsingErrorCount" .ParsingErrorCount }}
+    {{ template "feed_list" dict "categoryID" .category.ID "user" .user "feeds" .feeds "ParsingErrorCount" .ParsingErrorCount }}
 {{ end }}
 
 {{ end }}

--- a/internal/ui/category_remove_feed.go
+++ b/internal/ui/category_remove_feed.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ui // import "miniflux.app/v2/internal/ui"
+
+import (
+	"net/http"
+
+	"miniflux.app/v2/internal/http/request"
+	"miniflux.app/v2/internal/http/response/html"
+	"miniflux.app/v2/internal/http/route"
+)
+
+func (h *handler) removeCategoryFeed(w http.ResponseWriter, r *http.Request) {
+	feedID := request.RouteInt64Param(r, "feedID")
+	categoryID := request.RouteInt64Param(r, "categoryID")
+
+	if !h.store.CategoryFeedExists(request.UserID(r), categoryID, feedID) {
+		html.NotFound(w, r)
+		return
+	}
+
+	if err := h.store.RemoveFeed(request.UserID(r), feedID); err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
+	html.Redirect(w, r, route.Path(h.router, "categoryFeeds", "categoryID", categoryID))
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -84,6 +84,7 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	uiRouter.HandleFunc("/category/create", handler.showCreateCategoryPage).Name("createCategory").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/category/save", handler.saveCategory).Name("saveCategory").Methods(http.MethodPost)
 	uiRouter.HandleFunc("/category/{categoryID}/feeds", handler.showCategoryFeedsPage).Name("categoryFeeds").Methods(http.MethodGet)
+	uiRouter.HandleFunc("/category/{categoryID}/feed/{feedID}/remove", handler.removeCategoryFeed).Name("removeCategoryFeed").Methods(http.MethodPost)
 	uiRouter.HandleFunc("/category/{categoryID}/feeds/refresh", handler.refreshCategoryFeedsPage).Name("refreshCategoryFeedsPage").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/category/{categoryID}/entries", handler.showCategoryEntriesPage).Name("categoryEntries").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/category/{categoryID}/entries/refresh", handler.refreshCategoryEntriesPage).Name("refreshCategoryEntriesPage").Methods(http.MethodGet)


### PR DESCRIPTION
Currently, removing a feed from `/category/{id}/feeds` redirects incorrectly to `/feeds`. This change fixes it so that
removing a feed will now correctly redirect to `/category/{id}/feeds`. Removing a feed from `/feeds` is unaffected and
will work as it does currently.

To fix this, a new UI endpoint `/category/{categoryID}/feed/{feedID}/remove` is added and a corresponding handler method
to validate and perform the removal from DB.

## Comparison

| Before | After |
| ---- | ---- |
| <video src="https://github.com/user-attachments/assets/cda1d566-b7d0-47a3-9a79-1fd218ccbf3b"> | <video src="https://github.com/user-attachments/assets/ebdeaffc-cb10-46eb-9265-3ec259019c0b"> |

---

Do you follow the guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I really tested my changes and there is no regression
- [x] Ideally, my commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I read this document: https://miniflux.app/faq.html#pull-request
