### PR TITLE
refactor(svg): remove an inline svg

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -73,9 +73,7 @@
                 <a aria-label="{{ t "menu.home_page" }}" href="{{ route .user.DefaultHomePage }}">
                     Mini<span>flux</span>
                 </a>
-                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
-                    <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708"/>
-                </svg>
+                {{ icon "chevron-down"}}
             </div>
             <ul id="header-menu">
                 <li {{ if eq .menu "unread" }}class="active"{{ end }} title="{{ t "tooltip.keyboard_shortcuts" "g u" }}">

--- a/internal/ui/static/bin/sprite.svg
+++ b/internal/ui/static/bin/sprite.svg
@@ -4,6 +4,10 @@ SPDX-License-Identifier: MIT
 Source: https://github.com/tabler/tabler-icons
 -->
 <svg xmlns="http://www.w3.org/2000/svg">
+    <symbol id="icon-chevron-down" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M6 9l6 6l6 -6" />
+    </symbol>
     <symbol id="icon-read" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z"/>
         <circle cx="12" cy="12" r="9" />


### PR DESCRIPTION
There is no need to have an inline svg when we can have it in the sprite.svg file.