### PR TITLE
fix: let v' shortcut use main browser in Safari PWA

### DIFF
--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -42,10 +42,8 @@ function sendPOSTRequest(url, body = null) {
  * @param {string} url
  */
 function openNewTab(url) {
-    const win = window.open("");
-    win.opener = null;
-    win.location = url;
-    win.focus();
+    const win = window.open(url, "_blank", "noreferrer");
+    if (win) win.focus();
 }
 
 /**


### PR DESCRIPTION
When using the 'v' shortcut in a Safari PWA on macOS, Miniflux opened the link in something similar to an 'in-app browser' with no URL bar and a separate window for each link. When clicking the link with the mouse, a "normal" browser tab is opened instead.

It looks like `target="_blank"` on the <a> element implies the `"noopener"` attribute, which causes Safari to use the main browser. For window.open, `"noopener"` is not implied. This commit adds the `"noreferrer"` argument to the window.open call (which implies the `"noopener"` option) rather than changing the `window.opener` attribute manually. This option causes Safari to use the main browser with the 'v' shortcut.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
