### PR TITLE
fix(ui): avoid 500 error and NaN when marking as read a deleted entry

### DIFF
--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -369,18 +369,8 @@ func (s *Storage) ArchiveEntries(status string, days, limit int) (int64, error) 
 // SetEntriesStatus update the status of the given list of entries.
 func (s *Storage) SetEntriesStatus(userID int64, entryIDs []int64, status string) error {
 	query := `UPDATE entries SET status=$1, changed_at=now() WHERE user_id=$2 AND id=ANY($3)`
-	result, err := s.db.Exec(query, status, userID, pq.Array(entryIDs))
-	if err != nil {
+	if _, err := s.db.Exec(query, status, userID, pq.Array(entryIDs)); err != nil {
 		return fmt.Errorf(`store: unable to update entries statuses %v: %v`, entryIDs, err)
-	}
-
-	count, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf(`store: unable to update these entries %v: %v`, entryIDs, err)
-	}
-
-	if count == 0 {
-		return errors.New(`store: nothing has been updated`)
 	}
 
 	return nil


### PR DESCRIPTION
Steps to reproduce:

1. In /unread, open a feed's settings in a new tab. The feed must have unread entries in /unread.
2. In the new tab/window, delete the feed.
3. Without refreshing, mark an entry from the now-deleted feed as read.
4. Result: The total unread count in the UI header switches to NaN.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
