### PR TITLE
fix(consistency): align entry fetch content behavior between API and UI

### DIFF
--- a/internal/api/entry.go
+++ b/internal/api/entry.go
@@ -331,7 +331,14 @@ func (h *handler) fetchContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	json.OK(w, r, map[string]string{"content": entry.Content})
+	if err := h.store.UpdateEntryTitleAndContent(entry); err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	readingTime := locale.NewPrinter(user.Language).Plural("entry.estimated_reading_time", entry.ReadingTime, entry.ReadingTime)
+
+	json.OK(w, r, map[string]string{"content": mediaproxy.RewriteDocumentWithRelativeProxyURL(h.router, entry.Content), "reading_time": readingTime})
 }
 
 func (h *handler) flushHistory(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request

---

## Problem

I noticed a behavioral inconsistency between the UI and API when working with entries:

When fetching content via the API endpoint, the response was returning raw entry content without:
1. Updating the entry title and content (which happens in the UI flow)
2. Rewriting document URLs with relative proxy URLs
3. Including reading time information

This inconsistency creates different behaviors depending on whether users interact through the UI or API.

## Solution

This PR aligns the API behavior with the UI by:
- Adding a call to `UpdateEntryTitleAndContent()` when fetching content via API
- Enhancing the API response to include proper reading time information
- Using `mediaproxy.RewriteDocumentWithRelativeProxyURL()` to ensure consistent URL handling

These changes ensure that both the API and UI provide the same functionality and data format when fetching entry content.

## Related Behavior

This fix is similar to an issue I noticed previously: when modifying a feed through the web form (e.g., disabling it), the parsing error count and error message are reset. However, this reset doesn't occur when modifying via API. This PR addresses a similar type of UI/API inconsistency.