### PR TITLE
chore(contrib): update postgres volume path in Docker Compose sample files

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,10 +11,10 @@ services:
       - ADMIN_USERNAME=admin
       - ADMIN_PASSWORD=test123
   db:
-    image: postgres:15
+    image: postgres:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     hostname: postgres
     environment:
       POSTGRES_DB: miniflux2

--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -26,7 +26,7 @@ services:
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=miniflux
     volumes:
-      - miniflux-db:/var/lib/postgresql/data
+      - miniflux-db:/var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "miniflux"]
       interval: 10s

--- a/contrib/docker-compose/caddy.yml
+++ b/contrib/docker-compose/caddy.yml
@@ -31,7 +31,7 @@ services:
       - POSTGRES_USER=miniflux
       - POSTGRES_PASSWORD=secret
     volumes:
-      - miniflux-db:/var/lib/postgresql/data
+      - miniflux-db:/var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "miniflux"]
       interval: 10s

--- a/contrib/docker-compose/traefik.yml
+++ b/contrib/docker-compose/traefik.yml
@@ -43,7 +43,7 @@ services:
       - POSTGRES_USER=miniflux
       - POSTGRES_PASSWORD=secret
     volumes:
-      - miniflux-db:/var/lib/postgresql/data
+      - miniflux-db:/var/lib/postgresql
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "miniflux"]
       interval: 10s


### PR DESCRIPTION
Starting with Postgresql 18, the volume path has been changed to `/var/lib/postgresql`.

See https://hub.docker.com/_/postgres/#pgdata
