### PR TITLE
fix(mediaproxy): always forward the browser Accept header

### DIFF
--- a/internal/ui/proxy.go
+++ b/internal/ui/proxy.go
@@ -88,6 +88,9 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 	requestBuilder := fetcher.NewRequestBuilder()
 	requestBuilder.WithTimeout(config.Opts.MediaProxyHTTPClientTimeout())
 
+	// Disable compression for the media proxy requests (not implemented).
+	requestBuilder.WithoutCompression()
+
 	if referer := rewrite.GetRefererForURL(mediaURL); referer != "" {
 		requestBuilder.WithHeader("Referer", referer)
 	}


### PR DESCRIPTION
Tumblr CDN is blocking the Accept header used to fetch feeds