### PR TITLE
refactor(misc): replace fmt.Errorf with errors.New where possible

### DIFF
--- a/internal/cli/reset_password.go
+++ b/internal/cli/reset_password.go
@@ -4,6 +4,7 @@
 package cli // import "miniflux.app/v2/internal/cli"
 
 import (
+	"errors"
 	"fmt"
 
 	"miniflux.app/v2/internal/model"
@@ -19,7 +20,7 @@ func resetPassword(store *storage.Storage) {
 	}
 
 	if user == nil {
-		printErrorAndExit(fmt.Errorf("user not found"))
+		printErrorAndExit(errors.New("user not found"))
 	}
 
 	userModificationRequest := &model.UserModificationRequest{

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -60,7 +61,7 @@ func (cp *configParser) postParsing() error {
 
 	scheme := strings.ToLower(parsedURL.Scheme)
 	if scheme != "https" && scheme != "http" {
-		return fmt.Errorf("BASE_URL scheme must be http or https")
+		return errors.New("BASE_URL scheme must be http or https")
 	}
 
 	cp.options.options["BASE_URL"].ParsedStringValue = baseURL
@@ -294,7 +295,7 @@ func readSecretFileValue(filename string) (string, error) {
 
 	value := string(bytes.TrimSpace(data))
 	if value == "" {
-		return "", fmt.Errorf("secret file is empty")
+		return "", errors.New("secret file is empty")
 	}
 
 	return value, nil

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -4,6 +4,7 @@
 package config // import "miniflux.app/v2/internal/config"
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -29,7 +30,7 @@ func validateListChoices(inputValues, choices []string) error {
 func validateGreaterThan(rawValue string, min int) error {
 	intValue, err := strconv.Atoi(rawValue)
 	if err != nil {
-		return fmt.Errorf("value must be an integer")
+		return errors.New("value must be an integer")
 	}
 	if intValue > min {
 		return nil
@@ -40,7 +41,7 @@ func validateGreaterThan(rawValue string, min int) error {
 func validateGreaterOrEqualThan(rawValue string, min int) error {
 	intValue, err := strconv.Atoi(rawValue)
 	if err != nil {
-		return fmt.Errorf("value must be an integer")
+		return errors.New("value must be an integer")
 	}
 	if intValue >= min {
 		return nil
@@ -51,7 +52,7 @@ func validateGreaterOrEqualThan(rawValue string, min int) error {
 func validateRange(rawValue string, min, max int) error {
 	intValue, err := strconv.Atoi(rawValue)
 	if err != nil {
-		return fmt.Errorf("value must be an integer")
+		return errors.New("value must be an integer")
 	}
 	if intValue < min || intValue > max {
 		return fmt.Errorf("value must be between %d and %d", min, max)

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -126,8 +126,7 @@ func checkOutputFormat(r *http.Request) error {
 		output = request.QueryStringParam(r, "output", "")
 	}
 	if output != "json" {
-		err := fmt.Errorf("googlereader: only json output is supported")
-		return err
+		return errors.New("googlereader: only json output is supported")
 	}
 	return nil
 }

--- a/internal/integration/apprise/apprise.go
+++ b/internal/integration/apprise/apprise.go
@@ -6,6 +6,7 @@ package apprise
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -29,7 +30,7 @@ func NewClient(serviceURL, baseURL string) *Client {
 
 func (c *Client) SendNotification(feed *model.Feed, entries model.Entries) error {
 	if c.baseURL == "" || c.servicesURL == "" {
-		return fmt.Errorf("apprise: missing base URL or services URL")
+		return errors.New("apprise: missing base URL or services URL")
 	}
 
 	for _, entry := range entries {

--- a/internal/integration/espial/espial.go
+++ b/internal/integration/espial/espial.go
@@ -6,6 +6,7 @@ package espial // import "miniflux.app/v2/internal/integration/espial"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -27,7 +28,7 @@ func NewClient(baseURL, apiKey string) *Client {
 
 func (c *Client) CreateLink(entryURL, entryTitle, espialTags string) error {
 	if c.baseURL == "" || c.apiKey == "" {
-		return fmt.Errorf("espial: missing base URL or API key")
+		return errors.New("espial: missing base URL or API key")
 	}
 
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/add")

--- a/internal/integration/instapaper/instapaper.go
+++ b/internal/integration/instapaper/instapaper.go
@@ -4,6 +4,7 @@
 package instapaper // import "miniflux.app/v2/internal/integration/instapaper"
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,7 +26,7 @@ func NewClient(username, password string) *Client {
 
 func (c *Client) AddURL(entryURL, entryTitle string) error {
 	if c.username == "" || c.password == "" {
-		return fmt.Errorf("instapaper: missing username or password")
+		return errors.New("instapaper: missing username or password")
 	}
 
 	values := url.Values{}

--- a/internal/integration/linkace/linkace.go
+++ b/internal/integration/linkace/linkace.go
@@ -3,6 +3,7 @@ package linkace
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -28,7 +29,7 @@ func NewClient(baseURL, apiKey, tags string, private bool, checkDisabled bool) *
 
 func (c *Client) AddURL(entryURL, entryTitle string) error {
 	if c.baseURL == "" || c.apiKey == "" {
-		return fmt.Errorf("linkace: missing base URL or API key")
+		return errors.New("linkace: missing base URL or API key")
 	}
 
 	tagsSplitFn := func(c rune) bool {

--- a/internal/integration/linkding/linkding.go
+++ b/internal/integration/linkding/linkding.go
@@ -6,6 +6,7 @@ package linkding // import "miniflux.app/v2/internal/integration/linkding"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -30,7 +31,7 @@ func NewClient(baseURL, apiKey, tags string, unread bool) *Client {
 
 func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 	if c.baseURL == "" || c.apiKey == "" {
-		return fmt.Errorf("linkding: missing base URL or API key")
+		return errors.New("linkding: missing base URL or API key")
 	}
 
 	tagsSplitFn := func(c rune) bool {

--- a/internal/integration/linktaco/linktaco.go
+++ b/internal/integration/linktaco/linktaco.go
@@ -6,6 +6,7 @@ package linktaco // import "miniflux.app/v2/internal/integration/linktaco"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -44,7 +45,7 @@ func NewClient(apiToken, orgSlug, tags, visibility string) *Client {
 
 func (c *Client) CreateBookmark(entryURL, entryTitle, entryContent string) error {
 	if c.apiToken == "" || c.orgSlug == "" {
-		return fmt.Errorf("linktaco: missing API token or organization slug")
+		return errors.New("linktaco: missing API token or organization slug")
 	}
 
 	description := entryContent

--- a/internal/integration/notion/notion.go
+++ b/internal/integration/notion/notion.go
@@ -6,6 +6,7 @@ package notion
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -26,7 +27,7 @@ func NewClient(apiToken, pageID string) *Client {
 
 func (c *Client) UpdateDocument(entryURL string, entryTitle string) error {
 	if c.apiToken == "" || c.pageID == "" {
-		return fmt.Errorf("notion: missing API token or page ID")
+		return errors.New("notion: missing API token or page ID")
 	}
 
 	apiEndpoint := "https://api.notion.com/v1/blocks/" + c.pageID + "/children"

--- a/internal/integration/nunuxkeeper/nunuxkeeper.go
+++ b/internal/integration/nunuxkeeper/nunuxkeeper.go
@@ -6,6 +6,7 @@ package nunuxkeeper // import "miniflux.app/v2/internal/integration/nunuxkeeper"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -27,7 +28,7 @@ func NewClient(baseURL, apiKey string) *Client {
 
 func (c *Client) AddEntry(entryURL, entryTitle, entryContent string) error {
 	if c.baseURL == "" || c.apiKey == "" {
-		return fmt.Errorf("nunux-keeper: missing base URL or API key")
+		return errors.New("nunux-keeper: missing base URL or API key")
 	}
 
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/v2/documents")

--- a/internal/integration/pinboard/pinboard.go
+++ b/internal/integration/pinboard/pinboard.go
@@ -14,8 +14,8 @@ import (
 	"miniflux.app/v2/internal/version"
 )
 
-var errPostNotFound = fmt.Errorf("pinboard: post not found")
-var errMissingCredentials = fmt.Errorf("pinboard: missing auth token")
+var errPostNotFound = errors.New("pinboard: post not found")
+var errMissingCredentials = errors.New("pinboard: missing auth token")
 
 const defaultClientTimeout = 10 * time.Second
 

--- a/internal/integration/pushover/pushover.go
+++ b/internal/integration/pushover/pushover.go
@@ -5,6 +5,7 @@ package pushover // import "miniflux.app/v2/internal/integration/pushover"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -72,7 +73,7 @@ func New(user, token string, priority int, device, urlPrefix string) *Client {
 
 func (c *Client) SendMessages(feed *model.Feed, entries model.Entries) error {
 	if c.token == "" || c.user == "" {
-		return fmt.Errorf("pushover token and user are required")
+		return errors.New("pushover token and user are required")
 	}
 	for _, entry := range entries {
 		msg := &Message{

--- a/internal/integration/raindrop/raindrop.go
+++ b/internal/integration/raindrop/raindrop.go
@@ -6,6 +6,7 @@ package raindrop // import "miniflux.app/v2/internal/integration/raindrop"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,7 +30,7 @@ func NewClient(token, collectionID, tags string) *Client {
 // https://developer.raindrop.io/v1/raindrops/single#create-raindrop
 func (c *Client) CreateRaindrop(entryURL, entryTitle string) error {
 	if c.token == "" {
-		return fmt.Errorf("raindrop: missing token")
+		return errors.New("raindrop: missing token")
 	}
 
 	var request *http.Request

--- a/internal/integration/readeck/readeck.go
+++ b/internal/integration/readeck/readeck.go
@@ -6,6 +6,7 @@ package readeck // import "miniflux.app/v2/internal/integration/readeck"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime/multipart"
 	"net/http"
@@ -31,7 +32,7 @@ func NewClient(baseURL, apiKey, labels string, onlyURL bool) *Client {
 
 func (c *Client) CreateBookmark(entryURL, entryTitle string, entryContent string) error {
 	if c.baseURL == "" || c.apiKey == "" {
-		return fmt.Errorf("readeck: missing base URL or API key")
+		return errors.New("readeck: missing base URL or API key")
 	}
 
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/bookmarks/")

--- a/internal/integration/readwise/readwise.go
+++ b/internal/integration/readwise/readwise.go
@@ -8,6 +8,7 @@ package readwise // import "miniflux.app/v2/internal/integration/readwise"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -30,7 +31,7 @@ func NewClient(apiKey string) *Client {
 
 func (c *Client) CreateDocument(entryURL string) error {
 	if c.apiKey == "" {
-		return fmt.Errorf("readwise: missing API key")
+		return errors.New("readwise: missing API key")
 	}
 
 	requestBody, err := json.Marshal(&readwiseDocument{

--- a/internal/integration/shaarli/shaarli.go
+++ b/internal/integration/shaarli/shaarli.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -30,7 +31,7 @@ func NewClient(baseURL, apiSecret string) *Client {
 
 func (c *Client) CreateLink(entryURL, entryTitle string) error {
 	if c.baseURL == "" || c.apiSecret == "" {
-		return fmt.Errorf("shaarli: missing base URL or API secret")
+		return errors.New("shaarli: missing base URL or API secret")
 	}
 
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/v1/links")

--- a/internal/integration/shiori/shiori.go
+++ b/internal/integration/shiori/shiori.go
@@ -6,6 +6,7 @@ package shiori // import "miniflux.app/v2/internal/integration/shiori"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -28,7 +29,7 @@ func NewClient(baseURL, username, password string) *Client {
 
 func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 	if c.baseURL == "" || c.username == "" || c.password == "" {
-		return fmt.Errorf("shiori: missing base URL, username or password")
+		return errors.New("shiori: missing base URL, username or password")
 	}
 
 	token, err := c.authenticate()

--- a/internal/integration/wallabag/wallabag.go
+++ b/internal/integration/wallabag/wallabag.go
@@ -6,6 +6,7 @@ package wallabag // import "miniflux.app/v2/internal/integration/wallabag"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -34,7 +35,7 @@ func NewClient(baseURL, clientID, clientSecret, username, password, tags string,
 
 func (c *Client) CreateEntry(entryURL, entryTitle, entryContent string) error {
 	if c.baseURL == "" || c.clientID == "" || c.clientSecret == "" || c.username == "" || c.password == "" {
-		return fmt.Errorf("wallabag: missing base URL, client ID, client secret, username or password")
+		return errors.New("wallabag: missing base URL, client ID, client secret, username or password")
 	}
 
 	accessToken, err := c.getAccessToken()

--- a/internal/integration/webhook/webhook.go
+++ b/internal/integration/webhook/webhook.go
@@ -6,6 +6,7 @@ package webhook // import "miniflux.app/v2/internal/integration/webhook"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -113,7 +114,7 @@ func (c *Client) SendNewEntriesWebhookEvent(feed *model.Feed, entries model.Entr
 
 func (c *Client) makeRequest(eventType string, payload any) error {
 	if c.webhookURL == "" {
-		return fmt.Errorf(`webhook: missing webhook URL`)
+		return errors.New(`webhook: missing webhook URL`)
 	}
 
 	requestBody, err := json.Marshal(payload)

--- a/internal/reader/processor/bilibili.go
+++ b/internal/reader/processor/bilibili.go
@@ -5,6 +5,7 @@ package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -75,12 +76,12 @@ func fetchBilibiliWatchTime(websiteURL string) (int, error) {
 
 	data, ok := result["data"].(map[string]any)
 	if !ok {
-		return 0, fmt.Errorf("data field not found or not an object")
+		return 0, errors.New("data field not found or not an object")
 	}
 
 	duration, ok := data["duration"].(float64)
 	if !ok {
-		return 0, fmt.Errorf("duration not found or not a number")
+		return 0, errors.New("duration not found or not a number")
 	}
 	intDuration := int(duration)
 	durationMin := intDuration / 60

--- a/internal/reader/readability/readability_test.go
+++ b/internal/reader/readability/readability_test.go
@@ -5,6 +5,7 @@ package readability // import "miniflux.app/v2/internal/reader/readability"
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -2301,5 +2302,5 @@ func TestExtractContentWithBrokenReader(t *testing.T) {
 type brokenReader struct{}
 
 func (br *brokenReader) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("simulated read error")
+	return 0, errors.New("simulated read error")
 }

--- a/internal/reader/sanitizer/srcset.go
+++ b/internal/reader/sanitizer/srcset.go
@@ -4,7 +4,7 @@
 package sanitizer
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 )
@@ -54,11 +54,11 @@ func parseImageCandidate(input string) (*imageCandidate, error) {
 		return &imageCandidate{ImageURL: parts[0]}, nil
 	case 2:
 		if !isValidWidthOrDensityDescriptor(parts[1]) {
-			return nil, fmt.Errorf(`srcset: invalid descriptor`)
+			return nil, errors.New(`srcset: invalid descriptor`)
 		}
 		return &imageCandidate{ImageURL: parts[0], Descriptor: parts[1]}, nil
 	default:
-		return nil, fmt.Errorf(`srcset: invalid number of descriptors`)
+		return nil, errors.New(`srcset: invalid number of descriptors`)
 	}
 }
 

--- a/internal/reader/urlcleaner/urlcleaner.go
+++ b/internal/reader/urlcleaner/urlcleaner.go
@@ -4,7 +4,7 @@
 package urlcleaner // import "miniflux.app/v2/internal/reader/urlcleaner"
 
 import (
-	"fmt"
+	"errors"
 	"net/url"
 	"strings"
 )
@@ -97,7 +97,7 @@ var trackingParamsOutbound = map[string]bool{
 
 func RemoveTrackingParameters(parsedFeedURL, parsedSiteURL, parsedInputUrl *url.URL) (string, error) {
 	if parsedFeedURL == nil || parsedSiteURL == nil || parsedInputUrl == nil {
-		return "", fmt.Errorf("urlcleaner: one of the URLs is nil")
+		return "", errors.New("urlcleaner: one of the URLs is nil")
 	}
 
 	queryParams := parsedInputUrl.Query()

--- a/internal/storage/api_key.go
+++ b/internal/storage/api_key.go
@@ -4,13 +4,14 @@
 package storage // import "miniflux.app/v2/internal/storage"
 
 import (
+	"errors"
 	"fmt"
 
 	"miniflux.app/v2/internal/crypto"
 	"miniflux.app/v2/internal/model"
 )
 
-var ErrAPIKeyNotFound = fmt.Errorf("store: API Key not found")
+var ErrAPIKeyNotFound = errors.New("store: API Key not found")
 
 // APIKeyExists checks if an API Key with the same description exists.
 func (s *Storage) APIKeyExists(userID int64, description string) bool {

--- a/internal/storage/user_session.go
+++ b/internal/storage/user_session.go
@@ -6,6 +6,7 @@ package storage // import "miniflux.app/v2/internal/storage"
 import (
 	"crypto/rand"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -138,7 +139,7 @@ func (s *Storage) RemoveUserSessionByToken(userID int64, token string) error {
 	}
 
 	if count != 1 {
-		return fmt.Errorf(`store: nothing has been removed`)
+		return errors.New(`store: nothing has been removed`)
 	}
 
 	return nil
@@ -158,7 +159,7 @@ func (s *Storage) RemoveUserSessionByID(userID, sessionID int64) error {
 	}
 
 	if count != 1 {
-		return fmt.Errorf(`store: nothing has been removed`)
+		return errors.New(`store: nothing has been removed`)
 	}
 
 	return nil

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -4,6 +4,7 @@
 package systemd // import "miniflux.app/v2/internal/systemd"
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -40,7 +41,7 @@ func WatchdogInterval() (time.Duration, error) {
 	}
 
 	if s <= 0 {
-		return 0, fmt.Errorf(`systemd: error WATCHDOG_USEC must be a positive number`)
+		return 0, errors.New(`systemd: error WATCHDOG_USEC must be a positive number`)
 	}
 
 	return time.Duration(s) * time.Microsecond, nil

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -4,6 +4,7 @@
 package template // import "miniflux.app/v2/internal/template"
 
 import (
+	"errors"
 	"fmt"
 	"html/template"
 	"math"
@@ -153,13 +154,13 @@ func csp(user *model.User, nonce string) string {
 
 func dict(values ...any) (map[string]any, error) {
 	if len(values)%2 != 0 {
-		return nil, fmt.Errorf("dict expects an even number of arguments")
+		return nil, errors.New("dict expects an even number of arguments")
 	}
 	dict := make(map[string]any, len(values)/2)
 	for i := 0; i < len(values); i += 2 {
 		key, ok := values[i].(string)
 		if !ok {
-			return nil, fmt.Errorf("dict keys must be strings")
+			return nil, errors.New("dict keys must be strings")
 		}
 		dict[key] = values[i+1]
 	}

--- a/internal/urllib/url.go
+++ b/internal/urllib/url.go
@@ -4,6 +4,7 @@
 package urllib // import "miniflux.app/v2/internal/urllib"
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -103,11 +104,11 @@ func DomainWithoutWWW(websiteURL string) string {
 // JoinBaseURLAndPath returns a URL string with the provided path elements joined together.
 func JoinBaseURLAndPath(baseURL, path string) (string, error) {
 	if baseURL == "" {
-		return "", fmt.Errorf("empty base URL")
+		return "", errors.New("empty base URL")
 	}
 
 	if path == "" {
-		return "", fmt.Errorf("empty path")
+		return "", errors.New("empty path")
 	}
 
 	_, err := url.Parse(baseURL)

--- a/internal/validator/enclosure.go
+++ b/internal/validator/enclosure.go
@@ -4,14 +4,14 @@
 package validator
 
 import (
-	"fmt"
+	"errors"
 
 	"miniflux.app/v2/internal/model"
 )
 
 func ValidateEnclosureUpdateRequest(request *model.EnclosureUpdateRequest) error {
 	if request.MediaProgression < 0 {
-		return fmt.Errorf(`media progression must an positive integer`)
+		return errors.New(`media progression must an positive integer`)
 	}
 
 	return nil

--- a/internal/validator/entry.go
+++ b/internal/validator/entry.go
@@ -4,6 +4,7 @@
 package validator // import "miniflux.app/v2/internal/validator"
 
 import (
+	"errors"
 	"fmt"
 
 	"miniflux.app/v2/internal/model"
@@ -12,7 +13,7 @@ import (
 // ValidateEntriesStatusUpdateRequest validates a status update for a list of entries.
 func ValidateEntriesStatusUpdateRequest(request *model.EntriesStatusUpdateRequest) error {
 	if len(request.EntryIDs) == 0 {
-		return fmt.Errorf(`the list of entries cannot be empty`)
+		return errors.New(`the list of entries cannot be empty`)
 	}
 
 	return ValidateEntryStatus(request.Status)
@@ -35,17 +36,17 @@ func ValidateEntryOrder(order string) error {
 		return nil
 	}
 
-	return fmt.Errorf(`invalid entry order, valid order values are: "id", "status", "changed_at", "published_at", "created_at", "category_title", "category_id", "title", "author"`)
+	return errors.New(`invalid entry order, valid order values are: "id", "status", "changed_at", "published_at", "created_at", "category_title", "category_id", "title", "author"`)
 }
 
 // ValidateEntryModification makes sure the entry modification is valid.
 func ValidateEntryModification(request *model.EntryUpdateRequest) error {
 	if request.Title != nil && *request.Title == "" {
-		return fmt.Errorf(`the entry title cannot be empty`)
+		return errors.New(`the entry title cannot be empty`)
 	}
 
 	if request.Content != nil && *request.Content == "" {
-		return fmt.Errorf(`the entry content cannot be empty`)
+		return errors.New(`the entry content cannot be empty`)
 	}
 
 	return nil

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -4,7 +4,7 @@
 package validator // import "miniflux.app/v2/internal/validator"
 
 import (
-	"fmt"
+	"errors"
 	"net/url"
 	"regexp"
 	"strings"
@@ -15,11 +15,11 @@ var domainRegex = regexp.MustCompile(`^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.
 // ValidateRange makes sure the offset/limit values are valid.
 func ValidateRange(offset, limit int) error {
 	if offset < 0 {
-		return fmt.Errorf(`offset value should be >= 0`)
+		return errors.New(`offset value should be >= 0`)
 	}
 
 	if limit < 0 {
-		return fmt.Errorf(`limit value should be >= 0`)
+		return errors.New(`limit value should be >= 0`)
 	}
 
 	return nil
@@ -32,7 +32,7 @@ func ValidateDirection(direction string) error {
 		return nil
 	}
 
-	return fmt.Errorf(`invalid direction, valid direction values are: "asc" or "desc"`)
+	return errors.New(`invalid direction, valid direction values are: "asc" or "desc"`)
 }
 
 // IsValidRegex verifies if the regex can be compiled.


### PR DESCRIPTION
No need to to invoke the whole Printf machinery for constant strings. While this shouldn't have an impact on memory consumption nor allocation (as constructing errors to return is never in a hot path), this should reduce a bit the code size, as errors.New will be inlined to a simple struct initialization instead of a function call.