### PR TITLE
ci: remove deprecated `reviewers` field from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,52 +4,28 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "fguillot"
-    assignees:
-      - "fguillot"
 
   - package-ecosystem: "docker"
     directory: "/packaging/docker/alpine"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "fguillot"
-    assignees:
-      - "fguillot"
 
   - package-ecosystem: "docker"
     directory: "/packaging/docker/distroless"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "fguillot"
-    assignees:
-      - "fguillot"
 
   - package-ecosystem: "docker"
     directory: "packaging/debian"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "fguillot"
-    assignees:
-      - "fguillot"
 
   - package-ecosystem: "docker"
     directory: "packaging/rpm"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "fguillot"
-    assignees:
-      - "fguillot"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "fguillot"
-    assignees:
-      - "fguillot"


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
