### PR TITLE
Webauthn: enable discoverable credential

### DIFF
--- a/internal/ui/webauthn.go
+++ b/internal/ui/webauthn.go
@@ -105,6 +105,8 @@ func (h *handler) beginRegistration(w http.ResponseWriter, r *http.Request) {
 			nil,
 		},
 		webauthn.WithExclusions(credsDescriptors),
+		webauthn.WithResidentKeyRequirement(protocol.ResidentKeyRequirementPreferred),
+		webauthn.WithExtensions(protocol.AuthenticationExtensions{"credProps": true}),
 	)
 
 	if err != nil {


### PR DESCRIPTION
- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request

https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#residentkey

Before the change, miniflux would not create discoverable credential. So user must input username when login.
After the change, discoverable login is able to use which could skip username input.

I have tested passkey register and login on my Android 13 phone with Firefox and Chrome. Might need some help for more devices testing.

About the line 109 change: I found on Firefox Android(Android 13), create passkey(register) will not use Google passkey but get passkey(login) will use Google passkey, which make registed passkey unavailable to use for login.
But when I create passkey(register) with credProps=true, Google passkey is used.
This is not happened on Chrome Android(Android 13), so maybe this is a bug in Firefox Android. credProps=true is just a workaround.

https://webauthn.io/ This demo site is useful for testing. It create passkey with credProps=true.

Before Change             |  After Change
:-------------------------:|:-------------------------:
![Before_Change_Login](https://github.com/user-attachments/assets/ec9d633f-c2e7-4fa9-aae9-5ad723e2fdbc) | ![After_Change_Login](https://github.com/user-attachments/assets/eea9ad61-e9dc-4ced-9944-7101cb45f7c6)

