### PR TITLE
perf(reader): use a non-cryptographic hash when possible

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -11,18 +11,22 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 
 	"golang.org/x/crypto/bcrypt"
 )
 
-// HashFromBytes returns a SHA-256 checksum of the input.
+// HashFromBytes returns a non-cryptographic checksum of the input.
 func HashFromBytes(value []byte) string {
-	return fmt.Sprintf("%x", sha256.Sum256(value))
+	h := fnv.New128a()
+	h.Write(value)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
-// Hash returns a SHA-256 checksum of a string.
-func Hash(value string) string {
-	return HashFromBytes([]byte(value))
+// SHA256 returns a SHA-256 checksum of a string.
+func SHA256(value string) string {
+	h := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(h[:])
 }
 
 // GenerateRandomBytes returns random bytes.

--- a/internal/reader/atom/atom_03_adapter.go
+++ b/internal/reader/atom/atom_03_adapter.go
@@ -103,7 +103,7 @@ func (a *Atom03Adapter) BuildFeed(baseURL string) *model.Feed {
 		// Generate the entry hash.
 		for _, value := range []string{atomEntry.ID, atomEntry.Links.OriginalLink()} {
 			if value != "" {
-				entry.Hash = crypto.Hash(value)
+				entry.Hash = crypto.SHA256(value)
 				break
 			}
 		}

--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -152,7 +152,7 @@ func (a *Atom10Adapter) populateEntries(siteURL string) model.Entries {
 		// Generate the entry hash.
 		for _, value := range []string{atomEntry.ID, atomEntry.Links.OriginalLink()} {
 			if value != "" {
-				entry.Hash = crypto.Hash(value)
+				entry.Hash = crypto.SHA256(value)
 				break
 			}
 		}

--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -161,7 +161,7 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		for _, value := range []string{item.ID, item.URL, item.ContentText + item.ContentHTML + item.Summary} {
 			value = strings.TrimSpace(value)
 			if value != "" {
-				entry.Hash = crypto.Hash(value)
+				entry.Hash = crypto.SHA256(value)
 				break
 			}
 		}

--- a/internal/reader/rdf/adapter.go
+++ b/internal/reader/rdf/adapter.go
@@ -80,7 +80,7 @@ func (r *RDFAdapter) BuildFeed(baseURL string) *model.Feed {
 			hashValue = item.Title + item.Description // Fallback to the title and description if the link is empty.
 		}
 
-		entry.Hash = crypto.Hash(hashValue)
+		entry.Hash = crypto.SHA256(hashValue)
 
 		// Populate the entry date.
 		entry.Date = time.Now()

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -104,11 +104,11 @@ func (r *RSSAdapter) BuildFeed(baseURL string) *model.Feed {
 		// Generate the entry hash.
 		switch {
 		case item.GUID.Data != "":
-			entry.Hash = crypto.Hash(item.GUID.Data)
+			entry.Hash = crypto.SHA256(item.GUID.Data)
 		case entryURL != "":
-			entry.Hash = crypto.Hash(entryURL)
+			entry.Hash = crypto.SHA256(entryURL)
 		default:
-			entry.Hash = crypto.Hash(entry.Title + entry.Content)
+			entry.Hash = crypto.SHA256(entry.Title + entry.Content)
 		}
 
 		// Find CommentsURL if defined.


### PR DESCRIPTION
There is no need to use SHA256 everywhere, especially on small inputs where we don't care about its cryptographic properties.

This commit has the side-effect of invalidating all favicons saved in the database, which is desirable to benefit from the resize process implemented in 777d0dd2, as it didn't apply retro-actively.

We're also making use of hex.EncodeToString instead of fmt.Sprintf, as it's marginally faster.

Note that we can't change the usage of sha256 for feed.Hash as it's used to deduplicate entries in the database.