### PR TITLE
refactor(storage): split `DeleteContentRemovedEntries` into 2 functions and fix condition

### DIFF
--- a/internal/cli/cleanup_tasks.go
+++ b/internal/cli/cleanup_tasks.go
@@ -47,10 +47,17 @@ func runCleanupTasks(store *storage.Storage) {
 		}
 	}
 
-	if rowsAffected, err := store.DeleteContentRemovedEntries(); err != nil {
-		slog.Error("Unable to delete the content of removed entries", slog.Any("error", err))
+	if enclosuresAffected, err := store.DeleteRemovedEntriesEnclosures(); err != nil {
+		slog.Error("Unable to delete enclosures from removed entries", slog.Any("error", err))
 	} else {
-		slog.Info("Deleting content of removed entries completed",
-			slog.Int64("removed_entries_content_removed", rowsAffected))
+		slog.Info("Deleting enclosures from removed entries completed",
+			slog.Int64("removed_entries_enclosures_deleted", enclosuresAffected))
+	}
+
+	if contentAffected, err := store.ClearRemovedEntriesContent(); err != nil {
+		slog.Error("Unable to clear content from removed entries", slog.Any("error", err))
+	} else {
+		slog.Info("Clearing content from removed entries completed",
+			slog.Int64("removed_entries_content_cleared", contentAffected))
 	}
 }


### PR DESCRIPTION
- Add `content IS NOT NULL` to the condition to avoid clearing the same entries over and over
- Create `DeleteRemovedEntriesEnclosures` and `ClearRemovedEntriesContent` that report individual counts
