### PR TITLE
perf(api): speed up markFeedAsRead

### DIFF
--- a/internal/api/feed.go
+++ b/internal/api/feed.go
@@ -140,13 +140,7 @@ func (h *handler) markFeedAsRead(w http.ResponseWriter, r *http.Request) {
 	feedID := request.RouteInt64Param(r, "feedID")
 	userID := request.UserID(r)
 
-	feed, err := h.store.FeedByID(userID, feedID)
-	if err != nil {
-		json.NotFound(w, r)
-		return
-	}
-
-	if feed == nil {
+	if !h.store.FeedExists(userID, feedID) {
 		json.NotFound(w, r)
 		return
 	}


### PR DESCRIPTION
There is no need to get the whole feed data (involving a ton of JOIN operations) simply to check if it exists.