### PR TITLE
perf(rewrite): anchor the rewrite regex

### DIFF
--- a/internal/reader/rewrite/url_rewrite.go
+++ b/internal/reader/rewrite/url_rewrite.go
@@ -10,38 +10,40 @@ import (
 	"miniflux.app/v2/internal/model"
 )
 
-var customReplaceRuleRegex = regexp.MustCompile(`rewrite\("([^"]+)"\|"([^"]+)"\)`)
+var customReplaceRuleRegex = regexp.MustCompile(`^rewrite\("([^"]+)"\|"([^"]+)"\)$`)
 
 func RewriteEntryURL(feed *model.Feed, entry *model.Entry) string {
-	var rewrittenURL = entry.URL
-	if feed.UrlRewriteRules != "" {
-		parts := customReplaceRuleRegex.FindStringSubmatch(feed.UrlRewriteRules)
+	if feed.UrlRewriteRules == "" {
+		return entry.URL
+	}
 
-		if len(parts) >= 3 {
-			re, err := regexp.Compile(parts[1])
-			if err != nil {
-				slog.Error("Failed on regexp compilation",
-					slog.String("url_rewrite_rules", feed.UrlRewriteRules),
-					slog.Any("error", err),
-				)
-				return rewrittenURL
-			}
-			rewrittenURL = re.ReplaceAllString(entry.URL, parts[2])
-			slog.Debug("Rewriting entry URL",
-				slog.String("original_entry_url", entry.URL),
-				slog.String("rewritten_entry_url", rewrittenURL),
-				slog.Int64("feed_id", feed.ID),
-				slog.String("feed_url", feed.FeedURL),
-			)
-		} else {
-			slog.Debug("Cannot find search and replace terms for replace rule",
-				slog.String("original_entry_url", entry.URL),
-				slog.String("rewritten_entry_url", rewrittenURL),
-				slog.Int64("feed_id", feed.ID),
-				slog.String("feed_url", feed.FeedURL),
+	var rewrittenURL = entry.URL
+	parts := customReplaceRuleRegex.FindStringSubmatch(feed.UrlRewriteRules)
+
+	if len(parts) == 3 {
+		re, err := regexp.Compile(parts[1])
+		if err != nil {
+			slog.Error("Failed on regexp compilation",
 				slog.String("url_rewrite_rules", feed.UrlRewriteRules),
+				slog.Any("error", err),
 			)
+			return rewrittenURL
 		}
+		rewrittenURL = re.ReplaceAllString(entry.URL, parts[2])
+		slog.Debug("Rewriting entry URL",
+			slog.String("original_entry_url", entry.URL),
+			slog.String("rewritten_entry_url", rewrittenURL),
+			slog.Int64("feed_id", feed.ID),
+			slog.String("feed_url", feed.FeedURL),
+		)
+	} else {
+		slog.Debug("Cannot find search and replace terms for replace rule",
+			slog.String("original_entry_url", entry.URL),
+			slog.String("rewritten_entry_url", rewrittenURL),
+			slog.Int64("feed_id", feed.ID),
+			slog.String("feed_url", feed.FeedURL),
+			slog.String("url_rewrite_rules", feed.UrlRewriteRules),
+		)
 	}
 
 	return rewrittenURL


### PR DESCRIPTION
There is no need to try to match the regexp over the whole input, having it anchored is enough. If we feel extra-lenient, we might strip spaces in front/tail, but I don't think it's necessary.

This commit also invert a condition to reduce the level of nested indentation, and make a condition stricter.