### PR TITLE
fix(googlereader): handle various item ID formats

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -292,7 +292,7 @@ func (h *handler) editTagHandler(w http.ResponseWriter, r *http.Request) {
 
 	itemIDs, err := parseItemIDsFromRequest(r)
 	if err != nil {
-		json.ServerError(w, r, err)
+		json.BadRequest(w, r, err)
 		return
 	}
 
@@ -709,7 +709,7 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 
 	itemIDs, err := parseItemIDsFromRequest(r)
 	if err != nil {
-		json.ServerError(w, r, err)
+		json.BadRequest(w, r, err)
 		return
 	}
 
@@ -733,22 +733,11 @@ func (h *handler) streamItemContentsHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if len(entries) == 0 {
-		json.BadRequest(w, r, fmt.Errorf("googlereader: no items returned from the database for item IDs: %v", itemIDs))
-		return
-	}
-
 	result := streamContentItems{
 		Direction: "ltr",
-		ID:        fmt.Sprintf("feed/%d", entries[0].FeedID),
-		Title:     entries[0].Feed.Title,
-		Alternate: []contentHREFType{
-			{
-				HREF: entries[0].Feed.SiteURL,
-				Type: "text/html",
-			},
-		},
-		Updated: time.Now().Unix(),
+		ID:        "user/-/state/com.google/reading-list",
+		Title:     "Reading List",
+		Updated:   time.Now().Unix(),
 		Self: []contentHREF{
 			{
 				HREF: config.Opts.RootURL() + route.Path(h.router, "StreamItemsContents"),

--- a/internal/googlereader/item_test.go
+++ b/internal/googlereader/item_test.go
@@ -23,7 +23,10 @@ func TestConvertEntryIDToLongFormItemID(t *testing.T) {
 func TestParseItemIDsFromRequest(t *testing.T) {
 	formValues := url.Values{}
 	formValues.Add("i", "12345")
-	formValues.Add("i", convertEntryIDToLongFormItemID(45678))
+	formValues.Add("i", "tag:google.com,2005:reader/item/00000000148b9369")
+	formValues.Add("i", "tag:google.com,2005:reader/item/2f2")
+	formValues.Add("i", "000000000000046f")
+	formValues.Add("i", "tag:google.com,2005:reader/item/272")
 
 	request := &http.Request{
 		Form: formValues,
@@ -34,7 +37,7 @@ func TestParseItemIDsFromRequest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var expected = []int64{12345, 45678}
+	var expected = []int64{12345, 344691561, 754, 1135, 626}
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("expected %v, got %v", expected, result)
 	}
@@ -51,12 +54,22 @@ func TestParseItemIDsFromRequest(t *testing.T) {
 }
 
 func TestParseItemID(t *testing.T) {
-	// Test with long form ID
+	// Test with long form ID and hex ID
 	result, err := parseItemID("tag:google.com,2005:reader/item/0000000000000001")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	expected := int64(1)
+	if result != expected {
+		t.Errorf("expected %d, got %d", expected, result)
+	}
+
+	// Test with hexadecimal long form ID
+	result, err = parseItemID("0000000000000468")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected = int64(1128)
 	if result != expected {
 		t.Errorf("expected %d, got %d", expected, result)
 	}
@@ -85,24 +98,6 @@ func TestParseItemID(t *testing.T) {
 
 	// Test with empty ID
 	_, err = parseItemID("")
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-
-	// Test with ID that is too short
-	_, err = parseItemID("tag:google.com,2005:reader/item/00000000000000")
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-
-	// Test with ID that is too long
-	_, err = parseItemID("tag:google.com,2005:reader/item/000000000000000000")
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-
-	// Test with ID that is not a number
-	_, err = parseItemID("tag:google.com,2005:reader/item/abc")
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}


### PR DESCRIPTION
- Expected format: "tag:google.com,2005:reader/item/00000000148b9369" (hexadecimal string with prefix and padding)
- NetNewsWire uses this format: "tag:google.com,2005:reader/item/2f2" (hexadecimal string with prefix and no padding)
- Reeder uses this format: "000000000000048c" (hexadecimal string without prefix and padding)
- Liferea uses this format: "12345" (decimal string)

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
