### PR TITLE
refactor(static): simplify the code for static reources

### DIFF
--- a/internal/ui/static_javascript.go
+++ b/internal/ui/static_javascript.go
@@ -21,14 +21,14 @@ const licenseSuffix = "\n//@license-end"
 
 func (h *handler) showJavascript(w http.ResponseWriter, r *http.Request) {
 	filename := request.RouteStringParam(r, "name")
-	etag, found := static.JavascriptBundleChecksums[filename]
+	js, found := static.JavascriptBundles[filename]
 	if !found {
 		html.NotFound(w, r)
 		return
 	}
 
-	response.New(w, r).WithCaching(etag, 48*time.Hour, func(b *response.Builder) {
-		contents := static.JavascriptBundles[filename]
+	response.New(w, r).WithCaching(js.Checksum, 48*time.Hour, func(b *response.Builder) {
+		contents := js.Data
 
 		if filename == "service-worker" {
 			variables := fmt.Sprintf(`const OFFLINE_URL=%q;`, route.Path(h.router, "offline"))

--- a/internal/ui/static_stylesheet.go
+++ b/internal/ui/static_stylesheet.go
@@ -15,15 +15,15 @@ import (
 
 func (h *handler) showStylesheet(w http.ResponseWriter, r *http.Request) {
 	filename := request.RouteStringParam(r, "name")
-	etag, found := static.StylesheetBundleChecksums[filename]
+	m, found := static.StylesheetBundles[filename]
 	if !found {
 		html.NotFound(w, r)
 		return
 	}
 
-	response.New(w, r).WithCaching(etag, 48*time.Hour, func(b *response.Builder) {
+	response.New(w, r).WithCaching(m.Checksum, 48*time.Hour, func(b *response.Builder) {
 		b.WithHeader("Content-Type", "text/css; charset=utf-8")
-		b.WithBody(static.StylesheetBundles[filename])
+		b.WithBody(m.Data)
 		b.Write()
 	})
 }

--- a/internal/ui/view/view.go
+++ b/internal/ui/view/view.go
@@ -41,10 +41,10 @@ func New(tpl *template.Engine, r *http.Request, sess *session.Session) *View {
 		"flashErrorMessage":    sess.FlashErrorMessage(request.FlashErrorMessage(r)),
 		"theme":                theme,
 		"language":             request.UserLanguage(r),
-		"theme_checksum":       static.StylesheetBundleChecksums[theme],
-		"app_js_checksum":      static.JavascriptBundleChecksums["app"],
-		"sw_js_checksum":       static.JavascriptBundleChecksums["service-worker"],
-		"webauthn_js_checksum": static.JavascriptBundleChecksums["webauthn"],
+		"theme_checksum":       static.StylesheetBundles[theme].Checksum,
+		"app_js_checksum":      static.JavascriptBundles["app"].Checksum,
+		"sw_js_checksum":       static.JavascriptBundles["service-worker"].Checksum,
+		"webauthn_js_checksum": static.JavascriptBundles["webauthn"].Checksum,
 		"webAuthnEnabled":      config.Opts.WebAuthn(),
 	}}
 }


### PR DESCRIPTION
- Use a simple struct instead of two slices to store the data and the checksums of resources
- Remove a superfluous call to Sprintf
- Factorise presence check and data retrieval in some maps
- Size the maps when possible