### PR TITLE
feat: add `TRUSTED_REVERSE_PROXY_NETWORKS` config option

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -109,6 +109,12 @@ func Parse() {
 		}
 	}
 
+	if config.Opts.AuthProxyHeader() != "" {
+		if len(config.Opts.TrustedReverseProxyNetworks()) == 0 {
+			printErrorAndExit(errors.New("TRUSTED_REVERSE_PROXY_NETWORKS must be configured when AUTH_PROXY_HEADER is used"))
+		}
+	}
+
 	if flagConfigDump {
 		fmt.Print(config.Opts)
 		return

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -568,6 +568,11 @@ func NewConfigOptions() *configOptions {
 					return validateGreaterOrEqualThan(rawValue, 1)
 				},
 			},
+			"TRUSTED_REVERSE_PROXY_NETWORKS": {
+				parsedStringList: []string{},
+				rawValue:         "",
+				valueType:        stringListType,
+			},
 			"WATCHDOG": {
 				parsedBoolValue: true,
 				rawValue:        "1",
@@ -968,6 +973,10 @@ func (c *configOptions) SchedulerRoundRobinMaxInterval() time.Duration {
 
 func (c *configOptions) SchedulerRoundRobinMinInterval() time.Duration {
 	return c.options["SCHEDULER_ROUND_ROBIN_MIN_INTERVAL"].parsedDuration
+}
+
+func (c *configOptions) TrustedReverseProxyNetworks() []string {
+	return c.options["TRUSTED_REVERSE_PROXY_NETWORKS"].parsedStringList
 }
 
 func (c *configOptions) Watchdog() bool {

--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -3,7 +3,10 @@
 
 package config // import "miniflux.app/v2/internal/config"
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestBaseURLOptionParsing(t *testing.T) {
 	configParser := NewConfigParser()
@@ -1629,6 +1632,32 @@ func TestSchedulerRoundRobinMinIntervalOptionParsing(t *testing.T) {
 
 	if configParser.options.SchedulerRoundRobinMinInterval().Minutes() != 30 {
 		t.Fatalf("Expected SCHEDULER_ROUND_ROBIN_MIN_INTERVAL to be 30 minutes")
+	}
+}
+
+func TestTrustedReverseProxyNetworksOptionParsing(t *testing.T) {
+	configParser := NewConfigParser()
+
+	// Test default value
+	defaultNetworks := configParser.options.TrustedReverseProxyNetworks()
+	if len(defaultNetworks) != 0 {
+		t.Fatalf("Expected 0 allowed networks by default, got %d", len(defaultNetworks))
+	}
+
+	// Test valid value
+	if err := configParser.parseLines([]string{"TRUSTED_REVERSE_PROXY_NETWORKS=10.0.0.0/8,192.168.1.0/24"}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	allowedNetworks := configParser.options.TrustedReverseProxyNetworks()
+	if len(allowedNetworks) != 2 {
+		t.Fatalf("Expected 2 allowed networks, got %d", len(allowedNetworks))
+	}
+	if !slices.Contains(allowedNetworks, "10.0.0.0/8") {
+		t.Errorf("Expected 10.0.0.0/8 in allowed networks")
+	}
+	if !slices.Contains(allowedNetworks, "192.168.1.0/24") {
+		t.Errorf("Expected 192.168.1.0/24 in allowed networks")
 	}
 }
 

--- a/internal/http/server/middleware.go
+++ b/internal/http/server/middleware.go
@@ -15,11 +15,13 @@ import (
 
 func middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		clientIP := request.FindClientIP(r)
+		remoteIP := request.FindRemoteIP(r)
+		isTrustedProxyClientIP := request.IsTrustedIP(remoteIP, config.Opts.TrustedReverseProxyNetworks())
+		clientIP := request.FindClientIP(r, isTrustedProxyClientIP)
 		ctx := r.Context()
 		ctx = context.WithValue(ctx, request.ClientIPContextKey, clientIP)
 
-		if r.Header.Get("X-Forwarded-Proto") == "https" {
+		if isTrustedProxyClientIP && r.Header.Get("X-Forwarded-Proto") == "https" {
 			config.Opts.SetHTTPSValue(true)
 		}
 

--- a/miniflux.1
+++ b/miniflux.1
@@ -1,5 +1,5 @@
 .\" Manpage for miniflux.
-.TH "MINIFLUX" "1" "December 29, 2025" "\ \&" "\ \&"
+.TH "MINIFLUX" "1" "January 3, 2026" "\ \&" "\ \&"
 
 .SH NAME
 miniflux \- Minimalist and opinionated feed reader
@@ -148,6 +148,8 @@ Default is empty\&.
 .TP
 .B AUTH_PROXY_HEADER
 Proxy authentication HTTP header\&.
+.br
+The option \fBTRUSTED_REVERSE_PROXY_NETWORKS\fR must be configured to allow the proxy to authenticate users\&.
 .br
 Default is empty.
 .TP
@@ -570,6 +572,11 @@ Default is 1440 minutes (24 hours)\&.
 Minimum interval in minutes for the round robin scheduler\&.
 .br
 Default is 60 minutes\&.
+.TP
+.B TRUSTED_REVERSE_PROXY_NETWORKS
+List of networks (CIDR notation) allowed to use the proxy authentication header, \fBX-Forwarded-For\fR, \fBX-Forwarded-Proto\fR, and \fBX-Real-Ip\fR headers\&.
+.br
+Default is empty\&.
 .TP
 .B WATCHDOG
 Enable or disable Systemd watchdog\&.


### PR DESCRIPTION
Add an IP-based allow list to prevent spoofing of HTTP headers that should only be set by trusted reverse proxies.

Note that `TRUSTED_PROXY_NETWORKS` must be configured when `AUTH_PROXY_HEADER` is used.

The following HTTP headers are taken into consideration only when the client is an allowed reverse proxy: `X-Forwarded-For`, `X-Forwarded-Proto` and `X-Real-Ip`.
