### PR TITLE
feat(client): allow http.Client as option and add context to api methods

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,9 +4,11 @@
 package client // import "miniflux.app/v2/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -26,22 +28,45 @@ func New(endpoint string, credentials ...string) *Client {
 
 // NewClient returns a new Miniflux client.
 func NewClient(endpoint string, credentials ...string) *Client {
+	switch len(credentials) {
+	case 2:
+		return NewClientWithOptions(endpoint, WithCredentials(credentials[0], credentials[1]))
+	case 1:
+		return NewClientWithOptions(endpoint, WithAPIKey(credentials[0]))
+	default:
+		return NewClientWithOptions(endpoint)
+	}
+}
+
+// NewClientWithOptions returns a new Miniflux client with options.
+func NewClientWithOptions(endpoint string, options ...Option) *Client {
 	// Trim trailing slashes and /v1 from the endpoint.
 	endpoint = strings.TrimSuffix(endpoint, "/")
 	endpoint = strings.TrimSuffix(endpoint, "/v1")
-	switch len(credentials) {
-	case 2:
-		return &Client{request: &request{endpoint: endpoint, username: credentials[0], password: credentials[1]}}
-	case 1:
-		return &Client{request: &request{endpoint: endpoint, apiKey: credentials[0]}}
-	default:
-		return &Client{request: &request{endpoint: endpoint}}
+	request := &request{endpoint: endpoint, client: http.DefaultClient}
+
+	for _, option := range options {
+		option(request)
 	}
+
+	return &Client{request: request}
+}
+
+func withDefaultTimeout() (context.Context, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	return ctx, cancel
 }
 
 // Healthcheck checks if the application is up and running.
 func (c *Client) Healthcheck() error {
-	body, err := c.request.Get("/healthcheck")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.HealthcheckContext(ctx)
+}
+
+// HealthcheckContext checks if the application is up and running.
+func (c *Client) HealthcheckContext(ctx context.Context) error {
+	body, err := c.request.Get(ctx, "/healthcheck")
 	if err != nil {
 		return fmt.Errorf("miniflux: unable to perform healthcheck: %w", err)
 	}
@@ -61,7 +86,14 @@ func (c *Client) Healthcheck() error {
 
 // Version returns the version of the Miniflux instance.
 func (c *Client) Version() (*VersionResponse, error) {
-	body, err := c.request.Get("/v1/version")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.VersionContext(ctx)
+}
+
+// VersionContext returns the version of the Miniflux instance.
+func (c *Client) VersionContext(ctx context.Context) (*VersionResponse, error) {
+	body, err := c.request.Get(ctx, "/v1/version")
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +109,14 @@ func (c *Client) Version() (*VersionResponse, error) {
 
 // Me returns the logged user information.
 func (c *Client) Me() (*User, error) {
-	body, err := c.request.Get("/v1/me")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.MeContext(ctx)
+}
+
+// MeContext returns the logged user information.
+func (c *Client) MeContext(ctx context.Context) (*User, error) {
+	body, err := c.request.Get(ctx, "/v1/me")
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +132,14 @@ func (c *Client) Me() (*User, error) {
 
 // Users returns all users.
 func (c *Client) Users() (Users, error) {
-	body, err := c.request.Get("/v1/users")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UsersContext(ctx)
+}
+
+// UsersContext returns all users.
+func (c *Client) UsersContext(ctx context.Context) (Users, error) {
+	body, err := c.request.Get(ctx, "/v1/users")
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +155,14 @@ func (c *Client) Users() (Users, error) {
 
 // UserByID returns a single user.
 func (c *Client) UserByID(userID int64) (*User, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/users/%d", userID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UserByIDContext(ctx, userID)
+}
+
+// UserByIDContext returns a single user.
+func (c *Client) UserByIDContext(ctx context.Context, userID int64) (*User, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/users/%d", userID))
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +178,14 @@ func (c *Client) UserByID(userID int64) (*User, error) {
 
 // UserByUsername returns a single user.
 func (c *Client) UserByUsername(username string) (*User, error) {
-	body, err := c.request.Get("/v1/users/" + username)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UserByUsernameContext(ctx, username)
+}
+
+// UserByUsernameContext returns a single user.
+func (c *Client) UserByUsernameContext(ctx context.Context, username string) (*User, error) {
+	body, err := c.request.Get(ctx, "/v1/users/"+username)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +201,14 @@ func (c *Client) UserByUsername(username string) (*User, error) {
 
 // CreateUser creates a new user in the system.
 func (c *Client) CreateUser(username, password string, isAdmin bool) (*User, error) {
-	body, err := c.request.Post("/v1/users", &UserCreationRequest{
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CreateUserContext(ctx, username, password, isAdmin)
+}
+
+// CreateUserContext creates a new user in the system.
+func (c *Client) CreateUserContext(ctx context.Context, username, password string, isAdmin bool) (*User, error) {
+	body, err := c.request.Post(ctx, "/v1/users", &UserCreationRequest{
 		Username: username,
 		Password: password,
 		IsAdmin:  isAdmin,
@@ -161,7 +228,14 @@ func (c *Client) CreateUser(username, password string, isAdmin bool) (*User, err
 
 // UpdateUser updates a user in the system.
 func (c *Client) UpdateUser(userID int64, userChanges *UserModificationRequest) (*User, error) {
-	body, err := c.request.Put(fmt.Sprintf("/v1/users/%d", userID), userChanges)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateUserContext(ctx, userID, userChanges)
+}
+
+// UpdateUserContext updates a user in the system.
+func (c *Client) UpdateUserContext(ctx context.Context, userID int64, userChanges *UserModificationRequest) (*User, error) {
+	body, err := c.request.Put(ctx, fmt.Sprintf("/v1/users/%d", userID), userChanges)
 	if err != nil {
 		return nil, err
 	}
@@ -177,12 +251,26 @@ func (c *Client) UpdateUser(userID int64, userChanges *UserModificationRequest) 
 
 // DeleteUser removes a user from the system.
 func (c *Client) DeleteUser(userID int64) error {
-	return c.request.Delete(fmt.Sprintf("/v1/users/%d", userID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.DeleteUserContext(ctx, userID)
+}
+
+// DeleteUserContext removes a user from the system.
+func (c *Client) DeleteUserContext(ctx context.Context, userID int64) error {
+	return c.request.Delete(ctx, fmt.Sprintf("/v1/users/%d", userID))
 }
 
 // APIKeys returns all API keys for the authenticated user.
 func (c *Client) APIKeys() (APIKeys, error) {
-	body, err := c.request.Get("/v1/api-keys")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.APIKeysContext(ctx)
+}
+
+// APIKeysContext returns all API keys for the authenticated user.
+func (c *Client) APIKeysContext(ctx context.Context) (APIKeys, error) {
+	body, err := c.request.Get(ctx, "/v1/api-keys")
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +286,14 @@ func (c *Client) APIKeys() (APIKeys, error) {
 
 // CreateAPIKey creates a new API key for the authenticated user.
 func (c *Client) CreateAPIKey(description string) (*APIKey, error) {
-	body, err := c.request.Post("/v1/api-keys", &APIKeyCreationRequest{
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CreateAPIKeyContext(ctx, description)
+}
+
+// CreateAPIKeyContext creates a new API key for the authenticated user.
+func (c *Client) CreateAPIKeyContext(ctx context.Context, description string) (*APIKey, error) {
+	body, err := c.request.Post(ctx, "/v1/api-keys", &APIKeyCreationRequest{
 		Description: description,
 	})
 	if err != nil {
@@ -216,18 +311,39 @@ func (c *Client) CreateAPIKey(description string) (*APIKey, error) {
 
 // DeleteAPIKey removes an API key for the authenticated user.
 func (c *Client) DeleteAPIKey(apiKeyID int64) error {
-	return c.request.Delete(fmt.Sprintf("/v1/api-keys/%d", apiKeyID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.DeleteAPIKeyContext(ctx, apiKeyID)
+}
+
+// DeleteAPIKeyContext removes an API key for the authenticated user.
+func (c *Client) DeleteAPIKeyContext(ctx context.Context, apiKeyID int64) error {
+	return c.request.Delete(ctx, fmt.Sprintf("/v1/api-keys/%d", apiKeyID))
 }
 
 // MarkAllAsRead marks all unread entries as read for a given user.
 func (c *Client) MarkAllAsRead(userID int64) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/users/%d/mark-all-as-read", userID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.MarkAllAsReadContext(ctx, userID)
+}
+
+// MarkAllAsReadContext marks all unread entries as read for a given user.
+func (c *Client) MarkAllAsReadContext(ctx context.Context, userID int64) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/users/%d/mark-all-as-read", userID), nil)
 	return err
 }
 
 // IntegrationsStatus fetches the integrations status for the logged user.
 func (c *Client) IntegrationsStatus() (bool, error) {
-	body, err := c.request.Get("/v1/integrations/status")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.IntegrationsStatusContext(ctx)
+}
+
+// IntegrationsStatusContext fetches the integrations status for the logged user.
+func (c *Client) IntegrationsStatusContext(ctx context.Context) (bool, error) {
+	body, err := c.request.Get(ctx, "/v1/integrations/status")
 	if err != nil {
 		return false, err
 	}
@@ -246,7 +362,14 @@ func (c *Client) IntegrationsStatus() (bool, error) {
 
 // Discover try to find subscriptions from a website.
 func (c *Client) Discover(url string) (Subscriptions, error) {
-	body, err := c.request.Post("/v1/discover", map[string]string{"url": url})
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.DiscoverContext(ctx, url)
+}
+
+// DiscoverContext tries to find subscriptions from a website.
+func (c *Client) DiscoverContext(ctx context.Context, url string) (Subscriptions, error) {
+	body, err := c.request.Post(ctx, "/v1/discover", map[string]string{"url": url})
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +385,14 @@ func (c *Client) Discover(url string) (Subscriptions, error) {
 
 // Categories gets the list of categories.
 func (c *Client) Categories() (Categories, error) {
-	body, err := c.request.Get("/v1/categories")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CategoriesContext(ctx)
+}
+
+// CategoriesContext gets the list of categories.
+func (c *Client) CategoriesContext(ctx context.Context) (Categories, error) {
+	body, err := c.request.Get(ctx, "/v1/categories")
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +408,14 @@ func (c *Client) Categories() (Categories, error) {
 
 // CategoriesWithCounters fetches the categories with their respective feed and unread counts.
 func (c *Client) CategoriesWithCounters() (Categories, error) {
-	body, err := c.request.Get("/v1/categories?counts=true")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CategoriesWithCountersContext(ctx)
+}
+
+// CategoriesWithCountersContext fetches the categories with their respective feed and unread counts.
+func (c *Client) CategoriesWithCountersContext(ctx context.Context) (Categories, error) {
+	body, err := c.request.Get(ctx, "/v1/categories?counts=true")
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +431,14 @@ func (c *Client) CategoriesWithCounters() (Categories, error) {
 
 // CreateCategory creates a new category.
 func (c *Client) CreateCategory(title string) (*Category, error) {
-	body, err := c.request.Post("/v1/categories", &CategoryCreationRequest{
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CreateCategoryContext(ctx, title)
+}
+
+// CreateCategoryContext creates a new category.
+func (c *Client) CreateCategoryContext(ctx context.Context, title string) (*Category, error) {
+	body, err := c.request.Post(ctx, "/v1/categories", &CategoryCreationRequest{
 		Title: title,
 	})
 	if err != nil {
@@ -312,7 +456,14 @@ func (c *Client) CreateCategory(title string) (*Category, error) {
 
 // CreateCategoryWithOptions creates a new category with options.
 func (c *Client) CreateCategoryWithOptions(createRequest *CategoryCreationRequest) (*Category, error) {
-	body, err := c.request.Post("/v1/categories", createRequest)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CreateCategoryWithOptionsContext(ctx, createRequest)
+}
+
+// CreateCategoryWithOptionsContext creates a new category with options.
+func (c *Client) CreateCategoryWithOptionsContext(ctx context.Context, createRequest *CategoryCreationRequest) (*Category, error) {
+	body, err := c.request.Post(ctx, "/v1/categories", createRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +478,14 @@ func (c *Client) CreateCategoryWithOptions(createRequest *CategoryCreationReques
 
 // UpdateCategory updates a category.
 func (c *Client) UpdateCategory(categoryID int64, title string) (*Category, error) {
-	body, err := c.request.Put(fmt.Sprintf("/v1/categories/%d", categoryID), &CategoryModificationRequest{
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateCategoryContext(ctx, categoryID, title)
+}
+
+// UpdateCategoryContext updates a category.
+func (c *Client) UpdateCategoryContext(ctx context.Context, categoryID int64, title string) (*Category, error) {
+	body, err := c.request.Put(ctx, fmt.Sprintf("/v1/categories/%d", categoryID), &CategoryModificationRequest{
 		Title: SetOptionalField(title),
 	})
 	if err != nil {
@@ -345,7 +503,14 @@ func (c *Client) UpdateCategory(categoryID int64, title string) (*Category, erro
 
 // UpdateCategoryWithOptions updates a category with options.
 func (c *Client) UpdateCategoryWithOptions(categoryID int64, categoryChanges *CategoryModificationRequest) (*Category, error) {
-	body, err := c.request.Put(fmt.Sprintf("/v1/categories/%d", categoryID), categoryChanges)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateCategoryWithOptionsContext(ctx, categoryID, categoryChanges)
+}
+
+// UpdateCategoryWithOptionsContext updates a category with options.
+func (c *Client) UpdateCategoryWithOptionsContext(ctx context.Context, categoryID int64, categoryChanges *CategoryModificationRequest) (*Category, error) {
+	body, err := c.request.Put(ctx, fmt.Sprintf("/v1/categories/%d", categoryID), categoryChanges)
 	if err != nil {
 		return nil, err
 	}
@@ -361,13 +526,27 @@ func (c *Client) UpdateCategoryWithOptions(categoryID int64, categoryChanges *Ca
 
 // MarkCategoryAsRead marks all unread entries in a category as read.
 func (c *Client) MarkCategoryAsRead(categoryID int64) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/categories/%d/mark-all-as-read", categoryID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.MarkCategoryAsReadContext(ctx, categoryID)
+}
+
+// MarkCategoryAsReadContext marks all unread entries in a category as read.
+func (c *Client) MarkCategoryAsReadContext(ctx context.Context, categoryID int64) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/categories/%d/mark-all-as-read", categoryID), nil)
 	return err
 }
 
 // CategoryFeeds gets feeds of a category.
 func (c *Client) CategoryFeeds(categoryID int64) (Feeds, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/categories/%d/feeds", categoryID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CategoryFeedsContext(ctx, categoryID)
+}
+
+// CategoryFeedsContext gets feeds of a category.
+func (c *Client) CategoryFeedsContext(ctx context.Context, categoryID int64) (Feeds, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/categories/%d/feeds", categoryID))
 	if err != nil {
 		return nil, err
 	}
@@ -383,18 +562,39 @@ func (c *Client) CategoryFeeds(categoryID int64) (Feeds, error) {
 
 // DeleteCategory removes a category.
 func (c *Client) DeleteCategory(categoryID int64) error {
-	return c.request.Delete(fmt.Sprintf("/v1/categories/%d", categoryID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.DeleteCategoryContext(ctx, categoryID)
+}
+
+// DeleteCategoryContext removes a category.
+func (c *Client) DeleteCategoryContext(ctx context.Context, categoryID int64) error {
+	return c.request.Delete(ctx, fmt.Sprintf("/v1/categories/%d", categoryID))
 }
 
 // RefreshCategory refreshes a category.
 func (c *Client) RefreshCategory(categoryID int64) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/categories/%d/refresh", categoryID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.RefreshCategoryContext(ctx, categoryID)
+}
+
+// RefreshCategoryContext refreshes a category.
+func (c *Client) RefreshCategoryContext(ctx context.Context, categoryID int64) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/categories/%d/refresh", categoryID), nil)
 	return err
 }
 
 // Feeds gets all feeds.
 func (c *Client) Feeds() (Feeds, error) {
-	body, err := c.request.Get("/v1/feeds")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FeedsContext(ctx)
+}
+
+// FeedsContext gets all feeds.
+func (c *Client) FeedsContext(ctx context.Context) (Feeds, error) {
+	body, err := c.request.Get(ctx, "/v1/feeds")
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +610,14 @@ func (c *Client) Feeds() (Feeds, error) {
 
 // Export creates OPML file.
 func (c *Client) Export() ([]byte, error) {
-	body, err := c.request.Get("/v1/export")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.ExportContext(ctx)
+}
+
+// ExportContext creates OPML file.
+func (c *Client) ExportContext(ctx context.Context) ([]byte, error) {
+	body, err := c.request.Get(ctx, "/v1/export")
 	if err != nil {
 		return nil, err
 	}
@@ -426,13 +633,27 @@ func (c *Client) Export() ([]byte, error) {
 
 // Import imports an OPML file.
 func (c *Client) Import(f io.ReadCloser) error {
-	_, err := c.request.PostFile("/v1/import", f)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.ImportContext(ctx, f)
+}
+
+// ImportContext imports an OPML file.
+func (c *Client) ImportContext(ctx context.Context, f io.ReadCloser) error {
+	_, err := c.request.PostFile(ctx, "/v1/import", f)
 	return err
 }
 
 // Feed gets a feed.
 func (c *Client) Feed(feedID int64) (*Feed, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/feeds/%d", feedID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FeedContext(ctx, feedID)
+}
+
+// FeedContext gets a feed.
+func (c *Client) FeedContext(ctx context.Context, feedID int64) (*Feed, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/feeds/%d", feedID))
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +669,14 @@ func (c *Client) Feed(feedID int64) (*Feed, error) {
 
 // CreateFeed creates a new feed.
 func (c *Client) CreateFeed(feedCreationRequest *FeedCreationRequest) (int64, error) {
-	body, err := c.request.Post("/v1/feeds", feedCreationRequest)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CreateFeedContext(ctx, feedCreationRequest)
+}
+
+// CreateFeedContext creates a new feed.
+func (c *Client) CreateFeedContext(ctx context.Context, feedCreationRequest *FeedCreationRequest) (int64, error) {
+	body, err := c.request.Post(ctx, "/v1/feeds", feedCreationRequest)
 	if err != nil {
 		return 0, err
 	}
@@ -468,7 +696,14 @@ func (c *Client) CreateFeed(feedCreationRequest *FeedCreationRequest) (int64, er
 
 // UpdateFeed updates a feed.
 func (c *Client) UpdateFeed(feedID int64, feedChanges *FeedModificationRequest) (*Feed, error) {
-	body, err := c.request.Put(fmt.Sprintf("/v1/feeds/%d", feedID), feedChanges)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateFeedContext(ctx, feedID, feedChanges)
+}
+
+// UpdateFeedContext updates a feed.
+func (c *Client) UpdateFeedContext(ctx context.Context, feedID int64, feedChanges *FeedModificationRequest) (*Feed, error) {
+	body, err := c.request.Put(ctx, fmt.Sprintf("/v1/feeds/%d", feedID), feedChanges)
 	if err != nil {
 		return nil, err
 	}
@@ -484,30 +719,65 @@ func (c *Client) UpdateFeed(feedID int64, feedChanges *FeedModificationRequest) 
 
 // MarkFeedAsRead marks all unread entries of the feed as read.
 func (c *Client) MarkFeedAsRead(feedID int64) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/feeds/%d/mark-all-as-read", feedID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.MarkFeedAsReadContext(ctx, feedID)
+}
+
+// MarkFeedAsReadContext marks all unread entries of the feed as read.
+func (c *Client) MarkFeedAsReadContext(ctx context.Context, feedID int64) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/feeds/%d/mark-all-as-read", feedID), nil)
 	return err
 }
 
 // RefreshAllFeeds refreshes all feeds.
 func (c *Client) RefreshAllFeeds() error {
-	_, err := c.request.Put("/v1/feeds/refresh", nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.RefreshAllFeedsContext(ctx)
+}
+
+// RefreshAllFeedsContext refreshes all feeds.
+func (c *Client) RefreshAllFeedsContext(ctx context.Context) error {
+	_, err := c.request.Put(ctx, "/v1/feeds/refresh", nil)
 	return err
 }
 
 // RefreshFeed refreshes a feed.
 func (c *Client) RefreshFeed(feedID int64) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/feeds/%d/refresh", feedID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.RefreshFeedContext(ctx, feedID)
+}
+
+// RefreshFeedContext refreshes a feed.
+func (c *Client) RefreshFeedContext(ctx context.Context, feedID int64) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/feeds/%d/refresh", feedID), nil)
 	return err
 }
 
 // DeleteFeed removes a feed.
 func (c *Client) DeleteFeed(feedID int64) error {
-	return c.request.Delete(fmt.Sprintf("/v1/feeds/%d", feedID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.DeleteFeedContext(ctx, feedID)
+}
+
+// DeleteFeedContext removes a feed.
+func (c *Client) DeleteFeedContext(ctx context.Context, feedID int64) error {
+	return c.request.Delete(ctx, fmt.Sprintf("/v1/feeds/%d", feedID))
 }
 
 // FeedIcon gets a feed icon.
 func (c *Client) FeedIcon(feedID int64) (*FeedIcon, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/feeds/%d/icon", feedID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FeedIconContext(ctx, feedID)
+}
+
+// FeedIconContext gets a feed icon.
+func (c *Client) FeedIconContext(ctx context.Context, feedID int64) (*FeedIcon, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/feeds/%d/icon", feedID))
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +793,14 @@ func (c *Client) FeedIcon(feedID int64) (*FeedIcon, error) {
 
 // FeedEntry gets a single feed entry.
 func (c *Client) FeedEntry(feedID, entryID int64) (*Entry, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/feeds/%d/entries/%d", feedID, entryID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FeedEntryContext(ctx, feedID, entryID)
+}
+
+// FeedEntryContext gets a single feed entry.
+func (c *Client) FeedEntryContext(ctx context.Context, feedID, entryID int64) (*Entry, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/feeds/%d/entries/%d", feedID, entryID))
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +816,14 @@ func (c *Client) FeedEntry(feedID, entryID int64) (*Entry, error) {
 
 // CategoryEntry gets a single category entry.
 func (c *Client) CategoryEntry(categoryID, entryID int64) (*Entry, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/categories/%d/entries/%d", categoryID, entryID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CategoryEntryContext(ctx, categoryID, entryID)
+}
+
+// CategoryEntryContext gets a single category entry.
+func (c *Client) CategoryEntryContext(ctx context.Context, categoryID, entryID int64) (*Entry, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/categories/%d/entries/%d", categoryID, entryID))
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +839,14 @@ func (c *Client) CategoryEntry(categoryID, entryID int64) (*Entry, error) {
 
 // Entry gets a single entry.
 func (c *Client) Entry(entryID int64) (*Entry, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/entries/%d", entryID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.EntryContext(ctx, entryID)
+}
+
+// EntryContext gets a single entry.
+func (c *Client) EntryContext(ctx context.Context, entryID int64) (*Entry, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/entries/%d", entryID))
 	if err != nil {
 		return nil, err
 	}
@@ -571,9 +862,16 @@ func (c *Client) Entry(entryID int64) (*Entry, error) {
 
 // Entries fetch entries.
 func (c *Client) Entries(filter *Filter) (*EntryResultSet, error) {
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.EntriesContext(ctx, filter)
+}
+
+// EntriesContext fetches entries.
+func (c *Client) EntriesContext(ctx context.Context, filter *Filter) (*EntryResultSet, error) {
 	path := buildFilterQueryString("/v1/entries", filter)
 
-	body, err := c.request.Get(path)
+	body, err := c.request.Get(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -589,9 +887,16 @@ func (c *Client) Entries(filter *Filter) (*EntryResultSet, error) {
 
 // FeedEntries fetch feed entries.
 func (c *Client) FeedEntries(feedID int64, filter *Filter) (*EntryResultSet, error) {
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FeedEntriesContext(ctx, feedID, filter)
+}
+
+// FeedEntriesContext fetches feed entries.
+func (c *Client) FeedEntriesContext(ctx context.Context, feedID int64, filter *Filter) (*EntryResultSet, error) {
 	path := buildFilterQueryString(fmt.Sprintf("/v1/feeds/%d/entries", feedID), filter)
 
-	body, err := c.request.Get(path)
+	body, err := c.request.Get(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -607,9 +912,16 @@ func (c *Client) FeedEntries(feedID int64, filter *Filter) (*EntryResultSet, err
 
 // CategoryEntries fetch entries of a category.
 func (c *Client) CategoryEntries(categoryID int64, filter *Filter) (*EntryResultSet, error) {
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.CategoryEntriesContext(ctx, categoryID, filter)
+}
+
+// CategoryEntriesContext fetches category entries.
+func (c *Client) CategoryEntriesContext(ctx context.Context, categoryID int64, filter *Filter) (*EntryResultSet, error) {
 	path := buildFilterQueryString(fmt.Sprintf("/v1/categories/%d/entries", categoryID), filter)
 
-	body, err := c.request.Get(path)
+	body, err := c.request.Get(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -625,18 +937,32 @@ func (c *Client) CategoryEntries(categoryID int64, filter *Filter) (*EntryResult
 
 // UpdateEntries updates the status of a list of entries.
 func (c *Client) UpdateEntries(entryIDs []int64, status string) error {
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateEntriesContext(ctx, entryIDs, status)
+}
+
+// UpdateEntriesContext updates the status of a list of entries.
+func (c *Client) UpdateEntriesContext(ctx context.Context, entryIDs []int64, status string) error {
 	type payload struct {
 		EntryIDs []int64 `json:"entry_ids"`
 		Status   string  `json:"status"`
 	}
 
-	_, err := c.request.Put("/v1/entries", &payload{EntryIDs: entryIDs, Status: status})
+	_, err := c.request.Put(ctx, "/v1/entries", &payload{EntryIDs: entryIDs, Status: status})
 	return err
 }
 
 // UpdateEntry updates an entry.
 func (c *Client) UpdateEntry(entryID int64, entryChanges *EntryModificationRequest) (*Entry, error) {
-	body, err := c.request.Put(fmt.Sprintf("/v1/entries/%d", entryID), entryChanges)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateEntryContext(ctx, entryID, entryChanges)
+}
+
+// UpdateEntryContext updates an entry.
+func (c *Client) UpdateEntryContext(ctx context.Context, entryID int64, entryChanges *EntryModificationRequest) (*Entry, error) {
+	body, err := c.request.Put(ctx, fmt.Sprintf("/v1/entries/%d", entryID), entryChanges)
 	if err != nil {
 		return nil, err
 	}
@@ -652,19 +978,40 @@ func (c *Client) UpdateEntry(entryID int64, entryChanges *EntryModificationReque
 
 // ToggleStarred toggles entry starred value.
 func (c *Client) ToggleStarred(entryID int64) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/entries/%d/star", entryID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.ToggleStarredContext(ctx, entryID)
+}
+
+// ToggleStarredContext toggles entry starred value.
+func (c *Client) ToggleStarredContext(ctx context.Context, entryID int64) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/entries/%d/star", entryID), nil)
 	return err
 }
 
 // SaveEntry sends an entry to a third-party service.
 func (c *Client) SaveEntry(entryID int64) error {
-	_, err := c.request.Post(fmt.Sprintf("/v1/entries/%d/save", entryID), nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.SaveEntryContext(ctx, entryID)
+}
+
+// SaveEntryContext sends an entry to a third-party service.
+func (c *Client) SaveEntryContext(ctx context.Context, entryID int64) error {
+	_, err := c.request.Post(ctx, fmt.Sprintf("/v1/entries/%d/save", entryID), nil)
 	return err
 }
 
 // FetchEntryOriginalContent fetches the original content of an entry using the scraper.
 func (c *Client) FetchEntryOriginalContent(entryID int64) (string, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/entries/%d/fetch-content", entryID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FetchEntryOriginalContentContext(ctx, entryID)
+}
+
+// FetchEntryOriginalContentContext fetches the original content of an entry using the scraper.
+func (c *Client) FetchEntryOriginalContentContext(ctx context.Context, entryID int64) (string, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/entries/%d/fetch-content", entryID))
 	if err != nil {
 		return "", err
 	}
@@ -683,7 +1030,14 @@ func (c *Client) FetchEntryOriginalContent(entryID int64) (string, error) {
 
 // FetchCounters fetches feed counters.
 func (c *Client) FetchCounters() (*FeedCounters, error) {
-	body, err := c.request.Get("/v1/feeds/counters")
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FetchCountersContext(ctx)
+}
+
+// FetchCountersContext fetches feed counters.
+func (c *Client) FetchCountersContext(ctx context.Context) (*FeedCounters, error) {
+	body, err := c.request.Get(ctx, "/v1/feeds/counters")
 	if err != nil {
 		return nil, err
 	}
@@ -699,13 +1053,27 @@ func (c *Client) FetchCounters() (*FeedCounters, error) {
 
 // FlushHistory changes all entries with the status "read" to "removed".
 func (c *Client) FlushHistory() error {
-	_, err := c.request.Put("/v1/flush-history", nil)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.FlushHistoryContext(ctx)
+}
+
+// FlushHistoryContext changes all entries with the status "read" to "removed".
+func (c *Client) FlushHistoryContext(ctx context.Context) error {
+	_, err := c.request.Put(ctx, "/v1/flush-history", nil)
 	return err
 }
 
 // Icon fetches a feed icon.
 func (c *Client) Icon(iconID int64) (*FeedIcon, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/icons/%d", iconID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.IconContext(ctx, iconID)
+}
+
+// IconContext fetches a feed icon.
+func (c *Client) IconContext(ctx context.Context, iconID int64) (*FeedIcon, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/icons/%d", iconID))
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +1089,14 @@ func (c *Client) Icon(iconID int64) (*FeedIcon, error) {
 
 // Enclosure fetches a specific enclosure.
 func (c *Client) Enclosure(enclosureID int64) (*Enclosure, error) {
-	body, err := c.request.Get(fmt.Sprintf("/v1/enclosures/%d", enclosureID))
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.EnclosureContext(ctx, enclosureID)
+}
+
+// EnclosureContext fetches a specific enclosure.
+func (c *Client) EnclosureContext(ctx context.Context, enclosureID int64) (*Enclosure, error) {
+	body, err := c.request.Get(ctx, fmt.Sprintf("/v1/enclosures/%d", enclosureID))
 	if err != nil {
 		return nil, err
 	}
@@ -737,7 +1112,14 @@ func (c *Client) Enclosure(enclosureID int64) (*Enclosure, error) {
 
 // UpdateEnclosure updates an enclosure.
 func (c *Client) UpdateEnclosure(enclosureID int64, enclosureUpdate *EnclosureUpdateRequest) error {
-	_, err := c.request.Put(fmt.Sprintf("/v1/enclosures/%d", enclosureID), enclosureUpdate)
+	ctx, cancel := withDefaultTimeout()
+	defer cancel()
+	return c.UpdateEnclosureContext(ctx, enclosureID, enclosureUpdate)
+}
+
+// UpdateEnclosureContext updates an enclosure.
+func (c *Client) UpdateEnclosureContext(ctx context.Context, enclosureID int64, enclosureUpdate *EnclosureUpdateRequest) error {
+	_, err := c.request.Put(ctx, fmt.Sprintf("/v1/enclosures/%d", enclosureID), enclosureUpdate)
 	return err
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,1288 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func newFakeHTTPClient(
+	t *testing.T,
+	fn func(t *testing.T, req *http.Request) *http.Response,
+) *http.Client {
+	return &http.Client{
+		Transport: roundTripperFunc(
+			func(req *http.Request) (*http.Response, error) {
+				return fn(t, req), nil
+			}),
+	}
+}
+
+func jsonResponseFrom(
+	t *testing.T,
+	status int,
+	headers http.Header,
+	body any,
+) *http.Response {
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Unable to marshal body: %v", err)
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewBuffer(data)),
+		Header:     headers,
+	}
+}
+
+func asJSON(data any) string {
+	json, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(json)
+}
+
+func expectRequest(
+	t *testing.T,
+	method string,
+	url string,
+	checkBody func(r io.Reader),
+	req *http.Request,
+) {
+	if req.Method != method {
+		t.Fatalf("Expected method to be %s, got %s", method, req.Method)
+	}
+
+	if req.URL.String() != url {
+		t.Fatalf("Expected URL path to be %s, got %s", url, req.URL)
+	}
+
+	if checkBody != nil {
+		checkBody(req.Body)
+	}
+}
+
+func expectFromJSON[T any](
+	t *testing.T,
+	r io.Reader,
+	expected *T,
+) {
+	var got T
+	if err := json.NewDecoder(r).Decode(&got); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(&got, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(got))
+	}
+}
+
+func TestHealthcheck(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/healthcheck", nil, req)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString("OK")),
+				}
+			})))
+	if err := client.HealthcheckContext(t.Context()); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestVersion(t *testing.T) {
+	expected := &VersionResponse{
+		Version:   "1.0.0",
+		Commit:    "1234567890",
+		BuildDate: "2021-01-01T00:00:00Z",
+		GoVersion: "go1.20",
+		Compiler:  "gc",
+		Arch:      "amd64",
+		OS:        "linux",
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/version", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.VersionContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestMe(t *testing.T) {
+	expected := &User{
+		ID:                        1,
+		Username:                  "test",
+		Password:                  "password",
+		IsAdmin:                   false,
+		Theme:                     "light",
+		Language:                  "en",
+		Timezone:                  "UTC",
+		EntryDirection:            "asc",
+		EntryOrder:                "created_at",
+		Stylesheet:                "default",
+		CustomJS:                  "custom.js",
+		GoogleID:                  "google-id",
+		OpenIDConnectID:           "openid-connect-id",
+		EntriesPerPage:            10,
+		KeyboardShortcuts:         true,
+		ShowReadingTime:           true,
+		EntrySwipe:                true,
+		GestureNav:                "horizontal",
+		DisplayMode:               "read",
+		DefaultReadingSpeed:       1,
+		CJKReadingSpeed:           1,
+		DefaultHomePage:           "home",
+		CategoriesSortingOrder:    "asc",
+		MarkReadOnView:            true,
+		MediaPlaybackRate:         1.0,
+		BlockFilterEntryRules:     "block",
+		KeepFilterEntryRules:      "keep",
+		ExternalFontHosts:         "https://fonts.googleapis.com",
+		AlwaysOpenExternalLinks:   true,
+		OpenExternalLinksInNewTab: true,
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/me", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.MeContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestUsers(t *testing.T) {
+	expected := Users{
+		{
+			ID:       1,
+			Username: "test1",
+		},
+		{
+			ID:       2,
+			Username: "test2",
+		},
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/users", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UsersContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestUserByID(t *testing.T) {
+	expected := &User{
+		ID:       1,
+		Username: "test",
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/users/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UserByIDContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestUserByUsername(t *testing.T) {
+	expected := &User{
+		ID:       1,
+		Username: "test",
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/users/test", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UserByUsernameContext(t.Context(), "test")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestCreateUser(t *testing.T) {
+	expected := &User{
+		ID:       1,
+		Username: "test",
+		Password: "password",
+		IsAdmin:  true,
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				exp := UserCreationRequest{
+					Username: "test",
+					Password: "password",
+					IsAdmin:  true,
+				}
+				expectRequest(
+					t,
+					http.MethodPost,
+					"http://mf/v1/users",
+					func(r io.Reader) {
+						expectFromJSON(t, r, &exp)
+					},
+					req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CreateUserContext(t.Context(), "test", "password", true)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestUpdateUser(t *testing.T) {
+	expected := &User{
+		ID:       1,
+		Username: "test",
+		Password: "password",
+		IsAdmin:  true,
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/users/1", func(r io.Reader) {
+					expectFromJSON(t, r, &UserModificationRequest{
+						Username: &expected.Username,
+						Password: &expected.Password,
+					})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UpdateUserContext(t.Context(), 1, &UserModificationRequest{
+		Username: &expected.Username,
+		Password: &expected.Password,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodDelete, "http://mf/v1/users/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.DeleteUserContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestAPIKeys(t *testing.T) {
+	expected := APIKeys{
+		{
+			ID:          1,
+			Token:       "token",
+			Description: "test",
+		},
+		{
+			ID:          2,
+			Token:       "token2",
+			Description: "test2",
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/api-keys", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.APIKeysContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestCreateAPIKey(t *testing.T) {
+	expected := &APIKey{
+		ID:          42,
+		Token:       "some-token",
+		Description: "desc",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPost, "http://mf/v1/api-keys", func(r io.Reader) {
+					expectFromJSON(t, r, &APIKeyCreationRequest{
+						Description: "desc",
+					})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CreateAPIKeyContext(t.Context(), "desc")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodDelete, "http://mf/v1/api-keys/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.DeleteAPIKeyContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestMarkAllAsRead(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/users/1/mark-all-as-read", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.MarkAllAsReadContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestIntegrationsStatus(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/integrations/status", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, struct {
+					HasIntegrations bool `json:"has_integrations"`
+				}{
+					HasIntegrations: true,
+				})
+			})))
+	status, err := client.IntegrationsStatusContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !status {
+		t.Fatalf("Expected integrations status to be true, got false")
+	}
+}
+
+func TestDiscover(t *testing.T) {
+	expected := Subscriptions{
+		{
+			URL:   "http://example.com",
+			Title: "Example",
+			Type:  "rss",
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPost, "http://mf/v1/discover", func(r io.Reader) {
+					expectFromJSON(t, r, &map[string]string{"url": "http://example.com"})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.DiscoverContext(t.Context(), "http://example.com")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestCategories(t *testing.T) {
+	expected := Categories{
+		{
+			ID:    1,
+			Title: "Example",
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/categories", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CategoriesContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestCategoriesWithCounters(t *testing.T) {
+	feedCount := 1
+	totalUnread := 2
+	expected := Categories{
+		{
+			ID:          1,
+			Title:       "Example",
+			FeedCount:   &feedCount,
+			TotalUnread: &totalUnread,
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/categories?counts=true", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CategoriesWithCountersContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestCreateCategory(t *testing.T) {
+	expected := &Category{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPost, "http://mf/v1/categories", func(r io.Reader) {
+					expectFromJSON(t, r, &CategoryCreationRequest{
+						Title: "Example",
+					})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CreateCategoryContext(t.Context(), "Example")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestCreateCategoryWithOptions(t *testing.T) {
+	expected := &Category{
+		ID:           1,
+		Title:        "Example",
+		HideGlobally: true,
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPost, "http://mf/v1/categories", func(r io.Reader) {
+					expectFromJSON(t, r, &CategoryCreationRequest{
+						Title:        "Example",
+						HideGlobally: true,
+					})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CreateCategoryWithOptionsContext(t.Context(), &CategoryCreationRequest{
+		Title:        "Example",
+		HideGlobally: true,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestUpdateCategory(t *testing.T) {
+	expected := &Category{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/categories/1", func(r io.Reader) {
+					expectFromJSON(t, r, &CategoryModificationRequest{
+						Title: &expected.Title,
+					})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UpdateCategoryContext(t.Context(), 1, "Example")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestUpdateCategoryWithOptions(t *testing.T) {
+	expected := &Category{
+		ID:           1,
+		Title:        "Example",
+		HideGlobally: true,
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/categories/1", func(r io.Reader) {
+					expectFromJSON(t, r, &CategoryModificationRequest{
+						Title:        &expected.Title,
+						HideGlobally: &expected.HideGlobally,
+					})
+				}, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UpdateCategoryWithOptionsContext(t.Context(), 1, &CategoryModificationRequest{
+		Title:        &expected.Title,
+		HideGlobally: &expected.HideGlobally,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestMarkCategoryAsRead(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/categories/1/mark-all-as-read", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.MarkCategoryAsReadContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestCategoryFeeds(t *testing.T) {
+	expected := Feeds{
+		{
+			ID:    1,
+			Title: "Example",
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/categories/1/feeds", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CategoryFeedsContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestDeleteCategory(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodDelete, "http://mf/v1/categories/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.DeleteCategoryContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestRefreshCategory(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/categories/1/refresh", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.RefreshCategoryContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestFeeds(t *testing.T) {
+	expected := Feeds{
+		{
+			ID:                          1,
+			Title:                       "Example",
+			FeedURL:                     "http://example.com",
+			SiteURL:                     "http://example.com",
+			CheckedAt:                   time.Date(1970, 1, 1, 0, 7, 0, 0, time.UTC),
+			Disabled:                    false,
+			IgnoreHTTPCache:             false,
+			AllowSelfSignedCertificates: false,
+			FetchViaProxy:               false,
+			ScraperRules:                "",
+			RewriteRules:                "",
+			UrlRewriteRules:             "",
+			BlocklistRules:              "",
+			KeeplistRules:               "",
+			BlockFilterEntryRules:       "",
+			KeepFilterEntryRules:        "",
+			Crawler:                     false,
+			UserAgent:                   "",
+			Cookie:                      "",
+			Username:                    "",
+			Password:                    "",
+			Category: &Category{
+				ID:    1,
+				Title: "Example",
+			},
+			HideGlobally: false,
+			DisableHTTP2: false,
+			ProxyURL:     "",
+		},
+		{
+			ID:    2,
+			Title: "Example 2",
+		},
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/feeds", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.FeedsContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestExport(t *testing.T) {
+	expected := []byte("hello")
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/export", nil, req)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(string(expected))),
+					Header:     http.Header{},
+				}
+			})))
+	res, err := client.ExportContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %+v, got %+v", expected, res)
+	}
+}
+
+func TestImport(t *testing.T) {
+	expected := []byte("hello")
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(
+					t,
+					http.MethodPost,
+					"http://mf/v1/import",
+					func(r io.Reader) {
+						b, err := io.ReadAll(r)
+						if err != nil {
+							t.Fatalf("Expected no error, got %v", err)
+						}
+						if !bytes.Equal(b, expected) {
+							t.Fatalf("expected %+v, got %+v", expected, b)
+						}
+					},
+					req)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{},
+				}
+			})))
+	if err := client.ImportContext(t.Context(), io.NopCloser(bytes.NewBufferString(string(expected)))); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestFeed(t *testing.T) {
+	expected := &Feed{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/feeds/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.FeedContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestCreateFeed(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPost, "http://mf/v1/feeds", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, struct {
+					FeedID int64 `json:"feed_id"`
+				}{
+					FeedID: 1,
+				})
+			})))
+	id, err := client.CreateFeedContext(t.Context(), &FeedCreationRequest{
+		FeedURL: "http://example.com",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if id != 1 {
+		t.Fatalf("Expected feed ID to be 1, got %d", id)
+	}
+}
+
+func TestUpdateFeed(t *testing.T) {
+	expected := &Feed{
+		ID:      1,
+		FeedURL: "http://example.com/",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/feeds/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UpdateFeedContext(t.Context(), 1, &FeedModificationRequest{
+		FeedURL: &expected.FeedURL,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestMarkFeedAsRead(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/feeds/1/mark-all-as-read", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.MarkFeedAsReadContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestRefreshAllFeeds(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/feeds/refresh", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.RefreshAllFeedsContext(t.Context()); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestRefreshFeed(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/feeds/1/refresh", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.RefreshFeedContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestDeleteFeed(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodDelete, "http://mf/v1/feeds/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.DeleteFeedContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestFeedIcon(t *testing.T) {
+	expected := &FeedIcon{
+		ID:       1,
+		MimeType: "text/plain",
+		Data:     "data",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/feeds/1/icon", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.FeedIconContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestFeedEntry(t *testing.T) {
+	expected := &Entry{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/feeds/1/entries/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.FeedEntryContext(t.Context(), 1, 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestCategoryEntry(t *testing.T) {
+	expected := &Entry{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/categories/1/entries/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CategoryEntryContext(t.Context(), 1, 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestEntry(t *testing.T) {
+	expected := &Entry{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/entries/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.EntryContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestEntries(t *testing.T) {
+	expected := &EntryResultSet{
+		Total: 1,
+		Entries: Entries{
+			{
+				ID:    1,
+				Title: "Example",
+			},
+		},
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/entries", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.EntriesContext(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestFeedEntries(t *testing.T) {
+	expected := &EntryResultSet{
+		Total: 1,
+		Entries: Entries{
+			{
+				ID:    1,
+				Title: "Example",
+			},
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/feeds/1/entries?limit=10&offset=0", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.FeedEntriesContext(t.Context(), 1, &Filter{
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestCategoryEntries(t *testing.T) {
+	expected := &EntryResultSet{
+		Total: 1,
+		Entries: Entries{
+			{
+				ID:    1,
+				Title: "Example",
+			},
+		},
+	}
+
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/categories/1/entries?limit=10&offset=0", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.CategoryEntriesContext(t.Context(), 1, &Filter{
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestUpdateEntries(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/entries", nil, req)
+				expectFromJSON(t, req.Body, &struct {
+					EntryIDs []int64 `json:"entry_ids"`
+					Status   string  `json:"status"`
+				}{
+					EntryIDs: []int64{1, 2},
+					Status:   "read",
+				})
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.UpdateEntriesContext(t.Context(), []int64{1, 2}, "read"); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestUpdateEntry(t *testing.T) {
+	expected := &Entry{
+		ID:    1,
+		Title: "Example",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/entries/1", nil, req)
+				expectFromJSON(t, req.Body, &EntryModificationRequest{
+					Title: &expected.Title,
+				})
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.UpdateEntryContext(t.Context(), 1, &EntryModificationRequest{
+		Title: &expected.Title,
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestToggleStarred(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/entries/1/star", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.ToggleStarredContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestSaveEntry(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPost, "http://mf/v1/entries/1/save", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.SaveEntryContext(t.Context(), 1); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestFetchEntryOriginalContent(t *testing.T) {
+	expected := "Example"
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/entries/1/fetch-content", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, struct {
+					Content string `json:"content"`
+				}{
+					Content: expected,
+				})
+			})))
+	res, err := client.FetchEntryOriginalContentContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if res != expected {
+		t.Fatalf("Expected %s, got %s", expected, res)
+	}
+}
+
+func TestFetchCounters(t *testing.T) {
+	expected := &FeedCounters{
+		ReadCounters: map[int64]int{
+			2: 1,
+		},
+		UnreadCounters: map[int64]int{
+			3: 1,
+		},
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/feeds/counters", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.FetchCountersContext(t.Context())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestFlushHistory(t *testing.T) {
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/flush-history", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, nil)
+			})))
+	if err := client.FlushHistoryContext(t.Context()); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
+func TestIcon(t *testing.T) {
+	expected := &FeedIcon{
+		ID:       1,
+		MimeType: "text/plain",
+		Data:     "data",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/icons/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.IconContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestEnclosure(t *testing.T) {
+	expected := &Enclosure{
+		ID:       1,
+		URL:      "http://example.com",
+		MimeType: "text/plain",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodGet, "http://mf/v1/enclosures/1", nil, req)
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	res, err := client.EnclosureContext(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("Expected %s, got %s", asJSON(expected), asJSON(res))
+	}
+}
+
+func TestUpdateEnclosure(t *testing.T) {
+	expected := &Enclosure{
+		ID:       1,
+		URL:      "http://example.com",
+		MimeType: "text/plain",
+	}
+	client := NewClientWithOptions(
+		"http://mf",
+		WithHTTPClient(
+			newFakeHTTPClient(t, func(t *testing.T, req *http.Request) *http.Response {
+				expectRequest(t, http.MethodPut, "http://mf/v1/enclosures/1", nil, req)
+				expectFromJSON(t, req.Body, &EnclosureUpdateRequest{
+					MediaProgression: 10,
+				})
+				return jsonResponseFrom(t, http.StatusOK, http.Header{}, expected)
+			})))
+	if err := client.UpdateEnclosureContext(t.Context(), 1, &EnclosureUpdateRequest{
+		MediaProgression: 10,
+	}); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}

--- a/client/options.go
+++ b/client/options.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client // import "miniflux.app/v2/client"
+
+import "net/http"
+
+type Option func(*request)
+
+// WithAPIKey sets the API key for the client.
+func WithAPIKey(apiKey string) Option {
+	return func(r *request) {
+		r.apiKey = apiKey
+	}
+}
+
+// WithCredentials sets the username and password for the client.
+func WithCredentials(username, password string) Option {
+	return func(r *request) {
+		r.username = username
+		r.password = password
+	}
+}
+
+// WithHTTPClient sets the HTTP client for the client.
+func WithHTTPClient(client *http.Client) Option {
+	return func(r *request) {
+		r.client = client
+	}
+}


### PR DESCRIPTION
## Background
#3840

This updates the `miniflux.app/client` package to follow several widely used Go patterns.

1. It uses the functional options pattern to allow extensible options to be passed to the client.
2. One of the options added is `WithHttpClient` which allows callers to pass in the http client that should be used for requests. This is useful for testing and also for case where you need to either mutate the request, add counters, etc.
3. Each of the API methods now have a variant that accepts a `context.Context` allowing common patterns around timeouts, cancellations, etc.
4. Since the addition of `WithHttpClient` makes the `Client` testable, I have added a test that ensures that each of the API methods marshal and unmarshal their expected data structures properly.

## Note
I know this is a pretty large PR. If this is too much to review, I'm happy to break it up. Most of the change is repetitive, so breaking it up would probably mean adding a batch of new `*Context` methods at a time with their respective tests.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
