### PR TITLE
refactor(mediaproxy): simplify shouldProxy

### DIFF
--- a/internal/mediaproxy/rewriter.go
+++ b/internal/mediaproxy/rewriter.go
@@ -108,6 +108,14 @@ func proxifySourceSet(element *goquery.Selection, router *mux.Router, proxifyFun
 }
 
 func shouldProxy(attrValue, proxyOption string) bool {
-	return !strings.HasPrefix(attrValue, "data:") &&
-		(proxyOption == "all" || !urllib.IsHTTPS(attrValue))
+	if strings.HasPrefix(attrValue, "data:") {
+		return false
+	}
+	if proxyOption == "all" {
+		return true
+	}
+	if !urllib.IsHTTPS(attrValue) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
The original function was non-trivial to understand, as `!A && (B || !C)` isn't easily grokable by humans.