### PR TITLE
fix(sanitizer): MathML tags are not fully supported by `golang.org/x/net/html`

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -82,7 +82,7 @@ var (
 		"annotation":     {},
 		"annotation-xml": {},
 		"maction":        {},
-		"math":           {},
+		"math":           {"xmlns"},
 		"merror":         {},
 		"mfrac":          {},
 		"mi":             {},
@@ -131,7 +131,15 @@ func Sanitize(baseURL, input string) string {
 		}
 
 		token := tokenizer.Token()
-		tagName := token.DataAtom.String()
+
+		// Note: MathML elements are not fully supported by golang.org/x/net/html.
+		// See https://github.com/golang/net/blob/master/html/atom/gen.go
+		// and https://github.com/golang/net/blob/master/html/atom/table.go
+		tagName := token.Data
+		if tagName == "" {
+			continue
+		}
+
 		switch token.Type {
 		case html.TextToken:
 			if len(blockedStack) > 0 {

--- a/internal/reader/sanitizer/sanitizer_test.go
+++ b/internal/reader/sanitizer/sanitizer_test.go
@@ -705,3 +705,13 @@ func TestAttributesAreStripped(t *testing.T) {
 		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
 	}
 }
+
+func TestMathML(t *testing.T) {
+	input := `<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>`
+	expected := `<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>`
+	output := Sanitize("http://example.org/", input)
+
+	if expected != output {
+		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
+	}
+}


### PR DESCRIPTION
See https://github.com/golang/net/blob/master/html/atom/gen.go and https://github.com/golang/net/blob/master/html/atom/table.go

![image](https://github.com/user-attachments/assets/a1bfe828-b566-4e28-8582-5a1084b33be5)


Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
