### PR TITLE
feat(rewrite): add a rule to remove useless heading images on phoronix

### DIFF
--- a/internal/reader/rewrite/content_rewrite_rules.go
+++ b/internal/reader/rewrite/content_rewrite_rules.go
@@ -5,6 +5,8 @@ package rewrite // import "miniflux.app/v2/internal/reader/rewrite"
 
 // List of predefined rewrite rules (alphabetically sorted)
 // domain => rule name
+//
+// See https://miniflux.app/docs/rules.html#rewrite-rules
 var predefinedRules = map[string]string{
 	"abstrusegoose.com":      "add_image_title",
 	"amazingsuperpowers.com": "add_image_title",
@@ -25,6 +27,7 @@ var predefinedRules = map[string]string{
 	"oglaf.com":              `replace("media.oglaf.com/story/tt(.+).gif"|"media.oglaf.com/comic/$1.jpg"),add_image_title`,
 	"optipess.com":           "add_image_title",
 	"peebleslab.com":         "add_image_title",
+	"phoronix.com":           `remove("img[src^='/assets/categories/']")`,
 	"quantamagazine.org":     `add_youtube_video_from_id, remove("h6:not(.byline,.post__title__kicker), #comments, .next-post__content, .footer__section, figure .outer--content, script")`,
 	"qwantz.com":             "add_image_title,add_mailto_subject",
 	"sentfromthemoon.com":    "add_image_title",

--- a/internal/reader/rewrite/content_rewrite_test.go
+++ b/internal/reader/rewrite/content_rewrite_test.go
@@ -797,6 +797,23 @@ func TestRewriteRemoveCustom(t *testing.T) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
 	}
 }
+func TestRewriteRemoveQuotedSelector(t *testing.T) {
+	controlEntry := &model.Entry{
+		URL:     "https://example.org/article",
+		Title:   `A title`,
+		Content: `<div>Lorem Ipsum</div>`,
+	}
+	testEntry := &model.Entry{
+		URL:     "https://example.org/article",
+		Title:   `A title`,
+		Content: `<div>Lorem Ipsum<img alt="LINUX KERNEL" src="/assets/categories/linuxkernel.webp" width="100" height="100"></div>`,
+	}
+	ApplyContentRewriteRules(testEntry, `remove("img[src^='/assets/categories/']")`)
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}
 
 func TestRewriteAddCastopodEpisode(t *testing.T) {
 	controlEntry := &model.Entry{


### PR DESCRIPTION
Before:

<img width="1007" height="826" alt="image" src="https://github.com/user-attachments/assets/88f1fb8c-99da-487c-b02a-e84ded0b8305" />

After:

<img width="1007" height="826" alt="image" src="https://github.com/user-attachments/assets/e6f3acef-6bb9-499d-bd33-e5ae2626c14a" />
