### PR TITLE
Potential fix for code scanning alert no. 195: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -1,4 +1,6 @@
 name: Build Binaries
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/miniflux/v2/security/code-scanning/195](https://github.com/miniflux/v2/security/code-scanning/195)

To fix the problem, add a `permissions` block to restrict the GITHUB_TOKEN to only the privileges needed by this workflow/job. In this case, the job only needs to read repository contents (for `actions/checkout` and the build). The artifact upload step does not require write access to repository contents, only to the Actions artifacts API (which is internally handled and not governed by the workflow-level `permissions`). Therefore, set `permissions: contents: read` either at the root of the workflow YAML or within the specific `build` job. Since there's only one job, adding it at the root is clearer and applies to all jobs. Add the following block just after the workflow name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
