### PR TITLE
refactor(config): don't check random.Read's return value

### DIFF
--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -165,9 +165,7 @@ func (p *parser) parseLines(lines []string) (err error) {
 			p.opts.mediaProxyResourceTypes = parseStringList(value, []string{defaultMediaResourceTypes})
 		case "MEDIA_PROXY_PRIVATE_KEY":
 			randomKey := make([]byte, 16)
-			if _, err := rand.Read(randomKey); err != nil {
-				return fmt.Errorf("config: unable to generate random key: %w", err)
-			}
+			rand.Read(randomKey)
 			p.opts.mediaProxyPrivateKey = parseBytes(value, randomKey)
 		case "MEDIA_PROXY_CUSTOM_URL":
 			p.opts.mediaProxyCustomURL = parseString(value, defaultMediaProxyURL)


### PR DESCRIPTION
As stated in the documentation:

> Read calls io.ReadFull on Reader and crashes the program irrecoverably if an
error is returned. The default Reader uses operating system APIs that are documented to never return an error on all but legacy Linux systems. # Please enter the commit message for your changes.