### PR TITLE
fix(api): fetchContent should rewrite document with proxy

### DIFF
--- a/internal/api/entry.go
+++ b/internal/api/entry.go
@@ -343,7 +343,7 @@ func (h *handler) fetchContent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	json.OK(w, r, map[string]string{"content": mediaproxy.RewriteDocumentWithAbsoluteProxyURL(h.router, entry.Content), "reading_time": entry.ReadingTime})
+	json.OK(w, r, map[string]any{"content": mediaproxy.RewriteDocumentWithAbsoluteProxyURL(h.router, entry.Content), "reading_time": entry.ReadingTime})
 }
 
 func (h *handler) flushHistory(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

I am using `nextflux` as my rss reader, but when read article in the `full content mode`, it didn't rewrite URLs.
which using the api: `v1/entries/4619/fetch-content`.
