### PR TITLE
refactor(css): set externalIcon size in CSS

### DIFF
--- a/internal/template/templates/common/feed_list.html
+++ b/internal/template/templates/common/feed_list.html
@@ -10,7 +10,7 @@
                 <h2 id="feed-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "feedEntries" "feedID" .ID }}">
                         {{ if and (.Icon) (gt .Icon.IconID 0) }}
-                        <img src="{{ route "feedIcon" "externalIconID" .Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ if .Disabled }} 🚫 {{ end }}
                         {{ .Title }}

--- a/internal/template/templates/views/category_entries.html
+++ b/internal/template/templates/views/category_entries.html
@@ -104,7 +104,7 @@
                         {{ end }}
                     >
                         {{ if ne .Feed.Icon.IconID 0 }}
-                            <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                            <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ .Title }}
                     </a>

--- a/internal/template/templates/views/entry.html
+++ b/internal/template/templates/views/entry.html
@@ -141,7 +141,7 @@
         <div class="entry-meta" dir="auto">
             <span class="entry-website">
                 {{ if ne .entry.Feed.Icon.IconID 0 }}
-                <img src="{{ route "feedIcon" "externalIconID" .entry.Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="{{ .entry.Feed.Title }}">
+                <img src="{{ route "feedIcon" "externalIconID" .entry.Feed.Icon.ExternalIconID }}" loading="lazy" alt="{{ .entry.Feed.Title }}">
                 {{ end }}
                 {{ if .user }}
                 <a href="{{ route "feedEntries" "feedID" .entry.Feed.ID }}">{{ .entry.Feed.Title }}</a>

--- a/internal/template/templates/views/feed_entries.html
+++ b/internal/template/templates/views/feed_entries.html
@@ -113,7 +113,7 @@
                         {{ end }}
                     >
                         {{ if ne .Feed.Icon.IconID 0 }}
-                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ .Title }}
                     </a>

--- a/internal/template/templates/views/history_entries.html
+++ b/internal/template/templates/views/history_entries.html
@@ -48,7 +48,7 @@
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "readEntry" "entryID" .ID }}">
                         {{ if ne .Feed.Icon.IconID 0 }}
-                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ .Title }}
                     </a>

--- a/internal/template/templates/views/search.html
+++ b/internal/template/templates/views/search.html
@@ -35,7 +35,7 @@
                     <h2 id="entry-title-{{ .ID }}" class="item-title">
                         <a href="{{ route "searchEntry" "entryID" .ID }}{{ queryString (dict "q" $.searchQuery "unread" $.searchUnreadOnly) }}">
                             {{ if ne .Feed.Icon.IconID 0 }}
-                            <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="{{ .Feed.Title }}">
+                            <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="{{ .Feed.Title }}">
                             {{ else }}
                             <span class="sr-only">{{ .Feed.Title }}</span>
                             {{ end }}

--- a/internal/template/templates/views/shared_entries.html
+++ b/internal/template/templates/views/shared_entries.html
@@ -48,7 +48,7 @@
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "readEntry" "entryID" .ID }}">
                         {{ if ne .Feed.Icon.IconID 0 }}
-                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ .Title }}
                     </a>

--- a/internal/template/templates/views/starred_entries.html
+++ b/internal/template/templates/views/starred_entries.html
@@ -29,7 +29,7 @@
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "starredEntry" "entryID" .ID }}">
                         {{ if ne .Feed.Icon.IconID 0 }}
-                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ .Title }}
                     </a>

--- a/internal/template/templates/views/tag_entries.html
+++ b/internal/template/templates/views/tag_entries.html
@@ -29,7 +29,7 @@
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "tagEntry" "entryID" .ID "tagName" (urlEncode $.tagName) }}">
                         {{ if ne .Feed.Icon.IconID 0 }}
-                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end }}
                         {{ .Title }}
                     </a>

--- a/internal/template/templates/views/unread_entries.html
+++ b/internal/template/templates/views/unread_entries.html
@@ -56,7 +56,7 @@
                 <h2 id="entry-title-{{ .ID }}" class="item-title">
                     <a href="{{ route "unreadEntry" "entryID" .ID }}">
                         {{ if ne .Feed.Icon.IconID 0 -}}
-                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" width="16" height="16" loading="lazy" alt="">
+                        <img src="{{ route "feedIcon" "externalIconID" .Feed.Icon.ExternalIconID }}" loading="lazy" alt="">
                         {{ end -}}
                         {{ .Title }}
                     </a>

--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -849,6 +849,12 @@ dialog {
     font-size: inherit;
 }
 
+.item-title img,
+.entry-website img {
+    width: 16px;
+    height: 16px;
+}
+
 .feed-entries-counter {
     display: inline-flex;
     gap: 2px;


### PR DESCRIPTION
There is no need to repeat `width="16" height="16"` for every single externalIcon in the HTML, when we can specify this in the CSS instead.