### PR TITLE
fix: URL detection incorrectly capturing newlines in media descriptions

### DIFF
--- a/internal/reader/media/media.go
+++ b/internal/reader/media/media.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var textLinkRegex = regexp.MustCompile(`(?mi)(\bhttps?://[^\s]+)[.]?(?:\s|$)`)
+var textLinkRegex = regexp.MustCompile(`(?mi)(\bhttps?://[^\s]+)`)
 
 // Specs: https://www.rssboard.org/media-rss
 type MediaItemElement struct {
@@ -154,8 +154,8 @@ func (d *Description) HTML() string {
 		return d.Description
 	}
 
-	content := strings.ReplaceAll(d.Description, "\n", "<br>")
-	return textLinkRegex.ReplaceAllString(content, `<a href="${1}">${1}</a>`)
+	content := textLinkRegex.ReplaceAllString(d.Description, `<a href="${1}">${1}</a>`)
+	return strings.ReplaceAll(content, "\n", "<br>")
 }
 
 // DescriptionList represents a list of "media:description" XML elements.

--- a/internal/reader/media/media_test.go
+++ b/internal/reader/media/media_test.go
@@ -83,6 +83,8 @@ func TestDescription(t *testing.T) {
 		{"", "", ""},
 		{"html", "a <b>c</b>", "a <b>c</b>"},
 		{"plain", "a\nhttp://www.example.org/", `a<br><a href="http://www.example.org/">http://www.example.org/</a>`},
+		{"plain", "Link: https://example.com/path\n\nAnother: https://example.org",
+			`Link: <a href="https://example.com/path">https://example.com/path</a><br><br>Another: <a href="https://example.org">https://example.org</a>`},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
The regex was capturing `<br>` tags as part of the URL -- instead, apply URL linkification before converting newlines to `<br>` tags and make the regex not consume trailing whitespace.

Before:
<img width="691" height="453" alt="Screenshot 2025-08-08 at 13 09 48" src="https://github.com/user-attachments/assets/fd6a79c0-87f1-4631-8efa-03c3fac84f7d" />

After:
<img width="689" height="454" alt="Screenshot 2025-08-08 at 13 09 53" src="https://github.com/user-attachments/assets/7f92ea69-cd04-42de-97ad-0c847a8026e1" />


- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
