### PR TITLE
refactor(database): get rid of the dependency on hstore

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -123,13 +123,8 @@ var migrations = []func(tx *sql.Tx) error{
 		return err
 	},
 	func(tx *sql.Tx) (err error) {
-		sql := `
-			CREATE EXTENSION IF NOT EXISTS hstore;
-			ALTER TABLE users ADD COLUMN extra hstore;
-			CREATE INDEX users_extra_idx ON users using gin(extra);
-			`
-		_, err = tx.Exec(sql)
-		return err
+		// This used to create a hstore `extra` column in the table `users`
+		return nil
 	},
 	func(tx *sql.Tx) (err error) {
 		sql := `
@@ -436,6 +431,18 @@ var migrations = []func(tx *sql.Tx) error{
 		return err
 	},
 	func(tx *sql.Tx) (err error) {
+
+		hasExtra := false
+		if err := tx.QueryRow(`
+			SELECT true 
+			FROM information_schema.columns
+			WHERE
+				table_name='user' AND
+				column_name='extra';
+			`).Scan(&hasExtra); err != nil && err != sql.ErrNoRows {
+			return err
+		}
+
 		_, err = tx.Exec(`
 			ALTER TABLE users
 				ADD column stylesheet text not null default '',
@@ -444,6 +451,11 @@ var migrations = []func(tx *sql.Tx) error{
 		`)
 		if err != nil {
 			return err
+		}
+
+		if !hasExtra {
+			// No need to migrate things from the `extra` column if it's not present
+			return nil
 		}
 
 		_, err = tx.Exec(`
@@ -495,8 +507,20 @@ var migrations = []func(tx *sql.Tx) error{
 		return err
 	},
 	func(tx *sql.Tx) (err error) {
-		if _, err = tx.Exec(`ALTER TABLE users DROP COLUMN extra;`); err != nil {
+		hasExtra := false
+		if err := tx.QueryRow(`
+			SELECT true 
+			FROM information_schema.columns
+			WHERE
+				table_name='user' AND
+				column_name='extra';
+			`).Scan(&hasExtra); err != nil && err != sql.ErrNoRows {
 			return err
+		}
+		if hasExtra {
+			if _, err = tx.Exec(`ALTER TABLE users DROP COLUMN extra;`); err != nil {
+				return err
+			}
 		}
 		_, err = tx.Exec(`
 			CREATE UNIQUE INDEX users_google_id_idx ON users(google_id) WHERE google_id <> '';
@@ -1148,6 +1172,11 @@ var migrations = []func(tx *sql.Tx) error{
 				ADD COLUMN linktaco_tags text default '',
 				ADD COLUMN linktaco_visibility linktaco_link_visibility default 'PUBLIC';
 		`
+		_, err = tx.Exec(sql)
+		return err
+	},
+	func(tx *sql.Tx) (err error) {
+		sql := `DROP EXTENSION IF EXISTS hstore;`
 		_, err = tx.Exec(sql)
 		return err
 	},


### PR DESCRIPTION
The hstore extension was briefly used at some point by miniflux, but not anymore. Yet it's still required to deploy miniflux, as a hstore column is created then destroyed during the database creation/migration. This commit refactor the migrations (scary!) to get rid of hstore, so that it doesn't need to be installed/present when deploying/running miniflux.

This should close #3759