### PR TITLE
refactor(misc): Use proper slog.XXX instead of slog.Any

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -1092,7 +1092,7 @@ func (h *handler) handleReadingListStreamHandler(w http.ResponseWriter, r *http.
 				slog.String("handler", "handleReadingListStreamHandler"),
 				slog.String("client_ip", clientIP),
 				slog.String("user_agent", r.UserAgent()),
-				slog.Any("filter_type", s.Type),
+				slog.Int("filter_type", int(s.Type)),
 			)
 		}
 	}

--- a/internal/reader/filter/filter.go
+++ b/internal/reader/filter/filter.go
@@ -166,7 +166,7 @@ func logFilterAction(entry *model.Entry, feed *model.Feed, filterRule string, fi
 		slog.String("feed_url", feed.FeedURL),
 		slog.String("entry_url", entry.URL),
 		slog.String("filter_rule", filterRule),
-		slog.Any("filter_action", filterAction),
+		slog.String("filter_action", string(filterAction)),
 	)
 }
 

--- a/internal/ui/middleware.go
+++ b/internal/ui/middleware.go
@@ -40,13 +40,13 @@ func (m *middleware) handleUserSession(next http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 			} else {
 				slog.Debug("Redirecting to login page because no user session has been found",
-					slog.Any("url", r.RequestURI),
+					slog.String("url", r.RequestURI),
 				)
 				html.Redirect(w, r, route.Path(m.router, "login"))
 			}
 		} else {
 			slog.Debug("User session found",
-				slog.Any("url", r.RequestURI),
+				slog.String("url", r.RequestURI),
 				slog.Int64("user_id", session.UserID),
 				slog.Int64("user_session_id", session.ID),
 			)
@@ -102,7 +102,7 @@ func (m *middleware) handleAppSession(next http.Handler) http.Handler {
 
 			if !crypto.ConstantTimeCmp(session.Data.CSRF, formValue) && !crypto.ConstantTimeCmp(session.Data.CSRF, headerValue) {
 				slog.Warn("Invalid or missing CSRF token",
-					slog.Any("url", r.RequestURI),
+					slog.String("url", r.RequestURI),
 					slog.String("form_csrf", formValue),
 					slog.String("header_csrf", headerValue),
 				)
@@ -141,7 +141,7 @@ func (m *middleware) getAppSessionValueFromCookie(r *http.Request) *model.Sessio
 	session, err := m.store.AppSession(cookieValue)
 	if err != nil {
 		slog.Debug("Unable to fetch app session from the database; another session will be created",
-			slog.Any("cookie_value", cookieValue),
+			slog.String("cookie_value", cookieValue),
 			slog.Any("error", err),
 		)
 		return nil
@@ -185,7 +185,7 @@ func (m *middleware) getUserSessionFromCookie(r *http.Request) *model.UserSessio
 	session, err := m.store.UserSessionByToken(cookieValue)
 	if err != nil {
 		slog.Error("Unable to fetch user session from the database",
-			slog.Any("cookie_value", cookieValue),
+			slog.String("cookie_value", cookieValue),
 			slog.Any("error", err),
 		)
 		return nil


### PR DESCRIPTION
This has close to no impact for now, as our slog.Debug/Info/... are escaping their parameters to the heap, but using proper typing instead of Any allows to skip some reflection-based computation, making things marginally faster, and removing the corresponding heap escape.
