### PR TITLE
Update go devcontainer to go:1-trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
   ],
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   app:
-    image: mcr.microsoft.com/devcontainers/go:1.23
+    image: mcr.microsoft.com/devcontainers/go:1-trixie # https://www.debian.org/releases/trixie/index.en.html
     volumes:
       - ..:/workspace:cached
     command: sleep infinity


### PR DESCRIPTION
Update the devcontainer base image to go:1-trixie.  

It is necessary to skip installing moby.

  ## Why
  - The devcontainer build fails on Debian trixie because the docker-outside-of-docker feature
  defaults to `moby: true`, but the `moby-cli` package has been removed from debian 13 (trixie). (See: https://github.com/devcontainers/features/blob/main/src/docker-outside-of-docker/install.sh#L204-
    L207)

  ## What changed
  - Set `ghcr.io/devcontainers/features/docker-outside-of-docker` option `"moby": false` so it
  installs Docker CE CLI instead of the removed Moby packages.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
