### PR TITLE
feat(googlereader)!: remove CORS handler

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -47,9 +47,7 @@ func Serve(router *mux.Router, store *storage.Storage) {
 
 	middleware := newMiddleware(store)
 	sr := router.PathPrefix("/reader/api/0").Subrouter()
-	sr.Use(middleware.handleCORS)
 	sr.Use(middleware.apiKeyAuth)
-	sr.Methods(http.MethodOptions)
 	sr.HandleFunc("/token", handler.tokenHandler).Methods(http.MethodGet).Name("Token")
 	sr.HandleFunc("/edit-tag", handler.editTagHandler).Methods(http.MethodPost).Name("EditTag")
 	sr.HandleFunc("/rename-tag", handler.renameTagHandler).Methods(http.MethodPost).Name("Rename Tag")

--- a/internal/googlereader/middleware.go
+++ b/internal/googlereader/middleware.go
@@ -25,19 +25,6 @@ func newMiddleware(s *storage.Storage) *middleware {
 	return &middleware{s}
 }
 
-func (m *middleware) handleCORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization")
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 func (m *middleware) apiKeyAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		clientIP := request.ClientIP(r)


### PR DESCRIPTION
The Google Reader API is not supposed to be used by web clients.

Removing CORS should not break any Google Reader client and it reduces the attack surface.
