### PR TITLE
perf(templates): golf a bit templates space

### DIFF
--- a/internal/template/templates/common/item_meta.html
+++ b/internal/template/templates/common/item_meta.html
@@ -1,4 +1,4 @@
-{{ define "item_meta" }}
+{{ define "item_meta" -}}
 <div class="item-meta">
     <ul class="item-meta-info">
         <li class="item-meta-info-title">
@@ -7,13 +7,11 @@
         <li class="item-meta-info-timestamp">
             <time datetime="{{ isodate .entry.Date }}" title="{{ isodate .entry.Date }}">{{ elapsed .user.Timezone .entry.Date }}</time>
         </li>
-        {{ if and .user.ShowReadingTime (gt .entry.ReadingTime 0) }}
+        {{ if and .user.ShowReadingTime (gt .entry.ReadingTime 0) -}}
         <li class="item-meta-info-reading-time">
-            <span>
-            {{ plural "entry.estimated_reading_time" .entry.ReadingTime .entry.ReadingTime }}
-            </span>
+            <span>{{ plural "entry.estimated_reading_time" .entry.ReadingTime .entry.ReadingTime }}</span>
         </li>
-        {{ end }}
+        {{ end -}}
     </ul>
     <ul class="item-meta-icons">
         <li class="item-meta-icons-read">
@@ -55,7 +53,7 @@
                     data-label-no="{{ t "confirm.no" }}"
                     data-label-loading="{{ t "confirm.loading" }}">{{ icon "delete" }}<span class="icon-label">{{ t "entry.unshare.label" }}</span></button>
             </li>
-        {{ end }}
+        {{ end -}}
         {{ if .hasSaveEntry }}
             <li>
                 <button
@@ -67,7 +65,7 @@
                     data-label-done="{{ t "entry.save.completed" }}"
                     >{{ icon "save" }}<span class="icon-label">{{ t "entry.save.label" }}</span></button>
             </li>
-        {{ end }}
+        {{ end -}}
         <li class="item-meta-icons-external-url">
             <a href="{{ .entry.URL | safeURL  }}"
                 aria-describedby="entry-title-{{ .entry.ID }}"
@@ -86,7 +84,7 @@
                     referrerpolicy="no-referrer"
                     data-comments-link="true">{{ icon "comment" }}<span class="icon-label">{{ t "entry.comments.label" }}</span></a>
             </li>
-        {{ end }}
+        {{ end -}}
     </ul>
 </div>
 {{ end }}

--- a/internal/template/templates/views/unread_entries.html
+++ b/internal/template/templates/views/unread_entries.html
@@ -42,10 +42,10 @@
     <p role="alert" class="alert">{{ t "alert.no_unread_entry" }}</p>
 {{ else }}
     <div class="pagination-top">
-        {{ template "pagination" .pagination }}
+        {{ template "pagination" .pagination -}}
     </div>
     <div class="items hide-read-items">
-        {{ range .entries }}
+        {{ range .entries -}}
         <article
             class="item entry-item {{ if $.user.EntrySwipe }}entry-swipe{{ end }} item-status-{{ .Status }}"
             data-id="{{ .ID }}"
@@ -55,9 +55,9 @@
             <header class="item-header" dir="auto">
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "unreadEntry" "entryID" .ID }}">
-                        {{ if ne .Feed.Icon.IconID 0 }}
+                        {{ if ne .Feed.Icon.IconID 0 -}}
                         <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
-                        {{ end }}
+                        {{ end -}}
                         {{ .Title }}
                     </a>
                 </h2>
@@ -67,7 +67,7 @@
                     </a>
                 </span>
             </header>
-            {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry }}
+            {{ template "item_meta" dict "user" $.user "entry" . "hasSaveEntry" $.hasSaveEntry -}}
         </article>
         {{ end }}
     </div>


### PR DESCRIPTION
This commit removes a bunch of superfluous whitespaces in two templates. On my local test instance, this reduces the size of `/unread` from 320.61kB to 307.50kB, without any visible changes on the user-side.