### PR TITLE
refactor(js): minor regex simplification

### DIFF
--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -897,7 +897,7 @@ function updateUnreadCounterValue(delta) {
     if (window.location.href.endsWith('/unread')) {
         const oldValue = parseInt(document.title.split('(')[1], 10);
         const newValue = oldValue + delta;
-        document.title = document.title.replace(/(.*?)\(\d+\)(.*?)/, `$1(${newValue})$2`);
+        document.title = document.title.replace(/\(\d+\)/, `(${newValue})`);
     }
 }
 


### PR DESCRIPTION
There is no need to match on the whole title, use two groups, then merge the whole thing together, when we can simply search-and-replace only the matching value.