### PR TITLE
feat(sanitizer): allow `img` tags with only a `srcset` and no `src` attribute

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -296,9 +296,9 @@ func hasRequiredAttributes(tagName string, attributes []string) bool {
 	switch tagName {
 	case "a":
 		return slices.Contains(attributes, "href")
-	case "iframe", "img":
+	case "iframe":
 		return slices.Contains(attributes, "src")
-	case "source":
+	case "source", "img":
 		return slices.Contains(attributes, "src") || slices.Contains(attributes, "srcset")
 	default:
 		return true

--- a/internal/reader/sanitizer/sanitizer_test.go
+++ b/internal/reader/sanitizer/sanitizer_test.go
@@ -119,9 +119,19 @@ func TestImgWithDataURL(t *testing.T) {
 	}
 }
 
-func TestImgWithSrcset(t *testing.T) {
+func TestImgWithSrcsetAttribute(t *testing.T) {
 	input := `<img srcset="example-320w.jpg, example-480w.jpg 1.5x,   example-640w.jpg 2x, example-640w.jpg 640w" src="example-640w.jpg" alt="Example">`
 	expected := `<img srcset="http://example.org/example-320w.jpg, http://example.org/example-480w.jpg 1.5x, http://example.org/example-640w.jpg 2x, http://example.org/example-640w.jpg 640w" src="http://example.org/example-640w.jpg" alt="Example" loading="lazy">`
+	output := Sanitize("http://example.org/", input)
+
+	if output != expected {
+		t.Errorf(`Wrong output: %s`, output)
+	}
+}
+
+func TestImgWithSrcsetAndNoSrcAttribute(t *testing.T) {
+	input := `<img srcset="example-320w.jpg, example-480w.jpg 1.5x,   example-640w.jpg 2x, example-640w.jpg 640w" alt="Example">`
+	expected := `<img srcset="http://example.org/example-320w.jpg, http://example.org/example-480w.jpg 1.5x, http://example.org/example-640w.jpg 2x, http://example.org/example-640w.jpg 640w" alt="Example" loading="lazy">`
 	output := Sanitize("http://example.org/", input)
 
 	if output != expected {


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
