### PR TITLE
feat(icon): prioritize non-ico feed icons

### DIFF
--- a/internal/reader/icon/finder_test.go
+++ b/internal/reader/icon/finder_test.go
@@ -194,3 +194,24 @@ func TestResizeInvalidImage(t *testing.T) {
 		t.Fatalf("Tried to convert an invalid image")
 	}
 }
+
+func TestParseDocumentWithIcoAndPng(t *testing.T) {
+	html := `<link rel="shortcut icon" href="/static/img/favicon.ico">
+	<link rel="shortcut icon" href="/static/img/favicon.png">
+	<link rel="shortcut icon" href="/static/img/favicon.jpeg">
+	<link rel="shortcut icon" href="/static/img/favicon_max.ico">
+	`
+
+	iconURLs, err := findIconURLsFromHTMLDocument(strings.NewReader(html), "text/html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(iconURLs) != 4 {
+		t.Fatalf(`Invalid number of icon URLs, got %d`, len(iconURLs))
+	}
+
+	if iconURLs[0] != "/static/img/favicon.png" {
+		t.Errorf(`Expected favicon.png first, go %q instead`, iconURLs[0])
+	}
+}


### PR DESCRIPTION
The .ico format is a thing from the paste, and shouldn't be used anymore. As miniflux is able to downsize jpeg/png images, those should take priority over .ico. If a website is using something else, like .gif or .bmp, odds are that they hate their users anyway, and if they're using modern stuff like webp, those might already be correctly-sized/compressed anyway. All in all, this is strictly a improvement over the current sitation.

See https://en.wikipedia.org/wiki/ICO_(file_format) on why .ico sucks.