### PR TITLE
feat: Allow multiple listen addresses

### DIFF
--- a/internal/cli/health_check.go
+++ b/internal/cli/health_check.go
@@ -14,7 +14,7 @@ import (
 
 func doHealthCheck(healthCheckEndpoint string) {
 	if healthCheckEndpoint == "auto" {
-		healthCheckEndpoint = "http://" + config.Opts.ListenAddr() + config.Opts.BasePath() + "/healthcheck"
+		healthCheckEndpoint = "http://" + config.Opts.ListenAddr()[0] + config.Opts.BasePath() + "/healthcheck"
 	}
 
 	slog.Debug("Executing health check request", slog.String("endpoint", healthCheckEndpoint))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ package config // import "miniflux.app/v2/internal/config"
 import (
 	"bytes"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -428,18 +429,18 @@ func TestListenAddr(t *testing.T) {
 		t.Fatalf(`Parsing failure: %v`, err)
 	}
 
-	expected := "foobar"
+	expected := []string{"foobar"}
 	result := opts.ListenAddr()
 
-	if result != expected {
-		t.Fatalf(`Unexpected LISTEN_ADDR value, got %q instead of %q`, result, expected)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf(`Unexpected LISTEN_ADDR value, got %v instead of %v`, result, expected)
 	}
 }
 
 func TestListenAddrWithPortDefined(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("PORT", "3000")
-	os.Setenv("LISTEN_ADDR", "foobar")
+	os.Setenv("LISTEN_ADDR", "foobar") // This should be overridden by PORT
 
 	parser := NewParser()
 	opts, err := parser.ParseEnvironmentVariables()
@@ -447,11 +448,11 @@ func TestListenAddrWithPortDefined(t *testing.T) {
 		t.Fatalf(`Parsing failure: %v`, err)
 	}
 
-	expected := ":3000"
+	expected := []string{":3000"}
 	result := opts.ListenAddr()
 
-	if result != expected {
-		t.Fatalf(`Unexpected LISTEN_ADDR value, got %q instead of %q`, result, expected)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf(`Unexpected LISTEN_ADDR value when PORT is set, got %v instead of %v`, result, expected)
 	}
 }
 
@@ -464,11 +465,11 @@ func TestDefaultListenAddrValue(t *testing.T) {
 		t.Fatalf(`Parsing failure: %v`, err)
 	}
 
-	expected := defaultListenAddr
+	expected := []string{defaultListenAddr}
 	result := opts.ListenAddr()
 
-	if result != expected {
-		t.Fatalf(`Unexpected LISTEN_ADDR value, got %q instead of %q`, result, expected)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf(`Unexpected default LISTEN_ADDR value, got %v instead of %v`, result, expected)
 	}
 }
 

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -119,7 +119,7 @@ type Options struct {
 	databaseMinConns                   int
 	databaseConnectionLifetime         int
 	runMigrations                      bool
-	listenAddr                         string
+	listenAddr                         []string
 	certFile                           string
 	certDomain                         string
 	certKeyFile                        string
@@ -202,7 +202,7 @@ func NewOptions() *Options {
 		databaseMinConns:                   defaultDatabaseMinConns,
 		databaseConnectionLifetime:         defaultDatabaseConnectionLifetime,
 		runMigrations:                      defaultRunMigrations,
-		listenAddr:                         defaultListenAddr,
+		listenAddr:                         []string{defaultListenAddr},
 		certFile:                           defaultCertFile,
 		certDomain:                         defaultCertDomain,
 		certKeyFile:                        defaultKeyFile,
@@ -339,7 +339,7 @@ func (o *Options) DatabaseConnectionLifetime() time.Duration {
 }
 
 // ListenAddr returns the listen address for the HTTP server.
-func (o *Options) ListenAddr() string {
+func (o *Options) ListenAddr() []string {
 	return o.listenAddr
 }
 
@@ -740,7 +740,7 @@ func (o *Options) SortedOptions(redactSecret bool) []*Option {
 		"HTTP_SERVICE":                           o.httpService,
 		"INVIDIOUS_INSTANCE":                     o.invidiousInstance,
 		"KEY_FILE":                               o.certKeyFile,
-		"LISTEN_ADDR":                            o.listenAddr,
+		"LISTEN_ADDR":                            strings.Join(o.listenAddr, ","),
 		"LOG_FILE":                               o.logFile,
 		"LOG_DATE_TIME":                          o.logDateTime,
 		"LOG_FORMAT":                             o.logFormat,

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -94,7 +94,7 @@ func (p *Parser) parseLines(lines []string) (err error) {
 		case "PORT":
 			port = value
 		case "LISTEN_ADDR":
-			p.opts.listenAddr = parseString(value, defaultListenAddr)
+			p.opts.listenAddr = parseStringList(value, []string{defaultListenAddr})
 		case "DATABASE_URL":
 			p.opts.databaseURL = parseString(value, defaultDatabaseURL)
 		case "DATABASE_URL_FILE":
@@ -258,7 +258,7 @@ func (p *Parser) parseLines(lines []string) (err error) {
 	}
 
 	if port != "" {
-		p.opts.listenAddr = ":" + port
+		p.opts.listenAddr = []string{":" + port}
 	}
 
 	youtubeEmbedURL, err := url.Parse(p.opts.youTubeEmbedUrlOverride)
@@ -338,6 +338,10 @@ func parseStringList(value string, fallback []string) []string {
 	items := strings.Split(value, ",")
 	for _, item := range items {
 		itemValue := strings.TrimSpace(item)
+
+		if itemValue == "" {
+			continue
+		}
 
 		if _, found := strMap[itemValue]; !found {
 			strMap[itemValue] = true


### PR DESCRIPTION
This change implements the ability to specify multiple listen addresses. This allows the application to listen on different interfaces or ports simultaneously, or a combination of IP addresses and Unix sockets.

Closes #3343

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read this document: https://miniflux.app/faq.html#pull-request
