### PR TITLE
perf(readability): speed up ExtractedContent

### DIFF
--- a/internal/reader/readability/readability.go
+++ b/internal/reader/readability/readability.go
@@ -86,8 +86,8 @@ func ExtractContent(page io.Reader) (baseURL string, extractedContent string, er
 
 	document.Find("script,style").Remove()
 
-	transformMisusedDivsIntoParagraphs(document)
 	removeUnlikelyCandidates(document)
+	transformMisusedDivsIntoParagraphs(document)
 
 	candidates := getCandidates(document)
 	topCandidate := getTopCandidate(document, candidates)


### PR DESCRIPTION
As removeUnlikelyCandidates is the slowest function called by ExtractContent, it makes sens to call it as late as possible, after other functions have trimmed the selection as much as possible.

<img width="2357" height="455" alt="image" src="https://github.com/user-attachments/assets/da037e9f-adbf-42df-846f-9396b8fd988a" />
