### PR TITLE
refactor(template): rename noescape to safeHTML

### DIFF
--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -60,7 +60,7 @@ func (f *funcMap) Map() template.FuncMap {
 		"safeJS": func(str string) template.JS {
 			return template.JS(str)
 		},
-		"noescape": func(str string) template.HTML {
+		"safeHTML": func(str string) template.HTML {
 			return template.HTML(str)
 		},
 		"proxyFilter": func(data string) string {

--- a/internal/template/templates/views/entry.html
+++ b/internal/template/templates/views/entry.html
@@ -280,9 +280,9 @@
     {{ end }}
 
     {{ if .user }}
-        {{ noescape (proxyFilter .entry.Content) }}
+        {{ safeHTML (proxyFilter .entry.Content) }}
     {{ else }}
-        {{ noescape .entry.Content }}
+        {{ safeHTML .entry.Content }}
     {{ end }}
 </article>
 {{ if .entry.Enclosures }}


### PR DESCRIPTION
This makes the code more consistent, since all the other escaping escape hatches have a `safe` prefix.