### PR TITLE
refactor(proxyrotator): simplify mutex handling

### DIFF
--- a/internal/proxyrotator/proxyrotator.go
+++ b/internal/proxyrotator/proxyrotator.go
@@ -38,23 +38,19 @@ func NewProxyRotator(proxyURLs []string) (*ProxyRotator, error) {
 
 // GetNextProxy returns the next proxy in the rotation.
 func (pr *ProxyRotator) GetNextProxy() *url.URL {
-	pr.mutex.Lock()
-	defer pr.mutex.Unlock()
-
 	if len(pr.proxies) == 0 {
 		return nil
 	}
 
+	pr.mutex.Lock()
 	proxy := pr.proxies[pr.currentIndex]
 	pr.currentIndex = (pr.currentIndex + 1) % len(pr.proxies)
+	pr.mutex.Unlock()
 
 	return proxy
 }
 
 // HasProxies checks if there are any proxies available in the rotator.
 func (pr *ProxyRotator) HasProxies() bool {
-	pr.mutex.Lock()
-	defer pr.mutex.Unlock()
-
 	return len(pr.proxies) > 0
 }


### PR DESCRIPTION
There is no need to use a mutex to check the length of the proxies list, as it's read-only during the whole lifetime of a ProxyRotator structure. Moreover, it's a bit clearer to explicitly wrap the 2 lines of mutex-needing operations between a Lock/Unlock instead of using a defer.