### PR TITLE
Revert "refactor(storage): simplify `feed.go` by using `min()`, inline errors, and use idiomatic conditions"

### DIFF
--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -111,10 +111,14 @@ func (s *Storage) CountAllFeeds() map[string]int64 {
 
 // CountUserFeedsWithErrors returns the number of feeds with parsing errors that belong to the given user.
 func (s *Storage) CountUserFeedsWithErrors(userID int64) int {
-	pollingParsingErrorLimit := min(config.Opts.PollingParsingErrorLimit(), 1)
+	pollingParsingErrorLimit := config.Opts.PollingParsingErrorLimit()
+	if pollingParsingErrorLimit <= 0 {
+		pollingParsingErrorLimit = 1
+	}
 	query := `SELECT count(*) FROM feeds WHERE user_id=$1 AND parsing_error_count >= $2`
 	var result int
-	if s.db.QueryRow(query, userID, pollingParsingErrorLimit).Scan(&result) != nil {
+	err := s.db.QueryRow(query, userID, pollingParsingErrorLimit).Scan(&result)
+	if err != nil {
 		return 0
 	}
 
@@ -123,10 +127,14 @@ func (s *Storage) CountUserFeedsWithErrors(userID int64) int {
 
 // CountAllFeedsWithErrors returns the number of feeds with parsing errors.
 func (s *Storage) CountAllFeedsWithErrors() int {
-	pollingParsingErrorLimit := min(config.Opts.PollingParsingErrorLimit(), 1)
+	pollingParsingErrorLimit := config.Opts.PollingParsingErrorLimit()
+	if pollingParsingErrorLimit <= 0 {
+		pollingParsingErrorLimit = 1
+	}
 	query := `SELECT count(*) FROM feeds WHERE parsing_error_count >= $1`
 	var result int
-	if s.db.QueryRow(query, pollingParsingErrorLimit).Scan(&result) != nil {
+	err := s.db.QueryRow(query, pollingParsingErrorLimit).Scan(&result)
+	if err != nil {
 		return 0
 	}
 
@@ -142,11 +150,11 @@ func (s *Storage) Feeds(userID int64) (model.Feeds, error) {
 
 func getFeedsSorted(builder *FeedQueryBuilder) (model.Feeds, error) {
 	result, err := builder.GetFeeds()
-	if err != nil {
-		return nil, err
+	if err == nil {
+		sort.Sort(byStateAndName{result})
+		return result, nil
 	}
-	sort.Sort(byStateAndName{result})
-	return result, nil
+	return result, err
 }
 
 // FeedsWithCounters returns all feeds of the given user with counters of read and unread entries.


### PR DESCRIPTION
This reverts commit b1cbaae71c2988ddc303b9f67e9a45ed5865cb3a.