### PR TITLE
refactor(sanitizer): save some cycles in hasRequiredAttributes

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -467,7 +467,12 @@ func hasRequiredAttributes(tagName string, attributes []string) bool {
 	case "iframe":
 		return slices.Contains(attributes, "src")
 	case "source", "img":
-		return slices.Contains(attributes, "src") || slices.Contains(attributes, "srcset")
+		for _, attribute := range attributes {
+			if attribute == "src" || attribute == "srcset" {
+				return true
+			}
+		}
+		return false
 	default:
 		return true
 	}


### PR DESCRIPTION
There is no need to iterate twice on the attributes of source and img tags, when we can do it once. This shouldn't bring any noticeable performances improvements, except maybe in some extreme cases on pages with a lot of images with a lot of attributes.