### PR TITLE
fix(api): do not return removed entries

### DIFF
--- a/internal/api/entry.go
+++ b/internal/api/entry.go
@@ -47,6 +47,7 @@ func (h *handler) getFeedEntry(w http.ResponseWriter, r *http.Request) {
 	builder := h.store.NewEntryQueryBuilder(request.UserID(r))
 	builder.WithFeedID(feedID)
 	builder.WithEntryID(entryID)
+	builder.WithoutStatus(model.EntryStatusRemoved)
 
 	h.getEntryFromBuilder(w, r, builder)
 }
@@ -58,6 +59,7 @@ func (h *handler) getCategoryEntry(w http.ResponseWriter, r *http.Request) {
 	builder := h.store.NewEntryQueryBuilder(request.UserID(r))
 	builder.WithCategoryID(categoryID)
 	builder.WithEntryID(entryID)
+	builder.WithoutStatus(model.EntryStatusRemoved)
 
 	h.getEntryFromBuilder(w, r, builder)
 }
@@ -66,6 +68,7 @@ func (h *handler) getEntry(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 	builder := h.store.NewEntryQueryBuilder(request.UserID(r))
 	builder.WithEntryID(entryID)
+	builder.WithoutStatus(model.EntryStatusRemoved)
 
 	h.getEntryFromBuilder(w, r, builder)
 }
@@ -136,6 +139,7 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 	builder.WithLimit(limit)
 	builder.WithTags(tags)
 	builder.WithEnclosures()
+	builder.WithoutStatus(model.EntryStatusRemoved)
 
 	if request.HasQueryParam(r, "globally_visible") {
 		globallyVisible := request.QueryBoolParam(r, "globally_visible", true)


### PR DESCRIPTION
Starting with Miniflux 2.2.12, the content of removed entries is cleared, so returning them through the API no longer serves any purpose.