### PR TITLE
fix(scraper): avoid encoding issue if charset meta tag is after the first 1024 bytes

### DIFF
--- a/internal/reader/encoding/encoding_test.go
+++ b/internal/reader/encoding/encoding_test.go
@@ -4,6 +4,7 @@
 package encoding // import "miniflux.app/v2/internal/reader/encoding"
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"testing"
@@ -31,6 +32,11 @@ func TestCharsetReaderWithUTF8(t *testing.T) {
 	if !utf8.Valid(data) {
 		t.Fatalf("Data is not valid UTF-8")
 	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
 }
 
 func TestCharsetReaderWithISO88591(t *testing.T) {
@@ -53,6 +59,11 @@ func TestCharsetReaderWithISO88591(t *testing.T) {
 
 	if !utf8.Valid(data) {
 		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
 	}
 }
 
@@ -77,6 +88,11 @@ func TestCharsetReaderWithWindows1252(t *testing.T) {
 	if !utf8.Valid(data) {
 		t.Fatalf("Data is not valid UTF-8")
 	}
+
+	expectedUnicodeString := "Euro €"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
 }
 
 func TestCharsetReaderWithInvalidProlog(t *testing.T) {
@@ -99,6 +115,11 @@ func TestCharsetReaderWithInvalidProlog(t *testing.T) {
 
 	if !utf8.Valid(data) {
 		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
 	}
 }
 
@@ -123,6 +144,11 @@ func TestCharsetReaderWithUTF8DocumentWithIncorrectProlog(t *testing.T) {
 	if !utf8.Valid(data) {
 		t.Fatalf("Data is not valid UTF-8")
 	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
 }
 
 func TestCharsetReaderWithWindows1252DocumentWithIncorrectProlog(t *testing.T) {
@@ -145,5 +171,178 @@ func TestCharsetReaderWithWindows1252DocumentWithIncorrectProlog(t *testing.T) {
 
 	if !utf8.Valid(data) {
 		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Euro €"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
+}
+
+func TestNewReaderWithUTF8Document(t *testing.T) {
+	file := "testdata/utf8.html"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("Unable to open file: %v", err)
+	}
+
+	reader, err := NewCharsetReader(f, "text/html; charset=UTF-8")
+	if err != nil {
+		t.Fatalf("Unable to create reader: %v", err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Unable to read data: %v", err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
+}
+
+func TestNewReaderWithUTF8DocumentAndNoContentEncoding(t *testing.T) {
+	file := "testdata/utf8.html"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("Unable to open file: %v", err)
+	}
+
+	reader, err := NewCharsetReader(f, "text/html")
+	if err != nil {
+		t.Fatalf("Unable to create reader: %v", err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Unable to read data: %v", err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
+}
+
+func TestNewReaderWithISO88591Document(t *testing.T) {
+	file := "testdata/iso-8859-1.xml"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("Unable to open file: %v", err)
+	}
+
+	reader, err := NewCharsetReader(f, "text/html; charset=ISO-8859-1")
+	if err != nil {
+		t.Fatalf("Unable to create reader: %v", err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Unable to read data: %v", err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
+}
+
+func TestNewReaderWithISO88591DocumentAndNoContentType(t *testing.T) {
+	file := "testdata/iso-8859-1.xml"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("Unable to open file: %v", err)
+	}
+
+	reader, err := NewCharsetReader(f, "")
+	if err != nil {
+		t.Fatalf("Unable to create reader: %v", err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Unable to read data: %v", err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
+}
+
+func TestNewReaderWithISO88591DocumentWithMetaAfter1024Bytes(t *testing.T) {
+	file := "testdata/iso-8859-1-meta-after-1024.html"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("Unable to open file: %v", err)
+	}
+
+	reader, err := NewCharsetReader(f, "text/html")
+	if err != nil {
+		t.Fatalf("Unable to create reader: %v", err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Unable to read data: %v", err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
+	}
+}
+
+func TestNewReaderWithUTF8DocumentWithMetaAfter1024Bytes(t *testing.T) {
+	file := "testdata/utf8-meta-after-1024.html"
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("Unable to open file: %v", err)
+	}
+
+	reader, err := NewCharsetReader(f, "text/html")
+	if err != nil {
+		t.Fatalf("Unable to create reader: %v", err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Unable to read data: %v", err)
+	}
+
+	if !utf8.Valid(data) {
+		t.Fatalf("Data is not valid UTF-8")
+	}
+
+	expectedUnicodeString := "Café"
+	if !bytes.Contains(data, []byte(expectedUnicodeString)) {
+		t.Fatalf("Data does not contain expected unicode string: %s", expectedUnicodeString)
 	}
 }

--- a/internal/reader/encoding/testdata/invalid-prolog.xml
+++ b/internal/reader/encoding/testdata/invalid-prolog.xml
@@ -2,6 +2,6 @@
 <feed>
     <title>테스트 피드</title>
     <entry>
-        <title>こんにちは世界</title>
+        <title>Café</title>
     </entry>
 </feed>

--- a/internal/reader/encoding/testdata/iso-8859-1-meta-after-1024.html
+++ b/internal/reader/encoding/testdata/iso-8859-1-meta-after-1024.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <!---
+
+  This text is greater than 1024 bytes which are used by the charset.NewReader to determine the encoding of the file.
+
+  This comment is used to pad the file to 1024 bytes.
+
+  The <meta> tag must be after 1024 bytes to ensure that the encoding is detected correctly.
+
+  ---
+
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+
+  -->
+  <head>
+    <meta charset="iso-8859-1">
+    <title>Frédéric</title>
+  </head>
+  <body>
+    <p>Café</p>
+  </body>
+</html>

--- a/internal/reader/encoding/testdata/iso-8859-1.html
+++ b/internal/reader/encoding/testdata/iso-8859-1.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="iso-8859-1">
+    <title>Frédéric</title>
+  </head>
+  <body>
+    <p>Café</p>
+  </body>
+</html>

--- a/internal/reader/encoding/testdata/utf8-incorrect-prolog.xml
+++ b/internal/reader/encoding/testdata/utf8-incorrect-prolog.xml
@@ -2,6 +2,6 @@
 <feed>
     <title>테스트 피드</title>
     <entry>
-        <title>こんにちは世界</title>
+        <title>Café</title>
     </entry>
 </feed>

--- a/internal/reader/encoding/testdata/utf8-meta-after-1024.html
+++ b/internal/reader/encoding/testdata/utf8-meta-after-1024.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <!---
+
+  This text is greater than 1024 bytes which are used by the charset.NewReader to determine the encoding of the file.
+
+  This comment is used to pad the file to 1024 bytes.
+
+  The <meta> tag must be after 1024 bytes to ensure that the encoding is detected correctly.
+
+  ---
+
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+  More text to pad the file to 1024 bytes.
+
+  -->
+  <head>
+    <meta charset="utf-8">
+    <title>Frédéric</title>
+  </head>
+  <body>
+    <p>Café</p>
+  </body>
+</html>

--- a/internal/reader/encoding/testdata/utf8.html
+++ b/internal/reader/encoding/testdata/utf8.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Café</title>
+  </head>
+  <body>
+    <p>Café</p>
+  </body>
+</html>

--- a/internal/reader/encoding/testdata/utf8.xml
+++ b/internal/reader/encoding/testdata/utf8.xml
@@ -2,6 +2,6 @@
 <feed>
     <title>테스트 피드</title>
     <entry>
-        <title>こんにちは世界</title>
+        <title>Café</title>
     </entry>
 </feed>

--- a/internal/reader/icon/finder.go
+++ b/internal/reader/icon/finder.go
@@ -21,12 +21,12 @@ import (
 	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/crypto"
 	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/reader/encoding"
 	"miniflux.app/v2/internal/reader/fetcher"
 	"miniflux.app/v2/internal/urllib"
 
 	"github.com/PuerkitoBio/goquery"
 	"golang.org/x/image/draw"
-	"golang.org/x/net/html/charset"
 )
 
 type IconFinder struct {
@@ -248,7 +248,7 @@ func findIconURLsFromHTMLDocument(body io.Reader, contentType string) ([]string,
 		"link[rel='apple-touch-icon-precomposed.png']",
 	}
 
-	htmlDocumentReader, err := charset.NewReader(body, contentType)
+	htmlDocumentReader, err := encoding.NewCharsetReader(body, contentType)
 	if err != nil {
 		return nil, fmt.Errorf("icon: unable to create charset reader: %w", err)
 	}

--- a/internal/reader/scraper/scraper.go
+++ b/internal/reader/scraper/scraper.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 
 	"miniflux.app/v2/internal/config"
+	"miniflux.app/v2/internal/reader/encoding"
 	"miniflux.app/v2/internal/reader/fetcher"
 	"miniflux.app/v2/internal/reader/readability"
 	"miniflux.app/v2/internal/urllib"
 
 	"github.com/PuerkitoBio/goquery"
-	"golang.org/x/net/html/charset"
 )
 
 func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string) (baseURL string, extractedContent string, err error) {
@@ -39,10 +39,11 @@ func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string
 		rules = getPredefinedScraperRules(pageURL)
 	}
 
-	htmlDocumentReader, err := charset.NewReader(
+	htmlDocumentReader, err := encoding.NewCharsetReader(
 		responseHandler.Body(config.Opts.HTTPClientMaxBodySize()),
 		responseHandler.ContentType(),
 	)
+
 	if err != nil {
 		return "", "", fmt.Errorf("scraper: unable to read HTML document with charset reader: %v", err)
 	}

--- a/internal/reader/subscription/finder.go
+++ b/internal/reader/subscription/finder.go
@@ -16,12 +16,12 @@ import (
 	"miniflux.app/v2/internal/integration/rssbridge"
 	"miniflux.app/v2/internal/locale"
 	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/reader/encoding"
 	"miniflux.app/v2/internal/reader/fetcher"
 	"miniflux.app/v2/internal/reader/parser"
 	"miniflux.app/v2/internal/urllib"
 
 	"github.com/PuerkitoBio/goquery"
-	"golang.org/x/net/html/charset"
 )
 
 var (
@@ -136,7 +136,7 @@ func (f *SubscriptionFinder) FindSubscriptionsFromWebPage(websiteURL, contentTyp
 		"link[type='application/feed+json']": parser.FormatJSON,
 	}
 
-	htmlDocumentReader, err := charset.NewReader(body, contentType)
+	htmlDocumentReader, err := encoding.NewCharsetReader(body, contentType)
 	if err != nil {
 		return nil, locale.NewLocalizedErrorWrapper(err, "error.unable_to_parse_html_document", err)
 	}


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
