### PR TITLE
perf(misc): use arrays instead of slices where possible

### DIFF
--- a/internal/http/request/client_ip.go
+++ b/internal/http/request/client_ip.go
@@ -11,7 +11,7 @@ import (
 
 // FindClientIP returns the client real IP address based on trusted Reverse-Proxy HTTP headers.
 func FindClientIP(r *http.Request) string {
-	headers := []string{"X-Forwarded-For", "X-Real-Ip"}
+	headers := [...]string{"X-Forwarded-For", "X-Real-Ip"}
 	for _, header := range headers {
 		value := r.Header.Get(header)
 

--- a/internal/reader/icon/finder.go
+++ b/internal/reader/icon/finder.go
@@ -251,7 +251,7 @@ func findIconURLsFromHTMLDocument(body io.Reader, contentType string) ([]string,
 		return nil, fmt.Errorf("icon: unable to read document: %v", err)
 	}
 
-	queries := []string{
+	queries := [...]string{
 		"link[rel='icon' i][href]",
 		"link[rel='shortcut icon' i][href]",
 		"link[rel='icon shortcut' i][href]",

--- a/internal/reader/processor/reading_time.go
+++ b/internal/reader/processor/reading_time.go
@@ -65,7 +65,7 @@ func updateEntryReadingTime(store *storage.Storage, feed *model.Feed, entry *mod
 	}
 
 	// Define watch time fetching scenarios
-	watchTimeScenarios := []struct {
+	watchTimeScenarios := [...]struct {
 		shouldFetch func(*model.Entry) bool
 		fetchFunc   func(string) (int, error)
 		platform    string

--- a/internal/reader/rewrite/content_rewrite_functions.go
+++ b/internal/reader/rewrite/content_rewrite_functions.go
@@ -107,7 +107,7 @@ func addDynamicImage(entryContent string) string {
 	doc := goquery.NewDocumentFromNode(parserHtml)
 
 	// Ordered most preferred to least preferred.
-	candidateAttrs := []string{
+	candidateAttrs := [...]string{
 		"data-src",
 		"data-original",
 		"data-orig",
@@ -124,7 +124,7 @@ func addDynamicImage(entryContent string) string {
 		"data-380src",
 	}
 
-	candidateSrcsetAttrs := []string{
+	candidateSrcsetAttrs := [...]string{
 		"data-srcset",
 	}
 

--- a/internal/ui/proxy.go
+++ b/internal/ui/proxy.go
@@ -96,7 +96,7 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 		req.Header.Set("Referer", referer)
 	}
 
-	forwardedRequestHeader := []string{"Range", "Accept", "Accept-Encoding", "User-Agent"}
+	forwardedRequestHeader := [...]string{"Range", "Accept", "Accept-Encoding", "User-Agent"}
 	for _, requestHeaderName := range forwardedRequestHeader {
 		if r.Header.Get(requestHeaderName) != "" {
 			req.Header.Set(requestHeaderName, r.Header.Get(requestHeaderName))
@@ -151,7 +151,7 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 			b.WithHeader("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, filename))
 		}
 
-		forwardedResponseHeader := []string{"Content-Encoding", "Content-Type", "Content-Length", "Accept-Ranges", "Content-Range"}
+		forwardedResponseHeader := [...]string{"Content-Encoding", "Content-Type", "Content-Length", "Accept-Ranges", "Content-Range"}
 		for _, responseHeaderName := range forwardedResponseHeader {
 			if resp.Header.Get(responseHeaderName) != "" {
 				b.WithHeader(responseHeaderName, resp.Header.Get(responseHeaderName))


### PR DESCRIPTION
Arrays have a fixed size in go, while slices don't, making the former way faster than the latter: https://go-benchmarks.com/array-vs-slice