### PR TITLE
docs: Update client README to not reference deprecated function

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -27,10 +27,10 @@ import (
 
 func main() {
     // Authentication with username/password:
-    client := miniflux.New("https://api.example.org", "admin", "secret")
+    client := miniflux.NewClient("https://api.example.org", "admin", "secret")
 
     // Authentication with an API Key:
-    client := miniflux.New("https://api.example.org", "my-secret-token")
+    client := miniflux.NewClient("https://api.example.org", "my-secret-token")
 
     // Fetch all feeds.
     feeds, err := client.Feeds()

--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,7 @@ type Client struct {
 }
 
 // New returns a new Miniflux client.
+//
 // Deprecated: use NewClient instead.
 func New(endpoint string, credentials ...string) *Client {
 	return NewClient(endpoint, credentials...)


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
