### PR TITLE
refactor(template): use modern svg directive

### DIFF
--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -86,7 +86,7 @@ func (f *funcMap) Map() template.FuncMap {
 		"theme_color": model.ThemeColor,
 		"icon": func(iconName string) template.HTML {
 			return template.HTML(fmt.Sprintf(
-				`<svg class="icon" aria-hidden="true"><use xlink:href="%s#icon-%s"/></svg>`,
+				`<svg class="icon" aria-hidden="true"><use href="%s#icon-%s"/></svg>`,
 				route.Path(f.router, "appIcon", "filename", "sprite.svg"),
 				iconName,
 			))


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/use https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xlink:href

> Warning: Since SVG 2, the xlink:href attribute is deprecated in favor of
href. See xlink:href page for more information.