### PR TITLE
Revert "perf(storage): take advantage of entries_feed_id_hash_key in updateEntry"

### DIFF
--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -168,7 +168,6 @@ func (s *Storage) createEntry(tx *sql.Tx, entry *model.Entry) error {
 // Note: we do not update the published date because some feeds do not contains any date,
 // it default to time.Now() which could change the order of items on the history page.
 func (s *Storage) updateEntry(tx *sql.Tx, entry *model.Entry) error {
-	// Note: This query uses entries_feed_id_hash_key index (filtering on user_id is not necessary).
 	query := `
 		UPDATE
 			entries
@@ -182,7 +181,7 @@ func (s *Storage) updateEntry(tx *sql.Tx, entry *model.Entry) error {
 			document_vectors = setweight(to_tsvector(left(coalesce($1, ''), 500000)), 'A') || setweight(to_tsvector(left(coalesce($4, ''), 500000)), 'B'),
 			tags=$10
 		WHERE
-			feed_id=$8 AND hash=$9
+			user_id=$7 AND feed_id=$8 AND hash=$9
 		RETURNING
 			id
 	`
@@ -228,7 +227,6 @@ func (s *Storage) entryExists(tx *sql.Tx, entry *model.Entry) (bool, error) {
 
 func (s *Storage) IsNewEntry(feedID int64, entryHash string) bool {
 	var result bool
-	// Note: This query uses entries_feed_id_hash_key index (filtering on user_id is not necessary).
 	s.db.QueryRow(`SELECT true FROM entries WHERE feed_id=$1 AND hash=$2`, feedID, entryHash).Scan(&result)
 	return !result
 }


### PR DESCRIPTION
This reverts commit 6527c0430799213afb1fc06e04ff922f8e0b6ffd.