### PR TITLE
feat(ui): add checksum query parameter to icon URLs in templates and …

### DIFF
--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -21,6 +21,7 @@ import (
 	"miniflux.app/v2/internal/mediaproxy"
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/timezone"
+	"miniflux.app/v2/internal/ui/static"
 	"miniflux.app/v2/internal/urllib"
 
 	"github.com/gorilla/mux"
@@ -90,10 +91,16 @@ func (f *funcMap) Map() template.FuncMap {
 		},
 		"theme_color": model.ThemeColor,
 		"icon": func(iconName string) template.HTML {
+			filename := "sprite.svg"
+			value, ok := static.BinaryBundles[filename]
+			if !ok {
+				return ""
+			}
+			baseURL := route.Path(f.router, "appIcon", "filename", filename)
+			url := baseURL + "?checksum=" + url.QueryEscape(value.Checksum)
 			return template.HTML(fmt.Sprintf(
 				`<svg class="icon" aria-hidden="true"><use href="%s#icon-%s"/></svg>`,
-				route.Path(f.router, "appIcon", "filename", "sprite.svg"),
-				iconName,
+				url, iconName,
 			))
 		},
 		"nonce": func() string {

--- a/internal/ui/static_app_icon.go
+++ b/internal/ui/static_app_icon.go
@@ -16,8 +16,13 @@ import (
 
 func (h *handler) showAppIcon(w http.ResponseWriter, r *http.Request) {
 	filename := request.RouteStringParam(r, "filename")
+	checksum := r.URL.Query().Get("checksum")
 	value, ok := static.BinaryBundles[filename]
 	if !ok {
+		html.NotFound(w, r)
+		return
+	}
+	if checksum != "" && checksum != value.Checksum {
 		html.NotFound(w, r)
 		return
 	}

--- a/internal/ui/static_manifest.go
+++ b/internal/ui/static_manifest.go
@@ -5,12 +5,14 @@ package ui // import "miniflux.app/v2/internal/ui"
 
 import (
 	"net/http"
+	"net/url"
 
 	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response/json"
 	"miniflux.app/v2/internal/http/route"
 	"miniflux.app/v2/internal/locale"
 	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/ui/static"
 )
 
 func (h *handler) showWebManifest(w http.ResponseWriter, r *http.Request) {
@@ -78,6 +80,13 @@ func (h *handler) showWebManifest(w http.ResponseWriter, r *http.Request) {
 		labelSettingsMenu = printer.Print("menu.settings")
 	}
 	themeColor := model.ThemeColor(request.UserTheme(r), "light")
+	getIconURL := func(filename string) string {
+		baseURL := route.Path(h.router, "appIcon", "filename", filename)
+		if value, ok := static.BinaryBundles[filename]; ok {
+			return baseURL + "?checksum=" + url.QueryEscape(value.Checksum)
+		}
+		return baseURL
+	}
 	manifest := &webManifest{
 		Name:            "Miniflux",
 		ShortName:       "Miniflux",
@@ -86,12 +95,12 @@ func (h *handler) showWebManifest(w http.ResponseWriter, r *http.Request) {
 		StartURL:        route.Path(h.router, "login"),
 		BackgroundColor: themeColor,
 		Icons: []webManifestIcon{
-			{Source: route.Path(h.router, "appIcon", "filename", "icon-120.png"), Sizes: "120x120", Type: "image/png", Purpose: "any"},
-			{Source: route.Path(h.router, "appIcon", "filename", "icon-192.png"), Sizes: "192x192", Type: "image/png", Purpose: "any"},
-			{Source: route.Path(h.router, "appIcon", "filename", "icon-512.png"), Sizes: "512x512", Type: "image/png", Purpose: "any"},
-			{Source: route.Path(h.router, "appIcon", "filename", "maskable-icon-120.png"), Sizes: "120x120", Type: "image/png", Purpose: "maskable"},
-			{Source: route.Path(h.router, "appIcon", "filename", "maskable-icon-192.png"), Sizes: "192x192", Type: "image/png", Purpose: "maskable"},
-			{Source: route.Path(h.router, "appIcon", "filename", "maskable-icon-512.png"), Sizes: "512x512", Type: "image/png", Purpose: "maskable"},
+			{Source: getIconURL("icon-120.png"), Sizes: "120x120", Type: "image/png", Purpose: "any"},
+			{Source: getIconURL("icon-192.png"), Sizes: "192x192", Type: "image/png", Purpose: "any"},
+			{Source: getIconURL("icon-512.png"), Sizes: "512x512", Type: "image/png", Purpose: "any"},
+			{Source: getIconURL("maskable-icon-120.png"), Sizes: "120x120", Type: "image/png", Purpose: "maskable"},
+			{Source: getIconURL("maskable-icon-192.png"), Sizes: "192x192", Type: "image/png", Purpose: "maskable"},
+			{Source: getIconURL("maskable-icon-512.png"), Sizes: "512x512", Type: "image/png", Purpose: "maskable"},
 		},
 		ShareTarget: webManifestShareTarget{
 			Action:  route.Path(h.router, "bookmarklet"),
@@ -100,14 +109,14 @@ func (h *handler) showWebManifest(w http.ResponseWriter, r *http.Request) {
 			Params:  webManifestShareTargetParams{URL: "uri", Text: "text"},
 		},
 		Shortcuts: []webManifestShortcut{
-			{Name: labelNewFeed, URL: route.Path(h.router, "addSubscription"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "add-feed-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelUnreadMenu, URL: route.Path(h.router, "unread"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "unread-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelStarredMenu, URL: route.Path(h.router, "starred"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "starred-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelHistoryMenu, URL: route.Path(h.router, "history"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "history-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelFeedsMenu, URL: route.Path(h.router, "feeds"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "feeds-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelCategoriesMenu, URL: route.Path(h.router, "categories"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "categories-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelSearchMenu, URL: route.Path(h.router, "search"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "search-icon.png"), Sizes: "240x240", Type: "image/png"}}},
-			{Name: labelSettingsMenu, URL: route.Path(h.router, "settings"), Icons: []webManifestIcon{{Source: route.Path(h.router, "appIcon", "filename", "settings-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelNewFeed, URL: route.Path(h.router, "addSubscription"), Icons: []webManifestIcon{{Source: getIconURL("add-feed-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelUnreadMenu, URL: route.Path(h.router, "unread"), Icons: []webManifestIcon{{Source: getIconURL("unread-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelStarredMenu, URL: route.Path(h.router, "starred"), Icons: []webManifestIcon{{Source: getIconURL("starred-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelHistoryMenu, URL: route.Path(h.router, "history"), Icons: []webManifestIcon{{Source: getIconURL("history-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelFeedsMenu, URL: route.Path(h.router, "feeds"), Icons: []webManifestIcon{{Source: getIconURL("feeds-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelCategoriesMenu, URL: route.Path(h.router, "categories"), Icons: []webManifestIcon{{Source: getIconURL("categories-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelSearchMenu, URL: route.Path(h.router, "search"), Icons: []webManifestIcon{{Source: getIconURL("search-icon.png"), Sizes: "240x240", Type: "image/png"}}},
+			{Name: labelSettingsMenu, URL: route.Path(h.router, "settings"), Icons: []webManifestIcon{{Source: getIconURL("settings-icon.png"), Sizes: "240x240", Type: "image/png"}}},
 		},
 	}
 


### PR DESCRIPTION
…Web App Manifest

Add checksum query parameter to icon URLs in HTML templates (via the `icon` template function) and Web App Manifest to ensure cache invalidation when icon files are updated. This prevents browsers and CDNs from serving stale cached icons.

* In `functions.go`, the `icon` function now appends `?checksum=<value>` to the SVG sprite URL.
* In `static_manifest.go`, the `getIconURL` helper function appends `?checksum=<value>` to PNG icon URLs used in manifest icons and shortcuts.

This maintains consistency across static asset handling and improves reliability for icon updates.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
