### PR TITLE
refactor(config): massively simplify the configuration parser

### DIFF
--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -1614,8 +1614,8 @@ func TestSetLogLevelFunction(t *testing.T) {
 	if configParser.options.LogLevel() != "debug" {
 		t.Fatalf("Expected LOG_LEVEL to be 'debug' after SetLogLevel('debug'), got '%s'", configParser.options.LogLevel())
 	}
-	if configParser.options.options["LOG_LEVEL"].RawValue != "debug" {
-		t.Fatalf("Expected LOG_LEVEL RawValue to be 'debug', got '%s'", configParser.options.options["LOG_LEVEL"].RawValue)
+	if configParser.options.options["LOG_LEVEL"].str != "debug" {
+		t.Fatalf("Expected LOG_LEVEL str to be 'debug', got '%s'", configParser.options.options["LOG_LEVEL"].str)
 	}
 
 	// Test setting log level to warning
@@ -1623,8 +1623,8 @@ func TestSetLogLevelFunction(t *testing.T) {
 	if configParser.options.LogLevel() != "warning" {
 		t.Fatalf("Expected LOG_LEVEL to be 'warning' after SetLogLevel('warning'), got '%s'", configParser.options.LogLevel())
 	}
-	if configParser.options.options["LOG_LEVEL"].RawValue != "warning" {
-		t.Fatalf("Expected LOG_LEVEL RawValue to be 'warning', got '%s'", configParser.options.options["LOG_LEVEL"].RawValue)
+	if configParser.options.options["LOG_LEVEL"].str != "warning" {
+		t.Fatalf("Expected LOG_LEVEL RawValue to be 'warning', got '%s'", configParser.options.options["LOG_LEVEL"].str)
 	}
 }
 


### PR DESCRIPTION
Instead of having as structure with every possible type as member, use a single `any`. The type is determined by the default value, reducing the amount of copy/paste, code complexity, as well as memory consumption.

This PR is sent as a draft to gather feedback on the idea before moving all the different types to this new parsing method.