### PR TITLE
fix: increase horizontal padding on small screens

### DIFF
--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -15,6 +15,7 @@ body {
     text-rendering: optimizeLegibility;
     color: var(--body-color);
     background: var(--body-background);
+    padding: 0 10px;
 }
 
 hr {


### PR DESCRIPTION
I found the 3px horizontal padding between content and the edge of the viewport rather small.

There is no industry standard for this, but most mobile apps and websites use more space than Miniflux.

Android design guide recommends 16px: https://developer.android.com/design/ui/mobile/guides/layout-and-content/content-structure

I went for 10px which together with the 3px on `main` results in 13px, looking a lot better but still quite dense.

## Before:

<img width="588" height="998" alt="Screenshot 2026-01-13 at 12 25 01" src="https://github.com/user-attachments/assets/82457404-5a85-4981-9579-2139d4a6e7c2" />

## After:

<img width="534" height="998" alt="Screenshot 2026-01-13 at 12 25 25" src="https://github.com/user-attachments/assets/3d565c0e-971d-46a8-9eee-bfd76f19229d" />




Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
