### PR TITLE
feat(processor): apply filter rules after entry content processing

### DIFF
--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -72,18 +72,6 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 			slog.String("feed_url", feed.FeedURL),
 		)
 
-		if filter.IsBlockedEntry(blockRules, allowRules, feed, entry) {
-			slog.Debug("Entry is blocked by filter rules",
-				slog.Int64("user_id", user.ID),
-				slog.String("entry_url", entry.URL),
-				slog.String("entry_hash", entry.Hash),
-				slog.String("entry_title", entry.Title),
-				slog.Int64("feed_id", feed.ID),
-				slog.String("feed_url", feed.FeedURL),
-			)
-			continue
-		}
-
 		parsedInputUrl, _ := url.Parse(entry.URL)
 		if cleanedURL, err := urlcleaner.RemoveTrackingParameters(parsedFeedURL, parsedSiteURL, parsedInputUrl); err == nil {
 			entry.URL = cleanedURL
@@ -146,6 +134,19 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 
 		// The sanitizer should always run at the end of the process to make sure unsafe HTML is filtered out.
 		entry.Content = sanitizer.SanitizeHTML(webpageBaseURL, entry.Content, &sanitizer.SanitizerOptions{OpenLinksInNewTab: user.OpenExternalLinksInNewTab})
+
+		// Entry blocking applied after content rewrite, enables filtering on fetched content
+		if filter.IsBlockedEntry(blockRules, allowRules, feed, entry) {
+			slog.Debug("Entry is blocked by filter rules",
+				slog.Int64("user_id", user.ID),
+				slog.String("entry_url", entry.URL),
+				slog.String("entry_hash", entry.Hash),
+				slog.String("entry_title", entry.Title),
+				slog.Int64("feed_id", feed.ID),
+				slog.String("feed_url", feed.FeedURL),
+			)
+			continue
+		}
 
 		updateEntryReadingTime(store, feed, entry, entryIsNew, user)
 


### PR DESCRIPTION
Entry blocking rules are applied only to raw feed response. When "Fetch original content" is enabled, EntryContent won't include it. The solution is to move filtering further down the processing function, after content is fully processed. Feature is configurable with config flag, it basically performs another entry blocking check.

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
