### PR TITLE
refactor(timezone): improve internal timezones handling

### DIFF
--- a/internal/template/templates/views/settings.html
+++ b/internal/template/templates/views/settings.html
@@ -144,8 +144,8 @@
 
         <label for="form-timezone">{{ t "form.prefs.label.timezone" }}</label>
         <select id="form-timezone" name="timezone">
-        {{ range $key, $value := .timezones }}
-            <option value="{{ $key }}" {{ if eq $key $.form.Timezone }}selected="selected"{{ end }}>{{ $value }}</option>
+        {{ range $value := .timezones }}
+            <option value="{{ $value }}" {{ if eq $value $.form.Timezone }}selected="selected"{{ end }}>{{ $value }}</option>
         {{ end }}
         </select>
 

--- a/internal/timezone/timezone_test.go
+++ b/internal/timezone/timezone_test.go
@@ -89,3 +89,28 @@ func TestConvertPostgresDateTimeWithNegativeTimezoneOffset(t *testing.T) {
 		t.Fatalf(`Unexpected year, got %d instead of 0`, year)
 	}
 }
+
+func TestIsValid(t *testing.T) {
+	validTZ := []string{
+		"Antarctica/Davis",
+		"GMT",
+		"UTC",
+	}
+
+	for _, tz := range validTZ {
+		if !IsValid(tz) {
+			t.Fatalf(`Timezone %q should be valid an it's not`, tz)
+		}
+	}
+
+	invalidTZ := []string{
+		"MAP",
+		"Europe/Fronce",
+	}
+
+	for _, tz := range invalidTZ {
+		if IsValid(tz) {
+			t.Fatalf(`Timezone %q should be invalid an it's not`, tz)
+		}
+	}
+}

--- a/internal/validator/user.go
+++ b/internal/validator/user.go
@@ -202,7 +202,7 @@ func validateLanguage(language string) *locale.LocalizedError {
 }
 
 func validateTimezone(timezoneValue string) *locale.LocalizedError {
-	if _, found := timezone.AvailableTimezones()[timezoneValue]; !found {
+	if !timezone.IsValid(timezoneValue) {
 		return locale.NewLocalizedError("error.invalid_timezone")
 	}
 	return nil


### PR DESCRIPTION
- Instead of having a gigantic array, using a prefix-map allows to significantly reduce the space taken by the timezones list.
- Add a new IsValid method to avoid having to materialize a map just to check if a given timezone is in it.
- Use an iterator instead of materializing a map every time the full list of timezones is required.
- Use a slice in the template instead of a map to iterate over all timezones.