### PR TITLE
refactor(api): use *url.URL for MEDIA_PROXY_CUSTOM_URL

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1601,7 +1601,8 @@ func TestMediaProxyCustomURL(t *testing.T) {
 	}
 	expected := "http://example.org/proxy"
 	result := opts.MediaCustomProxyURL()
-	if result != expected {
+
+	if result == nil || result.String() != expected {
 		t.Fatalf(`Unexpected MEDIA_PROXY_CUSTOM_URL value, got %q instead of %q`, result, expected)
 	}
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -148,7 +148,7 @@ type options struct {
 	mediaProxyHTTPClientTimeout        int
 	mediaProxyMode                     string
 	mediaProxyResourceTypes            []string
-	mediaProxyCustomURL                string
+	mediaProxyCustomURL                *url.URL
 	fetchBilibiliWatchTime             bool
 	fetchNebulaWatchTime               bool
 	fetchOdyseeWatchTime               bool
@@ -229,7 +229,7 @@ func NewOptions() *options {
 		mediaProxyHTTPClientTimeout:        defaultMediaProxyHTTPClientTimeout,
 		mediaProxyMode:                     defaultMediaProxyMode,
 		mediaProxyResourceTypes:            []string{defaultMediaResourceTypes},
-		mediaProxyCustomURL:                defaultMediaProxyURL,
+		mediaProxyCustomURL:                nil,
 		filterEntryMaxAgeDays:              defaultFilterEntryMaxAgeDays,
 		fetchBilibiliWatchTime:             defaultFetchBilibiliWatchTime,
 		fetchNebulaWatchTime:               defaultFetchNebulaWatchTime,
@@ -563,7 +563,7 @@ func (o *options) MediaProxyResourceTypes() []string {
 }
 
 // MediaCustomProxyURL returns the custom proxy URL for medias.
-func (o *options) MediaCustomProxyURL() string {
+func (o *options) MediaCustomProxyURL() *url.URL {
 	return o.mediaProxyCustomURL
 }
 

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -170,7 +170,10 @@ func (p *parser) parseLines(lines []string) (err error) {
 			rand.Read(randomKey)
 			p.opts.mediaProxyPrivateKey = parseBytes(value, randomKey)
 		case "MEDIA_PROXY_CUSTOM_URL":
-			p.opts.mediaProxyCustomURL = parseString(value, defaultMediaProxyURL)
+			p.opts.mediaProxyCustomURL, err = url.Parse(parseString(value, defaultMediaProxyURL))
+			if err != nil {
+				return fmt.Errorf("config: invalid MEDIA_PROXY_CUSTOM_URL value: %w", err)
+			}
 		case "CREATE_ADMIN":
 			p.opts.createAdmin = parseBool(value, defaultCreateAdmin)
 		case "ADMIN_USERNAME":

--- a/internal/mediaproxy/media_proxy_test.go
+++ b/internal/mediaproxy/media_proxy_test.go
@@ -278,19 +278,8 @@ func TestProxyFilterWithHttpsAlwaysAndIncorrectCustomProxyServer(t *testing.T) {
 	var err error
 	parser := config.NewParser()
 	config.Opts, err = parser.ParseEnvironmentVariables()
-	if err != nil {
-		t.Fatalf(`Parsing failure: %v`, err)
-	}
-
-	r := mux.NewRouter()
-	r.HandleFunc("/proxy/{encodedDigest}/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
-
-	input := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
-	output := RewriteDocumentWithRelativeProxyURL(r, input)
-	expected := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
-
-	if expected != output {
-		t.Errorf(`Not expected output: got %q instead of %q`, output, expected)
+	if err == nil {
+		t.Fatalf(`Incorrect proxy URL silently accepted (MEDIA_PROXY_CUSTOM_URL=%q): %q`, os.Getenv("MEDIA_PROXY_CUSTOM_URL"), config.Opts.MediaCustomProxyURL())
 	}
 }
 

--- a/internal/mediaproxy/url.go
+++ b/internal/mediaproxy/url.go
@@ -7,7 +7,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"log/slog"
 	"net/url"
 
 	"github.com/gorilla/mux"
@@ -21,7 +20,7 @@ func ProxifyRelativeURL(router *mux.Router, mediaURL string) string {
 		return ""
 	}
 
-	if customProxyURL := config.Opts.MediaCustomProxyURL(); customProxyURL != "" {
+	if customProxyURL := config.Opts.MediaCustomProxyURL(); customProxyURL != nil {
 		return proxifyURLWithCustomProxy(mediaURL, customProxyURL)
 	}
 
@@ -36,7 +35,7 @@ func ProxifyAbsoluteURL(router *mux.Router, mediaURL string) string {
 		return ""
 	}
 
-	if customProxyURL := config.Opts.MediaCustomProxyURL(); customProxyURL != "" {
+	if customProxyURL := config.Opts.MediaCustomProxyURL(); customProxyURL != nil {
 		return proxifyURLWithCustomProxy(mediaURL, customProxyURL)
 	}
 
@@ -50,19 +49,11 @@ func ProxifyAbsoluteURL(router *mux.Router, mediaURL string) string {
 	return absoluteURL
 }
 
-func proxifyURLWithCustomProxy(mediaURL, customProxyURL string) string {
-	if customProxyURL == "" {
+func proxifyURLWithCustomProxy(mediaURL string, customProxyURL *url.URL) string {
+	if customProxyURL == nil {
 		return mediaURL
 	}
 
-	absoluteURL, err := url.JoinPath(customProxyURL, base64.URLEncoding.EncodeToString([]byte(mediaURL)))
-	if err != nil {
-		slog.Error("Incorrect custom media proxy URL",
-			slog.String("custom_proxy_url", customProxyURL),
-			slog.Any("error", err),
-		)
-		return mediaURL
-	}
-
-	return absoluteURL
+	absoluteURL := customProxyURL.JoinPath(base64.URLEncoding.EncodeToString([]byte(mediaURL)))
+	return absoluteURL.String()
 }


### PR DESCRIPTION
Same behaviour as for `HTTP_CLIENT_PROXY`.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
