### PR TITLE
refactor: avoid logging twice the feed errors in the background worker

### DIFF
--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -244,7 +244,12 @@ func RefreshFeed(store *storage.Storage, userID, feedID int64, forceRefresh bool
 	}
 
 	if localizedError := responseHandler.LocalizedError(); localizedError != nil {
-		slog.Warn("Unable to fetch feed", slog.String("feed_url", originalFeed.FeedURL), slog.Any("error", localizedError.Error()))
+		slog.Warn("Unable to fetch feed",
+			slog.Int64("user_id", userID),
+			slog.Int64("feed_id", feedID),
+			slog.String("feed_url", originalFeed.FeedURL),
+			slog.Any("error", localizedError.Error()),
+		)
 		user, storeErr := store.UserByID(userID)
 		if storeErr != nil {
 			return locale.NewLocalizedErrorWrapper(storeErr, "error.database_error", storeErr)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -44,13 +44,5 @@ func (w *Worker) Run(c <-chan model.Job) {
 			}
 			metric.BackgroundFeedRefreshDuration.WithLabelValues(status).Observe(time.Since(startTime).Seconds())
 		}
-
-		if localizedError != nil {
-			slog.Warn("Unable to refresh a feed",
-				slog.Int64("user_id", job.UserID),
-				slog.Int64("feed_id", job.FeedID),
-				slog.Any("error", localizedError.Error()),
-			)
-		}
 	}
 }


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
