### PR TITLE
perf(entries): remove some useless SQL queries

### DIFF
--- a/internal/api/entry.go
+++ b/internal/api/entry.go
@@ -152,12 +152,7 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 		json.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		json.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	for i := range entries {
 		entries[i].Content = mediaproxy.RewriteDocumentWithAbsoluteProxyURL(h.router, entries[i].Content)

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -1116,12 +1116,8 @@ func (h *handler) handleReadingListStreamHandler(w http.ResponseWriter, r *http.
 		formattedID := strconv.FormatInt(entryID, 10)
 		itemRefs = append(itemRefs, itemRef{ID: formattedID})
 	}
+	totalEntries := len(rawEntryIDs)
 
-	totalEntries, err := builder.CountEntries()
-	if err != nil {
-		json.ServerError(w, r, err)
-		return
-	}
 	continuation := 0
 	if len(itemRefs)+rm.Offset < totalEntries {
 		continuation = len(itemRefs) + rm.Offset
@@ -1155,11 +1151,8 @@ func (h *handler) handleStarredStreamHandler(w http.ResponseWriter, r *http.Requ
 		itemRefs = append(itemRefs, itemRef{ID: formattedID})
 	}
 
-	totalEntries, err := builder.CountEntries()
-	if err != nil {
-		json.ServerError(w, r, err)
-		return
-	}
+	totalEntries := len(rawEntryIDs)
+
 	continuation := 0
 	if len(itemRefs)+rm.Offset < totalEntries {
 		continuation = len(itemRefs) + rm.Offset
@@ -1193,11 +1186,7 @@ func (h *handler) handleReadStreamHandler(w http.ResponseWriter, r *http.Request
 		itemRefs = append(itemRefs, itemRef{ID: formattedID})
 	}
 
-	totalEntries, err := builder.CountEntries()
-	if err != nil {
-		json.ServerError(w, r, err)
-		return
-	}
+	totalEntries := len(rawEntryIDs)
 	continuation := 0
 	if len(itemRefs)+rm.Offset < totalEntries {
 		continuation = len(itemRefs) + rm.Offset
@@ -1248,12 +1237,7 @@ func (h *handler) handleFeedStreamHandler(w http.ResponseWriter, r *http.Request
 		itemRefs = append(itemRefs, itemRef{ID: formattedID})
 	}
 
-	totalEntries, err := builder.CountEntries()
-	if err != nil {
-		json.ServerError(w, r, err)
-		return
-	}
-
+	totalEntries := len(rawEntryIDs)
 	continuation := 0
 	if len(itemRefs)+rm.Offset < totalEntries {
 		continuation = len(itemRefs) + rm.Offset

--- a/internal/ui/bookmark_entries.go
+++ b/internal/ui/bookmark_entries.go
@@ -35,12 +35,7 @@ func (h *handler) showStarredPage(w http.ResponseWriter, r *http.Request) {
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/category_entries.go
+++ b/internal/ui/category_entries.go
@@ -47,12 +47,7 @@ func (h *handler) showCategoryEntriesPage(w http.ResponseWriter, r *http.Request
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/category_entries_all.go
+++ b/internal/ui/category_entries_all.go
@@ -47,12 +47,7 @@ func (h *handler) showCategoryEntriesAllPage(w http.ResponseWriter, r *http.Requ
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/category_entries_starred.go
+++ b/internal/ui/category_entries_starred.go
@@ -48,12 +48,7 @@ func (h *handler) showCategoryEntriesStarredPage(w http.ResponseWriter, r *http.
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/feed_entries.go
+++ b/internal/ui/feed_entries.go
@@ -47,12 +47,7 @@ func (h *handler) showFeedEntriesPage(w http.ResponseWriter, r *http.Request) {
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/feed_entries_all.go
+++ b/internal/ui/feed_entries_all.go
@@ -47,12 +47,7 @@ func (h *handler) showFeedEntriesAllPage(w http.ResponseWriter, r *http.Request)
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/history_entries.go
+++ b/internal/ui/history_entries.go
@@ -34,12 +34,7 @@ func (h *handler) showHistoryPage(w http.ResponseWriter, r *http.Request) {
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -39,12 +39,7 @@ func (h *handler) showSearchPage(w http.ResponseWriter, r *http.Request) {
 			html.ServerError(w, r, err)
 			return
 		}
-
-		entriesCount, err = builder.CountEntries()
-		if err != nil {
-			html.ServerError(w, r, err)
-			return
-		}
+		entriesCount = len(entries)
 	}
 
 	sess := session.New(h.store, request.SessionID(r))

--- a/internal/ui/shared_entries.go
+++ b/internal/ui/shared_entries.go
@@ -33,12 +33,7 @@ func (h *handler) sharedEntries(w http.ResponseWriter, r *http.Request) {
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)

--- a/internal/ui/tag_entries_all.go
+++ b/internal/ui/tag_entries_all.go
@@ -43,12 +43,7 @@ func (h *handler) showTagEntriesAllPage(w http.ResponseWriter, r *http.Request) 
 		html.ServerError(w, r, err)
 		return
 	}
-
-	count, err := builder.CountEntries()
-	if err != nil {
-		html.ServerError(w, r, err)
-		return
-	}
+	count := len(entries)
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)


### PR DESCRIPTION
When we're retrieving an Entries (which is a []Entry), there is no need to perform a SQL query to get their number, we can simply use len().