### PR TITLE
feat(finder): enhance youtube channel parsing with default playlists

### DIFF
--- a/internal/reader/subscription/finder.go
+++ b/internal/reader/subscription/finder.go
@@ -68,7 +68,7 @@ func (f *subscriptionFinder) FindSubscriptions(websiteURL, rssBridgeURL string, 
 		f.feedDownloaded = true
 		return Subscriptions{NewSubscription(responseHandler.EffectiveURL(), responseHandler.EffectiveURL(), feedFormat)}, nil
 	}
-	
+
 	// Step 2) Find the canonical URL of the website.
 	slog.Debug("Try to find the canonical URL of the website", slog.String("website_url", websiteURL))
 	websiteURL = f.findCanonicalURL(websiteURL, responseHandler.ContentType(), bytes.NewReader(responseBody))
@@ -285,15 +285,6 @@ func (f *subscriptionFinder) findSubscriptionsFromYouTube(websiteURL string) (Su
 		{"UULF", "Videos"},
 		{"UUSH", "Short videos"},
 		{"UULV", "Live streams"},
-
-		{"UULP", "Popular videos"},
-		{"UUPS", "Popular short videos"},
-		{"UUPV", "Popular live streams"},
-		
-		{"UUMO", "Members-only contents (videos, short videos and live streams)"},
-		{"UUMF", "Members-only videos"},
-		{"UUMS", "Members-only short videos"},
-		{"UUMV", "Members-only live streams"},
 	}
 
 	decodedURL, err := url.Parse(websiteURL)
@@ -308,15 +299,15 @@ func (f *subscriptionFinder) findSubscriptionsFromYouTube(websiteURL string) (Su
 
 	if _, baseID, found := strings.Cut(decodedURL.Path, "channel/UC"); found {
 		var subscriptions Subscriptions
-		
+
 		channelFeedURL := "https://www.youtube.com/feeds/videos.xml?channel_id=UC" + baseID
 		subscriptions = append(subscriptions, NewSubscription("Channel", channelFeedURL, parser.FormatAtom))
-			
+
 		for _, playlist := range playlistPrefixes {
 			playlistFeedURL := "https://www.youtube.com/feeds/videos.xml?playlist_id=" + playlist.prefix + baseID
 			subscriptions = append(subscriptions, NewSubscription(playlist.title, playlistFeedURL, parser.FormatAtom))
 		}
-		
+
 		return subscriptions, nil
 	}
 

--- a/internal/reader/subscription/finder_test.go
+++ b/internal/reader/subscription/finder_test.go
@@ -39,13 +39,6 @@ func TestFindYoutubeFeed(t *testing.T) {
 				"https://www.youtube.com/feeds/videos.xml?playlist_id=UULF-Qj80avWItNRjkZ41rzHyw",
 				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUSH-Qj80avWItNRjkZ41rzHyw",
 				"https://www.youtube.com/feeds/videos.xml?playlist_id=UULV-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UULP-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUPS-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUPV-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUMO-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUMF-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUMS-Qj80avWItNRjkZ41rzHyw",
-				"https://www.youtube.com/feeds/videos.xml?playlist_id=UUMV-Qj80avWItNRjkZ41rzHyw",
 			},
 		},
 		// Channel URL with name


### PR DESCRIPTION
This PR enhances the existing custom YouTube parsing. It consists of two parts:

1) using canonical URL 

`https://www.youtube.com/@rossmanngroup` and `https://www.youtube.com/c/Jan%C5%9Apiewak1` are both proper YouTube channel URLs, and Miniflux tries to parse them with `findSubscriptionsFromYouTube`, but fails - because it expects the URL's path to contain either `/channel`, `/watch` or `/playlist`.

Conveniently, YouTube uses `<link rel="canonical" href="...">`, and this canonical URL is exactly what the parser wants.  `findCanonicalURL` extracts this exact URL. That way we prevent YouTube links to fall through to generic feed parser in `findSubscriptionsFromWebPage`.

2) displaying default channel playlists

YouTube has this undocumented feature, where it generates multiple convenience playlist for each channel, using some clever prefixes (details in [this SO post](https://stackoverflow.com/a/76602819)).

Now that we catch all YouTube channels correctly, we can automatically display default playlists, making it easier to subscribe only to shorts, live streams, or popular videos.

I'm using this myself a lot, it would be very convenient not to have to remember all these prefixes, and enter them manually. And I assume it's not even obvious for most people such possibility exists.

Screenshot:

<img width="945" height="635" alt="yt-pls" src="https://github.com/user-attachments/assets/527c0612-37f2-460a-9be1-4152eb899306" />

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
