### PR TITLE
refactor(template): extract the CSP in a function and systematically use nonces. 

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -28,24 +28,20 @@
     <meta name="theme-color" content="{{ theme_color .theme "light" }}" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="{{ theme_color .theme "dark" }}" media="(prefers-color-scheme: dark)">
 
-    <link rel="stylesheet" type="text/css" href="{{ route "stylesheet" "name" .theme "checksum" .theme_checksum }}">
+    {{ $cspNonce := nonce }}
+    {{ csp .user $cspNonce | noescape }}
 
-    {{ if .user }}
-        {{ $cspNonce := nonce }}
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src * data:; media-src *; frame-src *; {{ if .user.ExternalFontHosts }}font-src {{ .user.ExternalFontHosts }}; {{ end }}style-src 'self'{{ if .user.Stylesheet }}{{ if .user.ExternalFontHosts }} {{ .user.ExternalFontHosts }}{{ end }} 'nonce-{{ $cspNonce }}'{{ end }}{{ if .user.CustomJS }}; script-src 'self' 'nonce-{{ $cspNonce }}'{{ end }}; require-trusted-types-for 'script'; trusted-types ttpolicy;">
+    <link rel="stylesheet" nonce="{{ $cspNonce }}" type="text/css" href="{{ route "stylesheet" "name" .theme "checksum" .theme_checksum }}">
+    <script nonce="{{ $cspNonce }}" src="{{ route "javascript" "name" "app" "checksum" .app_js_checksum }}" type="module"></script>
 
-        {{ if .user.Stylesheet }}
+    {{ if .user -}}
+        {{ if .user.Stylesheet -}}
         <style nonce="{{ $cspNonce }}">{{ .user.Stylesheet | safeCSS }}</style>
-        {{ end }}
-
-        {{ if .user.CustomJS }}
+        {{ end -}}
+        {{ if .user.CustomJS -}}
         <script type="module" nonce="{{ $cspNonce }}">{{ .user.CustomJS | safeJS }}</script>
-        {{ end }}
-    {{ else }}
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src * data:; media-src *; frame-src *; require-trusted-types-for 'script'; trusted-types ttpolicy;">
-    {{ end }}
-
-    <script src="{{ route "javascript" "name" "app" "checksum" .app_js_checksum }}" type="module"></script>
+        {{ end -}}
+    {{ end -}}
 </head>
 <body
     data-service-worker-url="{{ route "javascript" "name" "service-worker" "checksum" .sw_js_checksum }}"


### PR DESCRIPTION
Having the CSP built in a function instead of in the template makes it easier
to properly construct it. This was also the opportunity to switch from
`default-src 'self'` to `default-src 'none'`, to deny everything that isn't
explicitly allowed, instead of allowing everything coming from 'self'.
    
Moreover, as Miniflux is shoving the content of feeds in the same origin as
itself, using `self` doesn't do much security-wise. It's much better to
systematically use a nonce-based policy, so that an attacker able to bypass the
sanitization will have to guess the nonce to gain arbitrary javascript
execution.


While the merge-request has been tested locally, it would still be prudent to thoroughly test it before merging, as it has the potential to break the user-interface should weird constructs be used. 