### PR TITLE
perf(storage): Use `ON CONFLICT` instead of 2 SQL requests

### DIFF
--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -131,6 +131,7 @@ func (s *Storage) createEntry(tx *sql.Tx, entry *model.Entry) error {
 				setweight(to_tsvector($11), 'A') || setweight(to_tsvector($12), 'B'),
 				$13
 			)
+		ON CONFLICT DO NOTHING
 		RETURNING
 			id, status, created_at, changed_at
 	`
@@ -163,8 +164,7 @@ func (s *Storage) createEntry(tx *sql.Tx, entry *model.Entry) error {
 	for _, enclosure := range entry.Enclosures {
 		enclosure.EntryID = entry.ID
 		enclosure.UserID = entry.UserID
-		err := s.createEnclosure(tx, enclosure)
-		if err != nil {
+		if err := s.createEnclosure(tx, enclosure); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -308,21 +308,11 @@ func (s *Storage) CreateFeed(feed *model.Feed) error {
 			return fmt.Errorf(`store: unable to start transaction: %v`, err)
 		}
 
-		entryExists, err := s.entryExists(tx, entry)
-		if err != nil {
+		if err := s.createEntry(tx, entry); err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
 				return fmt.Errorf(`store: unable to rollback transaction: %v (rolled back due to: %v)`, rollbackErr, err)
 			}
 			return err
-		}
-
-		if !entryExists {
-			if err := s.createEntry(tx, entry); err != nil {
-				if rollbackErr := tx.Rollback(); rollbackErr != nil {
-					return fmt.Errorf(`store: unable to rollback transaction: %v (rolled back due to: %v)`, rollbackErr, err)
-				}
-				return err
-			}
 		}
 
 		if err := tx.Commit(); err != nil {


### PR DESCRIPTION
There is no need to first check if an entry exist before inserting it, when we can simply use `ON CONFLICT DO NOTHING`. Even though this is in a transaction, it's still work being done for nothing, for every single entry.