### PR TITLE
feat(config)!: deprecate `FILTER_ENTRY_MAX_AGE_DAYS` config option

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -238,14 +238,6 @@ func NewConfigOptions() *configOptions {
 				rawValue:        "0",
 				valueType:       boolType,
 			},
-			"FILTER_ENTRY_MAX_AGE_DAYS": {
-				parsedIntValue: 0,
-				rawValue:       "0",
-				valueType:      intType,
-				validator: func(rawValue string) error {
-					return validateGreaterOrEqualThan(rawValue, 0)
-				},
-			},
 			"FORCE_REFRESH_INTERVAL": {
 				parsedDuration: 30 * time.Minute,
 				rawValue:       "30",
@@ -716,10 +708,6 @@ func (c *configOptions) FetchOdyseeWatchTime() bool {
 
 func (c *configOptions) FetchYouTubeWatchTime() bool {
 	return c.options["FETCH_YOUTUBE_WATCH_TIME"].parsedBoolValue
-}
-
-func (c *configOptions) FilterEntryMaxAgeDays() int {
-	return c.options["FILTER_ENTRY_MAX_AGE_DAYS"].parsedIntValue
 }
 
 func (c *configOptions) ForceRefreshInterval() time.Duration {

--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -1273,22 +1273,6 @@ func TestDatabaseConnectionLifetimeOptionParsing(t *testing.T) {
 	}
 }
 
-func TestFilterEntryMaxAgeDaysOptionParsing(t *testing.T) {
-	configParser := NewConfigParser()
-
-	if configParser.options.FilterEntryMaxAgeDays() != 0 {
-		t.Fatalf("Expected FILTER_ENTRY_MAX_AGE_DAYS to be 0 by default")
-	}
-
-	if err := configParser.parseLines([]string{"FILTER_ENTRY_MAX_AGE_DAYS=7"}); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if configParser.options.FilterEntryMaxAgeDays() != 7 {
-		t.Fatalf("Expected FILTER_ENTRY_MAX_AGE_DAYS to be 7 days")
-	}
-}
-
 func TestForceRefreshIntervalOptionParsing(t *testing.T) {
 	configParser := NewConfigParser()
 

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/url"
 	"os"
 	"strconv"
@@ -119,6 +120,9 @@ func (cp *configParser) parseLines(lines []string) error {
 func (cp *configParser) parseLine(key, value string) error {
 	field, exists := cp.options.options[key]
 	if !exists {
+		if key == "FILTER_ENTRY_MAX_AGE_DAYS" {
+			slog.Warn("Configuration option FILTER_ENTRY_MAX_AGE_DAYS is deprecated; use user filter rule max-age:<duration> instead")
+		}
 		// Ignore unknown configuration keys to avoid parsing unrelated environment variables.
 		return nil
 	}

--- a/internal/reader/filter/filter.go
+++ b/internal/reader/filter/filter.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 	"time"
 
-	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/model"
 )
 
@@ -70,10 +69,6 @@ func parseRule(userDefinedRule string) (bool, filterRule) {
 }
 
 func IsBlockedEntry(blockRules filterRules, allowRules filterRules, feed *model.Feed, entry *model.Entry) bool {
-	if isBlockedGlobally(entry) {
-		return true
-	}
-
 	if matchesEntryFilterRules(blockRules, feed, entry) {
 		return true
 	}
@@ -96,26 +91,6 @@ func IsBlockedEntry(blockRules filterRules, allowRules filterRules, feed *model.
 			return true // Block entry if it doesn't match keeplist rules
 		}
 		return false // Allow entry if it matches keeplist rules or rule is invalid (ignored)
-	}
-
-	return false
-}
-
-func isBlockedGlobally(entry *model.Entry) bool {
-	if config.Opts == nil {
-		return false
-	}
-
-	if config.Opts.FilterEntryMaxAgeDays() > 0 {
-		maxAge := time.Duration(config.Opts.FilterEntryMaxAgeDays()) * 24 * time.Hour
-		if entry.Date.Before(time.Now().Add(-maxAge)) {
-			slog.Debug("Entry is blocked globally due to max age",
-				slog.String("entry_url", entry.URL),
-				slog.Time("entry_date", entry.Date),
-				slog.Duration("max_age", maxAge),
-			)
-			return true
-		}
 	}
 
 	return false

--- a/internal/reader/filter/filter_test.go
+++ b/internal/reader/filter/filter_test.go
@@ -4,11 +4,9 @@
 package filter // import "miniflux.app/v2/internal/reader/filter"
 
 import (
-	"os"
 	"testing"
 	"time"
 
-	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/model"
 )
 
@@ -408,39 +406,6 @@ func TestKeeplistRulesBehavior(t *testing.T) {
 					tt.keeplistRule, result, tt.expected, tt.description)
 			}
 		})
-	}
-}
-
-// Tests for isBlockedGlobally function
-func TestIsBlockedGlobally(t *testing.T) {
-	var err error
-	config.Opts, err = config.NewConfigParser().ParseEnvironmentVariables()
-	if err != nil {
-		t.Fatalf(`Parsing failure: %v`, err)
-	}
-
-	testEntry := createTestEntry()
-	testEntry.Date = time.Date(2020, 5, 1, 05, 05, 05, 05, time.UTC)
-
-	if IsBlockedEntry(nil, nil, createTestFeed(), testEntry) {
-		t.Error("Expected no entries to be blocked globally when max-age is not set")
-	}
-
-	os.Setenv("FILTER_ENTRY_MAX_AGE_DAYS", "30")
-	defer os.Clearenv()
-
-	config.Opts, err = config.NewConfigParser().ParseEnvironmentVariables()
-	if err != nil {
-		t.Fatalf(`Parsing failure: %v`, err)
-	}
-
-	if !IsBlockedEntry(nil, nil, createTestFeed(), testEntry) {
-		t.Error("Expected entries to be blocked globally when max-age is set")
-	}
-
-	testEntry.Date = time.Now().Add(-2 * 24 * time.Hour)
-	if isBlockedGlobally(testEntry) {
-		t.Error("Expected entries not to be blocked globally when they are within the max-age limit")
 	}
 }
 

--- a/miniflux.1
+++ b/miniflux.1
@@ -298,13 +298,6 @@ use it as a reading time\&.
 .br
 Disabled by default\&.
 .TP
-.B FILTER_ENTRY_MAX_AGE_DAYS
-Ignore new entries older than the given number of days\&.
-.br
-Set to 7 to fetch only entries from the last 7 days\&.
-.br
-Default is 0 (disabled)\&.
-.TP
 .B FORCE_REFRESH_INTERVAL
 The minimum interval for manual refresh\&.
 .br


### PR DESCRIPTION
This option can be replaced with a filter rule `max-age:<duration>` instead.

Global environment variables should be reserved for the Miniflux process configuration that are not meant to be modified by end users.
