### PR TITLE
fix(version): change development version naming to avoid breaking some clients

### DIFF
--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -32,6 +32,7 @@ type funcMap struct {
 // Map returns a map of template functions that are compiled during template parsing.
 func (f *funcMap) Map() template.FuncMap {
 	return template.FuncMap{
+		"contains":         strings.Contains,
 		"startsWith":       strings.HasPrefix,
 		"formatFileSize":   formatFileSize,
 		"dict":             dict,

--- a/internal/template/templates/views/about.html
+++ b/internal/template/templates/views/about.html
@@ -13,10 +13,10 @@
     <ul>
         <li>
             <strong>{{ t "page.about.version" }}</strong>
-            {{ if startsWith .version "2." }}
-                <a href="https://github.com/miniflux/v2/releases/tag/{{ .version }}">{{ .version }}</a>
-            {{ else }}
+            {{ if contains .version "dev" }}
                 {{ .version }}
+            {{ else }}
+                <a href="https://github.com/miniflux/v2/releases/tag/{{ .version }}">{{ .version }}</a>
             {{ end }}
         </li>
 	{{ if .commit }}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -43,7 +43,9 @@ func getBuildDate() string {
 // Falls back to values from the Go module's build info when available.
 func init() {
 	if Version == "" {
-		Version = "Development Version"
+		// Some Miniflux clients expect a specific version format.
+		// For example, Flux News converts the string version to an integer.
+		Version = "2.2.x-dev"
 	}
 	if Commit == "" {
 		Commit = getCommit()


### PR DESCRIPTION
Some Miniflux clients expect a specific version format. For example, Flux News converts the string version to an integer.

Using `Development Version` will break some clients.