### PR TITLE
perf(static): minimize the SVG

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -156,16 +156,16 @@ func Parse() {
 		slog.Info("The default value for DATABASE_URL is used")
 	}
 
-	if err := static.CalculateBinaryFileChecksums(); err != nil {
-		printErrorAndExit(fmt.Errorf("unable to calculate binary file checksums: %v", err))
+	if err := static.GenerateBinaryBundles(); err != nil {
+		printErrorAndExit(fmt.Errorf("unable to generate binary files bundle: %v", err))
 	}
 
 	if err := static.GenerateStylesheetsBundles(); err != nil {
-		printErrorAndExit(fmt.Errorf("unable to generate stylesheets bundles: %v", err))
+		printErrorAndExit(fmt.Errorf("unable to generate stylesheets bundle: %v", err))
 	}
 
 	if err := static.GenerateJavascriptBundles(); err != nil {
-		printErrorAndExit(fmt.Errorf("unable to generate javascript bundles: %v", err))
+		printErrorAndExit(fmt.Errorf("unable to generate javascript bundle: %v", err))
 	}
 
 	db, err := database.NewConnectionPool(

--- a/internal/ui/static/bin/sprite.svg
+++ b/internal/ui/static/bin/sprite.svg
@@ -1,29 +1,7 @@
 <!--
-
-MIT License
-
-Copyright (c) 2020 Paweł Kuna
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+SPDX-FileCopyrightText: Copyright (c) 2020-2025 Paweł Kuna
+SPDX-License-Identifier: MIT
 Source: https://github.com/tabler/tabler-icons
-
 -->
 <svg xmlns="http://www.w3.org/2000/svg">
     <symbol id="icon-read" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">

--- a/internal/ui/static_favicon.go
+++ b/internal/ui/static_favicon.go
@@ -13,22 +13,16 @@ import (
 )
 
 func (h *handler) showFavicon(w http.ResponseWriter, r *http.Request) {
-	etag, err := static.GetBinaryFileChecksum("favicon.ico")
-	if err != nil {
+	value, ok := static.BinaryBundles["favicon.ico"]
+	if !ok {
 		html.NotFound(w, r)
 		return
 	}
 
-	response.New(w, r).WithCaching(etag, 48*time.Hour, func(b *response.Builder) {
-		blob, err := static.LoadBinaryFile("favicon.ico")
-		if err != nil {
-			html.ServerError(w, r, err)
-			return
-		}
-
+	response.New(w, r).WithCaching(value.Checksum, 48*time.Hour, func(b *response.Builder) {
 		b.WithHeader("Content-Type", "image/x-icon")
 		b.WithoutCompression()
-		b.WithBody(blob)
+		b.WithBody(value.Data)
 		b.Write()
 	})
 }


### PR DESCRIPTION
Since tdewolff/minify supports SVG minimization, let's make use of it. As we need to keep the license in the SVG because we're nice netizens, we can at least use SPDX identifiers instead of using it verbatim.

This does save a couple of kB.