### PR TITLE
fix: avoid possible deadlock when cleaning removed entries

### DIFF
--- a/internal/cli/cleanup_tasks.go
+++ b/internal/cli/cleanup_tasks.go
@@ -47,7 +47,7 @@ func runCleanupTasks(store *storage.Storage) {
 		}
 	}
 
-	if enclosuresAffected, err := store.DeleteRemovedEntriesEnclosures(); err != nil {
+	if enclosuresAffected, err := store.DeleteEnclosuresOfRemovedEntries(); err != nil {
 		slog.Error("Unable to delete enclosures from removed entries", slog.Any("error", err))
 	} else {
 		slog.Info("Deleting enclosures from removed entries completed",


### PR DESCRIPTION
- Lock delete targets in order with SKIP LOCKED before deleting removed entries
- Have the removed-entry scrubber skip locked rows to prevent blocking