### PR TITLE
feat(login): redirect back to original page after logging in

### DIFF
--- a/internal/template/templates/views/login.html
+++ b/internal/template/templates/views/login.html
@@ -8,6 +8,7 @@
     {{ if not disableLocalAuth }}
     <form action="{{ route "checkLogin" }}" method="post">
         <input type="hidden" name="csrf" value="{{ .csrf }}">
+        <input type="hidden" name="redirect_url" value="{{ .redirectURL }}">
 
         {{ if .errorMessage }}
             <div role="alert" class="alert alert-error">{{ .errorMessage }}</div>

--- a/internal/ui/login_show.go
+++ b/internal/ui/login_show.go
@@ -27,5 +27,7 @@ func (h *handler) showLoginPage(w http.ResponseWriter, r *http.Request) {
 
 	sess := session.New(h.store, request.SessionID(r))
 	view := view.New(h.tpl, r, sess)
+	redirectURL := request.QueryStringParam(r, "redirect_url", "")
+	view.Set("redirectURL", redirectURL)
 	html.OK(w, r, view.Render("login"))
 }

--- a/internal/ui/middleware.go
+++ b/internal/ui/middleware.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/crypto"
@@ -42,7 +43,11 @@ func (m *middleware) handleUserSession(next http.Handler) http.Handler {
 				slog.Debug("Redirecting to login page because no user session has been found",
 					slog.String("url", r.RequestURI),
 				)
-				html.Redirect(w, r, route.Path(m.router, "login"))
+				loginURL, _ := url.Parse(route.Path(m.router, "login"))
+				values := loginURL.Query()
+				values.Set("redirect_url", r.RequestURI)
+				loginURL.RawQuery = values.Encode()
+				html.Redirect(w, r, loginURL.String())
 			}
 		} else {
 			slog.Debug("User session found",


### PR DESCRIPTION
Redirect back to original page after logging in

* In `handleUserSession`, save the original request URL in a query parameter when redirecting to the `login` route
* In `showLoginPage`, use the query parameter to set a template argument
* In `login.html`, render the template argument into a hidden form value
* In `checkLogin`, use the form value to set the template argument again (if authentication is unsuccessful) or to redirect to the original request URL (if authentication is successful)

Closes #549

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
