### PR TITLE
perf(storage): pair all `SELECT true` with `LIMIT 1`

### DIFF
--- a/internal/storage/category.go
+++ b/internal/storage/category.go
@@ -31,7 +31,7 @@ func (s *Storage) CategoryTitleExists(userID int64, title string) bool {
 // CategoryIDExists checks if the given category exists into the database.
 func (s *Storage) CategoryIDExists(userID, categoryID int64) bool {
 	var result bool
-	query := `SELECT true FROM categories WHERE user_id=$1 AND id=$2`
+	query := `SELECT true FROM categories WHERE user_id=$1 AND id=$2 LIMIT 1`
 	s.db.QueryRow(query, userID, categoryID).Scan(&result)
 	return result
 }

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -226,7 +226,7 @@ func (s *Storage) entryExists(tx *sql.Tx, entry *model.Entry) (bool, error) {
 	var result bool
 
 	// Note: This query uses entries_feed_id_hash_key index (filtering on user_id is not necessary).
-	err := tx.QueryRow(`SELECT true FROM entries WHERE feed_id=$1 AND hash=$2`, entry.FeedID, entry.Hash).Scan(&result)
+	err := tx.QueryRow(`SELECT true FROM entries WHERE feed_id=$1 AND hash=$2 LIMIT 1`, entry.FeedID, entry.Hash).Scan(&result)
 
 	if err != nil && err != sql.ErrNoRows {
 		return result, fmt.Errorf(`store: unable to check if entry exists: %v`, err)
@@ -237,7 +237,7 @@ func (s *Storage) entryExists(tx *sql.Tx, entry *model.Entry) (bool, error) {
 
 func (s *Storage) IsNewEntry(feedID int64, entryHash string) bool {
 	var result bool
-	s.db.QueryRow(`SELECT true FROM entries WHERE feed_id=$1 AND hash=$2`, feedID, entryHash).Scan(&result)
+	s.db.QueryRow(`SELECT true FROM entries WHERE feed_id=$1 AND hash=$2 LIMIT 1`, feedID, entryHash).Scan(&result)
 	return !result
 }
 

--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -35,7 +35,7 @@ func (l byStateAndName) Less(i, j int) bool {
 // FeedExists checks if the given feed exists.
 func (s *Storage) FeedExists(userID, feedID int64) bool {
 	var result bool
-	query := `SELECT true FROM feeds WHERE user_id=$1 AND id=$2`
+	query := `SELECT true FROM feeds WHERE user_id=$1 AND id=$2 LIMIT 1`
 	s.db.QueryRow(query, userID, feedID).Scan(&result)
 	return result
 }
@@ -43,7 +43,7 @@ func (s *Storage) FeedExists(userID, feedID int64) bool {
 // CategoryFeedExists returns true if the given feed exists that belongs to the given category.
 func (s *Storage) CategoryFeedExists(userID, categoryID, feedID int64) bool {
 	var result bool
-	query := `SELECT true FROM feeds WHERE user_id=$1 AND category_id=$2 AND id=$3`
+	query := `SELECT true FROM feeds WHERE user_id=$1 AND category_id=$2 AND id=$3 LIMIT 1`
 	s.db.QueryRow(query, userID, categoryID, feedID).Scan(&result)
 	return result
 }
@@ -51,7 +51,7 @@ func (s *Storage) CategoryFeedExists(userID, categoryID, feedID int64) bool {
 // FeedURLExists checks if feed URL already exists.
 func (s *Storage) FeedURLExists(userID int64, feedURL string) bool {
 	var result bool
-	query := `SELECT true FROM feeds WHERE user_id=$1 AND feed_url=$2`
+	query := `SELECT true FROM feeds WHERE user_id=$1 AND feed_url=$2 LIMIT 1`
 	s.db.QueryRow(query, userID, feedURL).Scan(&result)
 	return result
 }
@@ -59,7 +59,7 @@ func (s *Storage) FeedURLExists(userID int64, feedURL string) bool {
 // AnotherFeedURLExists checks if the user a duplicated feed.
 func (s *Storage) AnotherFeedURLExists(userID, feedID int64, feedURL string) bool {
 	var result bool
-	query := `SELECT true FROM feeds WHERE id <> $1 AND user_id=$2 AND feed_url=$3`
+	query := `SELECT true FROM feeds WHERE id <> $1 AND user_id=$2 AND feed_url=$3 LIMIT 1`
 	s.db.QueryRow(query, feedID, userID, feedURL).Scan(&result)
 	return result
 }

--- a/internal/storage/icon.go
+++ b/internal/storage/icon.go
@@ -15,7 +15,7 @@ import (
 // HasFeedIcon checks if the given feed has an icon.
 func (s *Storage) HasFeedIcon(feedID int64) bool {
 	var result bool
-	query := `SELECT true FROM feed_icons WHERE feed_id=$1`
+	query := `SELECT true FROM feed_icons WHERE feed_id=$1 LIMIT 1`
 	s.db.QueryRow(query, feedID).Scan(&result)
 	return result
 }

--- a/internal/storage/integration.go
+++ b/internal/storage/integration.go
@@ -13,7 +13,7 @@ import (
 
 // HasDuplicateFeverUsername checks if another user have the same Fever username.
 func (s *Storage) HasDuplicateFeverUsername(userID int64, feverUsername string) bool {
-	query := `SELECT true FROM integrations WHERE user_id != $1 AND fever_username=$2`
+	query := `SELECT true FROM integrations WHERE user_id != $1 AND fever_username=$2 LIMIT 1`
 	var result bool
 	s.db.QueryRow(query, userID, feverUsername).Scan(&result)
 	return result
@@ -21,7 +21,7 @@ func (s *Storage) HasDuplicateFeverUsername(userID int64, feverUsername string) 
 
 // HasDuplicateGoogleReaderUsername checks if another user have the same Google Reader username.
 func (s *Storage) HasDuplicateGoogleReaderUsername(userID int64, googleReaderUsername string) bool {
-	query := `SELECT true FROM integrations WHERE user_id != $1 AND googlereader_username=$2`
+	query := `SELECT true FROM integrations WHERE user_id != $1 AND googlereader_username=$2 LIMIT 1`
 	var result bool
 	s.db.QueryRow(query, userID, googleReaderUsername).Scan(&result)
 	return result

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -42,14 +42,14 @@ func (s *Storage) SetLastLogin(userID int64) error {
 // UserExists checks if a user exists by using the given username.
 func (s *Storage) UserExists(username string) bool {
 	var result bool
-	s.db.QueryRow(`SELECT true FROM users WHERE username=LOWER($1)`, username).Scan(&result)
+	s.db.QueryRow(`SELECT true FROM users WHERE username=LOWER($1) LIMIT 1`, username).Scan(&result)
 	return result
 }
 
 // AnotherUserExists checks if another user exists with the given username.
 func (s *Storage) AnotherUserExists(userID int64, username string) bool {
 	var result bool
-	s.db.QueryRow(`SELECT true FROM users WHERE id != $1 AND username=LOWER($2)`, userID, username).Scan(&result)
+	s.db.QueryRow(`SELECT true FROM users WHERE id != $1 AND username=LOWER($2) LIMIT 1`, userID, username).Scan(&result)
 	return result
 }
 
@@ -472,7 +472,7 @@ func (s *Storage) UserByField(field, value string) (*model.User, error) {
 // AnotherUserWithFieldExists returns true if a user has the value set for the given field.
 func (s *Storage) AnotherUserWithFieldExists(userID int64, field, value string) bool {
 	var result bool
-	s.db.QueryRow(fmt.Sprintf(`SELECT true FROM users WHERE id <> $1 AND %s=$2`, pq.QuoteIdentifier(field)), userID, value).Scan(&result)
+	s.db.QueryRow(fmt.Sprintf(`SELECT true FROM users WHERE id <> $1 AND %s=$2 LIMIT 1`, pq.QuoteIdentifier(field)), userID, value).Scan(&result)
 	return result
 }
 
@@ -750,7 +750,7 @@ func (s *Storage) CheckPassword(username, password string) error {
 // HasPassword returns true if the given user has a password defined.
 func (s *Storage) HasPassword(userID int64) (bool, error) {
 	var result bool
-	query := `SELECT true FROM users WHERE id=$1 AND password <> ''`
+	query := `SELECT true FROM users WHERE id=$1 AND password <> '' LIMIT 1`
 
 	err := s.db.QueryRow(query, userID).Scan(&result)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
Apparently, postgresql isn't smart enough to realize that once a true value value is found as part of a `SELECT true`, there is no need to scan the rest of the table, so we have to make this explicit. We could also have used the `SELECT EXISTS(…)` construct, but it's more verbose and I don't like it.