### PR TITLE
feat: added spotify iframe support

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -385,6 +385,7 @@ func isValidIframeSource(baseURL, src string) bool {
 		"dailymotion.com",
 		"youtube-nocookie.com",
 		"youtube.com",
+		"open.spotify.com",
 	}
 	domain := urllib.Domain(src)
 


### PR DESCRIPTION
Have you followed these guidelines?

feat: added Spotify iframe support

I recently made a [feed](https://raw.githubusercontent.com/NoelNegash/rss-actions/refs/heads/main/dist/the-dowsers.atom) out of a site called [The Dowsers](https://the-dowsers.com) that regularly publishes Spotify playlists. The playlists are embedded using an iframe from open.spotify.com.
It works on https://rssviewer.app, for example, but not Miniflux because Spotify isn't whitelisted.

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
