### PR TITLE
[chore] remove obsolete docker compose 'version' key

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     image: mcr.microsoft.com/devcontainers/go:1.23


### PR DESCRIPTION
Docker compose "version" key was [deprecated](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete).

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
