### PR TITLE
perf(storage): speed up marking a feed as read

### DIFF
--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"time"
 
 	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/model"
@@ -38,6 +39,17 @@ func (s *Storage) FeedExists(userID, feedID int64) bool {
 	query := `SELECT true FROM feeds WHERE user_id=$1 AND id=$2 LIMIT 1`
 	s.db.QueryRow(query, userID, feedID).Scan(&result)
 	return result
+}
+
+// CheckedAt returns when the feed was last checked.
+func (s *Storage) CheckedAt(userID, feedID int64) (time.Time, error) {
+	var result time.Time
+	query := `SELECT checked_at FROM feeds WHERE user_id=$1 AND id=$2 LIMIT 1`
+	err := s.db.QueryRow(query, userID, feedID).Scan(&result)
+	if err != nil {
+		return time.Now(), err
+	}
+	return result, nil
 }
 
 // CategoryFeedExists returns true if the given feed exists that belongs to the given category.

--- a/internal/ui/feed_mark_as_read.go
+++ b/internal/ui/feed_mark_as_read.go
@@ -15,19 +15,13 @@ func (h *handler) markFeedAsRead(w http.ResponseWriter, r *http.Request) {
 	feedID := request.RouteInt64Param(r, "feedID")
 	userID := request.UserID(r)
 
-	feed, err := h.store.FeedByID(userID, feedID)
-
+	checkedAt, err := h.store.CheckedAt(userID, feedID)
 	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
-
-	if feed == nil {
 		html.NotFound(w, r)
 		return
 	}
 
-	if err = h.store.MarkFeedAsRead(userID, feedID, feed.CheckedAt); err != nil {
+	if err = h.store.MarkFeedAsRead(userID, feedID, checkedAt); err != nil {
 		html.ServerError(w, r, err)
 		return
 	}


### PR DESCRIPTION
There is no need to perform a heavy-weight SQL query gathering all the information available on a feed when we're only interested in its last check timestamp.