### PR TITLE
fix: clarify share flow in UI

### DIFF
--- a/internal/template/templates/views/entry.html
+++ b/internal/template/templates/views/entry.html
@@ -67,11 +67,12 @@
                 </li>
                 {{ else }}
                 <li>
-                    <a href="{{ route "shareEntry" "entryID" .entry.ID }}"
-                        class="page-link"
-                        title="{{ t "entry.share.title" }}"
-                        data-share-status="share"
-                        target="_blank">{{ icon "share" }}<span class="icon-label">{{ t "entry.share.label" }}</span></a>
+                  <form method="post" action="{{route "shareEntry" "entryID" .entry.ID }}">
+                    <input type="hidden" name="csrf" value="{{ .csrf }}">
+                      <button type="submit" class="page-button">
+			{{ icon "share" }}<span class="icon-label">{{ t "entry.share.label" }}</span>
+		      </button>
+		  </form>
                 </li>
                 {{ end }}
                 <li>

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -108,7 +108,7 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	uiRouter.HandleFunc("/entry/bookmark/{entryID}", handler.toggleBookmark).Name("toggleBookmark").Methods(http.MethodPost)
 
 	// Share pages.
-	uiRouter.HandleFunc("/entry/share/{entryID}", handler.createSharedEntry).Name("shareEntry").Methods(http.MethodGet)
+	uiRouter.HandleFunc("/entry/share/{entryID}", handler.createSharedEntry).Name("shareEntry").Methods(http.MethodPost)
 	uiRouter.HandleFunc("/entry/unshare/{entryID}", handler.unshareEntry).Name("unshareEntry").Methods(http.MethodPost)
 	uiRouter.HandleFunc("/share/{shareCode}", handler.sharedEntry).Name("sharedEntry").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/shares", handler.sharedEntries).Name("sharedEntries").Methods(http.MethodGet)


### PR DESCRIPTION
Prior to this commit, to share an entry, a user has to click on the share link and then copy the URL they are redirected to. The danger is that they may right-click and copy the share link without actually clicking on it, and therefore share a link that, when authenticated, shares the entry, rather than actually sharing the entry.

Here, we avoid this misinterpretation by making sharing into a POST request and using a form rather than a link.

---

This would have clarified some of the confusion in #3251. Please let me know if there's anything to change/improve with this; thanks!

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
