### PR TITLE
fix: unbreak cmd/ctrl/shift click on main nav

### DIFF
--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -540,10 +540,11 @@ function initializeMainMenuHandlers() {
 
     onClick(".header nav li", (event) => {
         const linkElement = event.target.closest("a") || event.target.querySelector("a");
-        if (linkElement) {
+        if (linkElement && !event.ctrlKey && !event.shiftKey && !event.metaKey) {
+            event.preventDefault();
             window.location.href = linkElement.getAttribute("href");
         }
-    });
+    }, true);
 }
 
 /**


### PR DESCRIPTION
Most browsers allow opening links in a new window or new tab by holding down a modifier key like shift, command, control (depending on the OS and browser) while clicking a link.

Unconditional event.preventDefault() on click events breaks this functionality.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
