### PR TITLE
refactor(sanitizer): remove two useless `www.` prefixes

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -134,8 +134,8 @@ var (
 		"stats.wordpress.com",
 		"twitter.com/intent/tweet",
 		"twitter.com/share",
-		"www.facebook.com/sharer.php",
-		"www.linkedin.com/shareArticle",
+		"facebook.com/sharer.php",
+		"linkedin.com/shareArticle",
 	}
 
 	validURISchemes = map[string]struct{}{


### PR DESCRIPTION
No need to have those prefixes, as the check is for substrings, so removing them will improve the amount of matches.