### PR TITLE
ci: update GitHub Actions workflows to use Go 1.24

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.x"
+          go-version: "1.24.x"
           check-latest: true
       - name: Compile binaries
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.23.x"
+        go-version: "1.24.x"
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.x"
+          go-version: "1.24.x"
       - uses: golangci/golangci-lint-action@v6
         with:
           args: >
@@ -38,7 +38,7 @@ jobs:
             --enable sqlclosecheck,misspell,gofmt,goimports,whitespace,gocritic
       - uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2024.1.1"
+          version: "latest"
           install-go: false
 
   commitlint:
@@ -48,16 +48,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-
       - name: Install commitlint
         run: |
           npm install --save-dev @commitlint/config-conventional @commitlint/cli
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
-
       - name: Validate PR commits
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        go-version: ["1.23.x"]
+        go-version: ["1.24.x"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.23.x"
+        go-version: "1.24.x"
     - name: Install Postgres client
       run: sudo apt update && sudo apt install -y postgresql-client
     - name: Run integration tests


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
