### PR TITLE
feat(config): add option to skip updating existing entries during polling

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -508,6 +508,11 @@ func NewConfigOptions() *configOptions {
 					return validateChoices(rawValue, []string{"round_robin", "entry_frequency"})
 				},
 			},
+			"POLLING_SKIP_EXISTING_ENTRIES": {
+				parsedBoolValue: false,
+				rawValue:        "0",
+				valueType:       boolType,
+			},
 			"PORT": {
 				parsedStringValue: "",
 				rawValue:          "",
@@ -908,6 +913,10 @@ func (c *configOptions) PollingParsingErrorLimit() int {
 
 func (c *configOptions) PollingScheduler() string {
 	return c.options["POLLING_SCHEDULER"].parsedStringValue
+}
+
+func (c *configOptions) PollingSkipExistingEntries() bool {
+	return c.options["POLLING_SKIP_EXISTING_ENTRIES"].parsedBoolValue
 }
 
 func (c *configOptions) Port() string {

--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -339,7 +339,7 @@ func RefreshFeed(store *storage.Storage, userID, feedID int64, forceRefresh bool
 		processor.ProcessFeedEntries(store, originalFeed, userID, forceRefresh)
 
 		// We don't update existing entries when the crawler is enabled (we crawl only inexisting entries). Unless it is forced to refresh
-		updateExistingEntries := forceRefresh || !originalFeed.Crawler
+		updateExistingEntries := forceRefresh || (!originalFeed.Crawler && !config.Opts.PollingSkipExistingEntries())
 		newEntries, storeErr := store.RefreshFeedEntries(originalFeed.UserID, originalFeed.ID, originalFeed.Entries, updateExistingEntries)
 		if storeErr != nil {
 			localizedError := locale.NewLocalizedErrorWrapper(storeErr, "error.database_error", storeErr)


### PR DESCRIPTION
Add POLLING_SKIP_EXISTING_ENTRIES configuration option to prevent existing entries from being updated during feed refresh, unless force refresh is triggered.

This is useful when external services (e.g., AI summarizers) modify entry content and users want to preserve those modifications across feed syncs.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
