### PR TITLE
refactor(proxy): remove usage of fmt

### DIFF
--- a/internal/ui/proxy.go
+++ b/internal/ui/proxy.go
@@ -8,11 +8,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"time"
 
 	"miniflux.app/v2/internal/config"
@@ -128,7 +128,7 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 		)
 
 		// Forward the status code from the origin.
-		http.Error(w, fmt.Sprintf("Origin status code is %d", resp.StatusCode), resp.StatusCode)
+		http.Error(w, "Origin status code is "+strconv.Itoa(resp.StatusCode), resp.StatusCode)
 		return
 	}
 
@@ -140,7 +140,7 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 		b.WithHeader("Content-Type", resp.Header.Get("Content-Type"))
 
 		if filename := path.Base(parsedMediaURL.Path); filename != "" {
-			b.WithHeader("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, filename))
+			b.WithHeader("Content-Disposition", `inline; filename="`+filename+`"`)
 		}
 
 		forwardedResponseHeader := [...]string{"Content-Encoding", "Content-Type", "Content-Length", "Accept-Ranges", "Content-Range"}


### PR DESCRIPTION
There is no need to use the heavy machinery (fmt) when we can simply use string concatenation instead.