### PR TITLE
fix(processor): add missing quotation marks to import comments

### DIFF
--- a/internal/reader/processor/bilibili.go
+++ b/internal/reader/processor/bilibili.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"encoding/json"

--- a/internal/reader/processor/filters.go
+++ b/internal/reader/processor/filters.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"log/slog"

--- a/internal/reader/processor/nebula.go
+++ b/internal/reader/processor/nebula.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"errors"

--- a/internal/reader/processor/odysee.go
+++ b/internal/reader/processor/odysee.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"errors"

--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"log/slog"

--- a/internal/reader/processor/reading_time.go
+++ b/internal/reader/processor/reading_time.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"log/slog"

--- a/internal/reader/processor/youtube.go
+++ b/internal/reader/processor/youtube.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package processor // import "miniflux.app/v2/internal/reader/processor
+package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request

Forwarded from [Debian](https://salsa.debian.org/go-team/packages/miniflux/-/blob/337a5abcfc6eeae9395878c7762640c677b9f7ca/debian/patches/0002-fix-import-comment.patch).