### PR TITLE
perf(reader): minify content even further

### DIFF
--- a/internal/reader/processor/utils.go
+++ b/internal/reader/processor/utils.go
@@ -61,8 +61,11 @@ func minifyContent(content string) string {
 
 	// Options required to avoid breaking the HTML content.
 	m.Add("text/html", &html.Minifier{
-		KeepEndTags: true,
-		KeepQuotes:  true,
+		KeepEndTags:         true,
+		KeepQuotes:          true,
+		KeepComments:        false,
+		KeepSpecialComments: false,
+		KeepDefaultAttrVals: false,
 	})
 
 	if minifiedHTML, err := m.String("text/html", content); err == nil {


### PR DESCRIPTION
There is no need to keep comments (conditionals or not, as IE isn't a thing anymore), nor default attribute values.