### PR TITLE
fix(migrations): prevent failure at v45 with long entry URLs

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -509,7 +509,7 @@ var migrations = []func(tx *sql.Tx, driver string) error{
 	},
 	func(tx *sql.Tx, _ string) (err error) {
 		_, err = tx.Exec(`
-			CREATE INDEX entries_feed_url_idx ON entries(feed_id, url);
+			CREATE INDEX entries_feed_url_idx ON entries(feed_id, url) WHERE length(url) < 2000;
 			CREATE INDEX entries_user_status_feed_idx ON entries(user_id, status, feed_id);
 			CREATE INDEX entries_user_status_changed_idx ON entries(user_id, status, changed_at);
 		`)


### PR DESCRIPTION
Fixes an issue where upgrading from older versions of Miniflux could fail with the following PostgreSQL error:

```
[FATAL] [Migration v45] pq: index row size 2744 exceeds btree version 4 maximum 2704 for index "entries_feed_url_idx"
```

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
