### PR TITLE
fix(icon): fix apple icon detection

### DIFF
--- a/internal/reader/icon/finder.go
+++ b/internal/reader/icon/finder.go
@@ -255,7 +255,7 @@ func findIconURLsFromHTMLDocument(body io.Reader, contentType string) ([]string,
 		"link[rel='icon' i][href]",
 		"link[rel='shortcut icon' i][href]",
 		"link[rel='icon shortcut' i][href]",
-		"link[rel='apple-touch-icon-precomposed.png'][href]",
+		"link[rel='apple-touch-icon'][href]",
 	}
 
 	var iconURLs []string


### PR DESCRIPTION
The rel of the icon is apple-touch-icon, not apple-touch-icon-precomposed.png

See https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html