### PR TITLE
feat(ui): add route for viewing individual starred entries from category starred list

### DIFF
--- a/internal/template/templates/views/category_entries.html
+++ b/internal/template/templates/views/category_entries.html
@@ -97,6 +97,8 @@
                     <a
                         {{ if $.showOnlyUnreadEntries }}
                         href="{{ route "unreadCategoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}"
+                        {{ else if $.showOnlyStarredEntries }}
+                        href="{{ route "starredCategoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}"
                         {{ else }}
                         href="{{ route "categoryEntry" "categoryID" .Feed.Category.ID "entryID" .ID }}"
                         {{ end }}

--- a/internal/ui/starred_entry_category.go
+++ b/internal/ui/starred_entry_category.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ui // import "miniflux.app/v2/internal/ui"
+
+import (
+	"net/http"
+
+	"miniflux.app/v2/internal/http/request"
+	"miniflux.app/v2/internal/http/response/html"
+	"miniflux.app/v2/internal/http/route"
+	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/storage"
+	"miniflux.app/v2/internal/ui/session"
+	"miniflux.app/v2/internal/ui/view"
+)
+
+func (h *handler) showStarredCategoryEntryPage(w http.ResponseWriter, r *http.Request) {
+	user, err := h.store.UserByID(request.UserID(r))
+	if err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
+	categoryID := request.RouteInt64Param(r, "categoryID")
+	entryID := request.RouteInt64Param(r, "entryID")
+
+	builder := h.store.NewEntryQueryBuilder(user.ID)
+	builder.WithCategoryID(categoryID)
+	builder.WithEntryID(entryID)
+	builder.WithoutStatus(model.EntryStatusRemoved)
+
+	entry, err := builder.GetEntry()
+	if err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
+	if entry == nil {
+		html.NotFound(w, r)
+		return
+	}
+
+	if entry.ShouldMarkAsReadOnView(user) {
+		err = h.store.SetEntriesStatus(user.ID, []int64{entry.ID}, model.EntryStatusRead)
+		if err != nil {
+			html.ServerError(w, r, err)
+			return
+		}
+
+		entry.Status = model.EntryStatusRead
+	}
+
+	if user.AlwaysOpenExternalLinks {
+		html.Redirect(w, r, entry.URL)
+		return
+	}
+
+	entryPaginationBuilder := storage.NewEntryPaginationBuilder(h.store, user.ID, entry.ID, user.EntryOrder, user.EntryDirection)
+	entryPaginationBuilder.WithCategoryID(categoryID)
+	entryPaginationBuilder.WithStarred()
+
+	prevEntry, nextEntry, err := entryPaginationBuilder.Entries()
+	if err != nil {
+		html.ServerError(w, r, err)
+		return
+	}
+
+	nextEntryRoute := ""
+	if nextEntry != nil {
+		nextEntryRoute = route.Path(h.router, "starredCategoryEntry", "categoryID", categoryID, "entryID", nextEntry.ID)
+	}
+
+	prevEntryRoute := ""
+	if prevEntry != nil {
+		prevEntryRoute = route.Path(h.router, "starredCategoryEntry", "categoryID", categoryID, "entryID", prevEntry.ID)
+	}
+
+	sess := session.New(h.store, request.SessionID(r))
+	view := view.New(h.tpl, r, sess)
+	view.Set("entry", entry)
+	view.Set("prevEntry", prevEntry)
+	view.Set("nextEntry", nextEntry)
+	view.Set("nextEntryRoute", nextEntryRoute)
+	view.Set("prevEntryRoute", prevEntryRoute)
+	view.Set("menu", "categories")
+	view.Set("user", user)
+	view.Set("countUnread", h.store.CountUnreadEntries(user.ID))
+	view.Set("countErrorFeeds", h.store.CountUserFeedsWithErrors(user.ID))
+	view.Set("hasSaveEntry", h.store.HasSaveEntry(user.ID))
+
+	html.OK(w, r, view.Render("entry"))
+}
+

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -79,6 +79,7 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool) {
 	// Category pages.
 	uiRouter.HandleFunc("/category/{categoryID}/entry/{entryID}", handler.showCategoryEntryPage).Name("categoryEntry").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/unread/category/{categoryID}/entry/{entryID}", handler.showUnreadCategoryEntryPage).Name("unreadCategoryEntry").Methods(http.MethodGet)
+	uiRouter.HandleFunc("/starred/category/{categoryID}/entry/{entryID}", handler.showStarredCategoryEntryPage).Name("starredCategoryEntry").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/categories", handler.showCategoryListPage).Name("categories").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/category/create", handler.showCreateCategoryPage).Name("createCategory").Methods(http.MethodGet)
 	uiRouter.HandleFunc("/category/save", handler.saveCategory).Name("saveCategory").Methods(http.MethodPost)


### PR DESCRIPTION
It is possible to show unread items for a category, and when a single item is opened, we are still in the scope of unread category items - going to next or previous item works as expected. This is not the case for starred items. Starred items are properly listed per category, but opening a single item changes the scope, and going to next or previous item will eventually open starred item from another category. The solution is to replicate category unread behavior. starred_entry_category.go file that implements this is basically a copy of unread_entry_category.go with relevant adjustments.

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
