### PR TITLE
perf(sanitizer): remove two useless calls to strings.ReplaceAll

### DIFF
--- a/internal/reader/sanitizer/truncate.go
+++ b/internal/reader/sanitizer/truncate.go
@@ -7,8 +7,6 @@ import "strings"
 
 func TruncateHTML(input string, max int) string {
 	text := StripTags(input)
-	text = strings.ReplaceAll(text, "\n", " ")
-	text = strings.ReplaceAll(text, "\t", " ")
 
 	// Collapse multiple spaces into a single space
 	text = strings.Join(strings.Fields(text), " ")


### PR DESCRIPTION
The [strings.Fields](https://pkg.go.dev/strings#Fields) considers `'\t', '\n', '\v', '\f', '\r', ' ', U+0085 (NEL), U+00A0 (NBSP).` as spaces, so no need to remove them beforehand.

This is a continuation of f2f60a8f73ec2f1c82a9834452a29930f3302dbb
