### PR TITLE
refactor(js): golf a bit touch-related js

### DIFF
--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -1230,8 +1230,10 @@ function initializeKeyboardShortcuts() {
  * Initialize touch handler for mobile devices.
  */
 function initializeTouchHandler() {
-    const touchHandler = new TouchHandler();
-    touchHandler.listen();
+    if ( "ontouchstart" in window || navigator.maxTouchPoints > 0) {
+        const touchHandler = new TouchHandler();
+        touchHandler.listen();
+    }
 }
 
 /**

--- a/internal/ui/static/js/touch_handler.js
+++ b/internal/ui/static/js/touch_handler.js
@@ -151,35 +151,27 @@ class TouchHandler {
         }
     }
 
-    static isTouchSupported() {
-        return "ontouchstart" in window || navigator.maxTouchPoints > 0;
-    }
-
     listen() {
-        if (!TouchHandler.isTouchSupported()) {
-            return;
-        }
-
         const eventListenerOptions = { passive: true };
 
         document.querySelectorAll(".entry-swipe").forEach((element) => {
             element.addEventListener("touchstart", (e) => this.onItemTouchStart(e), eventListenerOptions);
             element.addEventListener("touchmove", (e) => this.onItemTouchMove(e));
             element.addEventListener("touchend", (e) => this.onItemTouchEnd(e), eventListenerOptions);
-            element.addEventListener("touchcancel", () => this.reset(), eventListenerOptions);
+            element.addEventListener("touchcancel", this.reset, eventListenerOptions);
         });
 
         const element = document.querySelector(".entry-content");
         if (element) {
             if (element.classList.contains("gesture-nav-tap")) {
                 element.addEventListener("touchend", (e) => this.onTapEnd(e), eventListenerOptions);
-                element.addEventListener("touchmove", () => this.reset(), eventListenerOptions);
-                element.addEventListener("touchcancel", () => this.reset(), eventListenerOptions);
+                element.addEventListener("touchmove", this.reset, eventListenerOptions);
+                element.addEventListener("touchcancel", this.reset, eventListenerOptions);
             } else if (element.classList.contains("gesture-nav-swipe")) {
                 element.addEventListener("touchstart", (e) => this.onContentTouchStart(e), eventListenerOptions);
                 element.addEventListener("touchmove", (e) => this.onContentTouchMove(e), eventListenerOptions);
                 element.addEventListener("touchend", (e) => this.onContentTouchEnd(e), eventListenerOptions);
-                element.addEventListener("touchcancel", () => this.reset(), eventListenerOptions);
+                element.addEventListener("touchcancel", this.reset, eventListenerOptions);
             }
         }
     }


### PR DESCRIPTION
There is no need to instantiate the whole TouchHandler object to call a single static method that immediately returns in case touch events aren't supported: it's better to extract the condition around the calls, so that the object is never instantiated.

Another change is to replace `() => this.reset()` with `this.reset`, which is equivalent, but shorted and less weird.