### PR TITLE
chore(gitignore): ignore miniflux binary in root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ./*.sha256
-./miniflux
+/miniflux
 .idea
 .vscode
 *.deb


### PR DESCRIPTION
Currently `miniflux` binary in root directory is not ignored. To ignore file only in root directory of Git repo it should start with `/`.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
