### PR TITLE
refactor(css): use css to scale svg icons

### DIFF
--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -86,7 +86,7 @@ func (f *funcMap) Map() template.FuncMap {
 		"theme_color": model.ThemeColor,
 		"icon": func(iconName string) template.HTML {
 			return template.HTML(fmt.Sprintf(
-				`<svg class="icon" aria-hidden="true"><use href="%s#icon-%s"/></svg>`,
+				`<svg aria-hidden="true"><use href="%s#icon-%s"/></svg>`,
 				route.Path(f.router, "appIcon", "filename", "sprite.svg"),
 				iconName,
 			))

--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -175,8 +175,8 @@ a:hover {
     white-space: nowrap;
 }
 
-#header-menu .icon,
-.page-header ul a .icon {
+#header-menu a>svg,
+.page-header ul a>svg {
     margin-bottom: 2px;
 }
 
@@ -929,14 +929,16 @@ article.category-has-unread {
 }
 
 /* Icons */
-.icon,
+a>svg,
+button>svg,
 .icon-label {
     vertical-align: text-bottom;
     display: inline-block;
     margin-right: 2px;
 }
 
-.icon {
+a>svg,
+button>svg {
     width: 16px;
     height: 16px;
 }


### PR DESCRIPTION
There is no need to specify `class="icon"` on al svg icons, as all svg are used as icons anyway. But just in case, let's specify this in the css only for svg directly under `a` and `buttons`, to be on the safe-side.