### PR TITLE
feat(integrations): automatically disable googlereader/fever when not used

### DIFF
--- a/internal/fever/handler.go
+++ b/internal/fever/handler.go
@@ -25,7 +25,9 @@ func Serve(router *mux.Router, store *storage.Storage) {
 	handler := &handler{store, router}
 
 	sr := router.PathPrefix("/fever").Subrouter()
-	sr.Use(newMiddleware(store).serve)
+	middleware := newMiddleware(store)
+	sr.Use(middleware.maybeUnauthorizedFever)
+	sr.Use(middleware.serve)
 	sr.HandleFunc("/", handler.serve).Name("feverEndpoint")
 }
 

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -49,6 +49,7 @@ func Serve(router *mux.Router, store *storage.Storage) {
 	sr := router.PathPrefix("/reader/api/0").Subrouter()
 	sr.Use(middleware.handleCORS)
 	sr.Use(middleware.apiKeyAuth)
+	sr.Use(middleware.maybeUnauthorizedGoogleReader)
 	sr.Methods(http.MethodOptions)
 	sr.HandleFunc("/token", handler.tokenHandler).Methods(http.MethodGet).Name("Token")
 	sr.HandleFunc("/edit-tag", handler.editTagHandler).Methods(http.MethodPost).Name("EditTag")

--- a/internal/storage/integration.go
+++ b/internal/storage/integration.go
@@ -52,6 +52,21 @@ func (s *Storage) UserByFeverToken(token string) (*model.User, error) {
 	}
 }
 
+func (s *Storage) IsFeverUsed() (bool, error) {
+	query := `SELECT true FROM integrations WHERE fever_enabled=true LIMIT 1`
+	result := false
+	err := s.db.QueryRow(query).Scan(&result)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf(`store: unable to check if fever is used: %v`, err)
+	}
+
+	return result, nil
+}
+
 // GoogleReaderUserCheckPassword validates the Google Reader hashed password.
 func (s *Storage) GoogleReaderUserCheckPassword(username, password string) error {
 	var hash string
@@ -103,6 +118,21 @@ func (s *Storage) GoogleReaderUserGetIntegration(username string) (*model.Integr
 	}
 
 	return &integration, nil
+}
+
+func (s *Storage) IsGoogleReaderUsed() (bool, error) {
+	query := `SELECT true FROM integrations WHERE googlereader_enabled=true LIMIT 1`
+	var result bool
+	err := s.db.QueryRow(query).Scan(&result)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf(`store: unable to check if Google Reader is used: %v`, err)
+	}
+
+	return result, nil
 }
 
 // Integration returns user integration settings.


### PR DESCRIPTION
When there is no user of Fever/GoogleReader, there is no need to expose their endpoints. This reduces quite a bit the exposition surface of miniflux, while not breaking any existing deployments, and is pretty self-contained.