### PR TITLE
perf(misc): explicitly size some slices

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -12,7 +12,7 @@ import (
 var schemaVersion = len(migrations)
 
 // Order is important. Add new migrations at the end of the list.
-var migrations = []func(tx *sql.Tx) error{
+var migrations = [...]func(tx *sql.Tx) error{
 	func(tx *sql.Tx) (err error) {
 		sql := `
 			CREATE TABLE schema_version (

--- a/internal/reader/date/parser.go
+++ b/internal/reader/date/parser.go
@@ -12,14 +12,14 @@ import (
 )
 
 // RFC822, RFC850, and RFC1123 formats should be applied only to local times.
-var dateFormatsLocalTimesOnly = []string{
+var dateFormatsLocalTimesOnly = [...]string{
 	time.RFC822, // RSS
 	time.RFC850,
 	time.RFC1123,
 }
 
 // dateFormats taken from github.com/mjibson/goread
-var dateFormats = []string{
+var dateFormats = [...]string{
 	time.RFC822Z, // RSS
 	time.RFC3339, // Atom
 	time.UnixDate,

--- a/internal/reader/media/media.go
+++ b/internal/reader/media/media.go
@@ -23,7 +23,7 @@ type MediaItemElement struct {
 
 // AllMediaThumbnails returns all thumbnail elements merged together.
 func (e *MediaItemElement) AllMediaThumbnails() []Thumbnail {
-	var items []Thumbnail
+	items := make([]Thumbnail, 0, len(e.MediaThumbnails)+len(e.MediaGroups))
 	items = append(items, e.MediaThumbnails...)
 	for _, mediaGroup := range e.MediaGroups {
 		items = append(items, mediaGroup.MediaThumbnails...)
@@ -33,7 +33,7 @@ func (e *MediaItemElement) AllMediaThumbnails() []Thumbnail {
 
 // AllMediaContents returns all content elements merged together.
 func (e *MediaItemElement) AllMediaContents() []Content {
-	var items []Content
+	items := make([]Content, 0, len(e.MediaContents)+len(e.MediaGroups))
 	items = append(items, e.MediaContents...)
 	for _, mediaGroup := range e.MediaGroups {
 		items = append(items, mediaGroup.MediaContents...)
@@ -43,7 +43,7 @@ func (e *MediaItemElement) AllMediaContents() []Content {
 
 // AllMediaPeerLinks returns all peer link elements merged together.
 func (e *MediaItemElement) AllMediaPeerLinks() []PeerLink {
-	var items []PeerLink
+	items := make([]PeerLink, 0, len(e.MediaPeerLinks)+len(e.MediaGroups))
 	items = append(items, e.MediaPeerLinks...)
 	for _, mediaGroup := range e.MediaGroups {
 		items = append(items, mediaGroup.MediaPeerLinks...)


### PR DESCRIPTION
Arrays are cheaper than slices, as they are fixed-size, so the compiler can be smarted about them. This commit also add a handful of `make`-based constructors to some slices, to reduce the amount of re-allocations needed, based on best-effort guessing of their final size.