### PR TITLE
perf(sanitizer): use a switch-case instead of a map

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -180,12 +180,6 @@ var (
 		"hack":   {}, // https://apps.apple.com/it/app/hack-for-hacker-news-reader/id1464477788?l=en-GB
 	}
 
-	blockedTags = map[string]struct{}{
-		"noscript": {},
-		"script":   {},
-		"style":    {},
-	}
-
 	dataAttributeAllowedPrefixes = []string{
 		"data:image/avif",
 		"data:image/apng",
@@ -537,8 +531,12 @@ func rewriteIframeURL(link string) string {
 }
 
 func isBlockedTag(tagName string) bool {
-	_, ok := blockedTags[tagName]
-	return ok
+	switch tagName {
+	case "noscript", "script", "style":
+		return true
+	default:
+		return false
+	}
 }
 
 func sanitizeSrcsetAttr(baseURL, value string) string {


### PR DESCRIPTION
This removes a heap allocation, and should be way faster. It also makes the code shorted/simpler.