### PR TITLE
refactor(misc): replace from ParseInt/ParseFloat with cheaper Itoa

### DIFF
--- a/internal/reader/processor/reading_time.go
+++ b/internal/reader/processor/reading_time.go
@@ -49,11 +49,11 @@ func fetchWatchTime(websiteURL, query string, isoDate bool) (int, error) {
 		}
 		ret = int(parsedDuration.Minutes())
 	} else {
-		parsedDuration, err := strconv.ParseInt(duration, 10, 64)
+		parsedDuration, err := strconv.Atoi(duration)
 		if err != nil {
 			return 0, fmt.Errorf("unable to parse duration %s: %v", duration, err)
 		}
-		ret = int(parsedDuration / 60)
+		ret = parsedDuration / 60
 	}
 	return ret, nil
 }

--- a/internal/reader/processor/utils.go
+++ b/internal/reader/processor/utils.go
@@ -25,31 +25,31 @@ func parseISO8601Duration(duration string) (time.Duration, error) {
 	num := ""
 
 	for _, char := range after {
-		var val float64
+		var val int
 		var err error
 
 		switch char {
 		case 'Y', 'W', 'D':
 			return 0, fmt.Errorf("the '%c' specifier isn't supported", char)
 		case 'H':
-			if val, err = strconv.ParseFloat(num, 64); err != nil {
+			if val, err = strconv.Atoi(num); err != nil {
 				return 0, err
 			}
 			d += time.Duration(val) * time.Hour
 			num = ""
 		case 'M':
-			if val, err = strconv.ParseFloat(num, 64); err != nil {
+			if val, err = strconv.Atoi(num); err != nil {
 				return 0, err
 			}
 			d += time.Duration(val) * time.Minute
 			num = ""
 		case 'S':
-			if val, err = strconv.ParseFloat(num, 64); err != nil {
+			if val, err = strconv.Atoi(num); err != nil {
 				return 0, err
 			}
 			d += time.Duration(val) * time.Second
 			num = ""
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			num += string(char)
 			continue
 		default:

--- a/internal/reader/processor/utils_test.go
+++ b/internal/reader/processor/utils_test.go
@@ -70,10 +70,10 @@ func TestISO8601DurationParsingErrors(t *testing.T) {
 		{"PT1a2H", "invalid character in the period"},
 		{"PT3b4M", "invalid character in the period"},
 		{"PT5c6S", "invalid character in the period"},
-		// Test cases for actual ParseFloat errors (empty number before specifier)
-		{"PTH", "strconv.ParseFloat: parsing \"\": invalid syntax"},
-		{"PTM", "strconv.ParseFloat: parsing \"\": invalid syntax"},
-		{"PTS", "strconv.ParseFloat: parsing \"\": invalid syntax"},
+		// Test cases for actual Atoi errors (empty number before specifier)
+		{"PTH", "strconv.Atoi: parsing \"\": invalid syntax"},
+		{"PTM", "strconv.Atoi: parsing \"\": invalid syntax"},
+		{"PTS", "strconv.Atoi: parsing \"\": invalid syntax"},
 		// Invalid character
 		{"PT1X", "invalid character in the period"},
 		// Invalid character mixed

--- a/internal/ui/form/settings.go
+++ b/internal/ui/form/settings.go
@@ -166,15 +166,15 @@ func (s *SettingsForm) Validate() *locale.LocalizedError {
 
 // NewSettingsForm returns a new SettingsForm.
 func NewSettingsForm(r *http.Request) *SettingsForm {
-	entriesPerPage, err := strconv.ParseInt(r.FormValue("entries_per_page"), 10, 0)
+	entriesPerPage, err := strconv.Atoi(r.FormValue("entries_per_page"))
 	if err != nil {
 		entriesPerPage = 0
 	}
-	defaultReadingSpeed, err := strconv.ParseInt(r.FormValue("default_reading_speed"), 10, 0)
+	defaultReadingSpeed, err := strconv.Atoi(r.FormValue("default_reading_speed"))
 	if err != nil {
 		defaultReadingSpeed = 0
 	}
-	cjkReadingSpeed, err := strconv.ParseInt(r.FormValue("cjk_reading_speed"), 10, 0)
+	cjkReadingSpeed, err := strconv.Atoi(r.FormValue("cjk_reading_speed"))
 	if err != nil {
 		cjkReadingSpeed = 0
 	}


### PR DESCRIPTION
There is no need to use strconv.ParseInt and strconv.ParseFloat instead of the much simpler/faster strconv.Itoa.