### PR TITLE
fix: log warning on an empty client secret

### DIFF
--- a/internal/oauth2/manager.go
+++ b/internal/oauth2/manager.go
@@ -39,5 +39,9 @@ func NewManager(ctx context.Context, clientID, clientSecret, redirectURL, oidcDi
 		}
 	}
 
+	if clientSecret == "" {
+		slog.Warn("OIDC client secret is empty or missing.")
+	}
+
 	return m
 }


### PR DESCRIPTION
Because Miniflux runs as a confidential service, a missing client secret is a mistake in configuration. An empty client secret appears to be valid per RFC 6749 (and is in fact the default set by Miniflux!), so we log a warning.

Let me know if there are any changes to this PR that you would appreciate; this warning would have been saved me some time earlier today in determining that I had typo'd the configuration and not, in fact, set the client secret as I thought I had.

Thanks so much!

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
