### PR TITLE
perf(rss): early return when looking for an item's author

### DIFF
--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -169,8 +169,11 @@ func findFeedAuthor(rssChannel *RSSChannel) string {
 		author = rssChannel.ManagingEditor
 	case rssChannel.Webmaster != "":
 		author = rssChannel.Webmaster
+	default:
+		return ""
 	}
-	return sanitizer.StripTags(strings.TrimSpace(author))
+
+	return strings.TrimSpace(sanitizer.StripTags(author))
 }
 
 func findEntryTitle(rssItem *RSSItem) string {
@@ -258,8 +261,10 @@ func findEntryAuthor(rssItem *RSSItem) string {
 		author = rssItem.PersonName()
 	case strings.Contains(rssItem.Author.Inner, "<![CDATA["):
 		author = rssItem.Author.Data
-	default:
+	case rssItem.Author.Inner != "":
 		author = rssItem.Author.Inner
+	default:
+		return ""
 	}
 
 	return strings.TrimSpace(sanitizer.StripTags(author))


### PR DESCRIPTION
The `sanitizer.StripTags` function is calling `html.NewTokenizer`, which is allocating a 4096 bytes buffer on the heap, as well a running a complex state machine to tokenize html. There is no need to do all of this for empty strings.

This commit also fixes a TrimSpace/StripTags call inversion.