### PR TITLE
perf(refresh): minor optimization for FetchJobs

### DIFF
--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -55,15 +55,15 @@ func (b *BatchBuilder) WithNextCheckExpired() *BatchBuilder {
 }
 
 func (b *BatchBuilder) WithoutDisabledFeeds() *BatchBuilder {
-	b.conditions = append(b.conditions, "disabled is false")
+	b.conditions = append(b.conditions, "disabled IS false")
 	return b
 }
 
-func (b *BatchBuilder) FetchJobs() (jobs model.JobList, err error) {
+func (b *BatchBuilder) FetchJobs() (model.JobList, error) {
 	query := `SELECT id, user_id FROM feeds`
 
 	if len(b.conditions) > 0 {
-		query += fmt.Sprintf(" WHERE %s", strings.Join(b.conditions, " AND "))
+		query += " WHERE " + strings.Join(b.conditions, " AND ")
 	}
 
 	if b.limit > 0 {
@@ -75,6 +75,8 @@ func (b *BatchBuilder) FetchJobs() (jobs model.JobList, err error) {
 		return nil, fmt.Errorf(`store: unable to fetch batch of jobs: %v`, err)
 	}
 	defer rows.Close()
+
+	jobs := make(model.JobList, 0, b.limit)
 
 	for rows.Next() {
 		var job model.Job

--- a/internal/ui/feed_refresh.go
+++ b/internal/ui/feed_refresh.go
@@ -33,7 +33,6 @@ func (h *handler) refreshFeed(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) refreshAllFeeds(w http.ResponseWriter, r *http.Request) {
-	userID := request.UserID(r)
 	printer := locale.NewPrinter(request.UserLanguage(r))
 	sess := session.New(h.store, request.SessionID(r))
 
@@ -42,6 +41,7 @@ func (h *handler) refreshAllFeeds(w http.ResponseWriter, r *http.Request) {
 		time := config.Opts.ForceRefreshInterval()
 		sess.NewFlashErrorMessage(printer.Plural("alert.too_many_feeds_refresh", time, time))
 	} else {
+		userID := request.UserID(r)
 		// We allow the end-user to force refresh all its feeds
 		// without taking into consideration the number of errors.
 		batchBuilder := h.store.NewBatchBuilder()


### PR DESCRIPTION
- Replace a call to fmt.Sprintf with a concatenation
- Explicit declaration of return values in FetchJobs
- Initialize the size of FetchJobs return value to b.limit: when b.limit is used, which is most of the time, this avoid resizing the slice, and when it isn't, the size of the map is set to 0, which is equivalent to the previous situation anyway.
- Move a call to `request.UserID(r)` to a lower scope.