### PR TITLE
refactor(sanitizer): use a parser instead of a tokenizer

### DIFF
--- a/internal/reader/sanitizer/sanitizer_test.go
+++ b/internal/reader/sanitizer/sanitizer_test.go
@@ -304,7 +304,7 @@ func TestMediumImgWithSrcset(t *testing.T) {
 }
 
 func TestSelfClosingTags(t *testing.T) {
-	input := `<p>This <br> is a <strong>text</strong> <br/>with an image: <img src="http://example.org/" alt="Test" loading="lazy"/>.</p>`
+	input := `<p>This <br> is a <strong>text</strong> <br>with an image: <img src="http://example.org/" alt="Test" loading="lazy">.</p>`
 	output := sanitizeHTMLWithDefaultOptions("http://example.org/", input)
 
 	if input != output {
@@ -322,8 +322,8 @@ func TestTable(t *testing.T) {
 }
 
 func TestRelativeURL(t *testing.T) {
-	input := `This <a href="/test.html">link is relative</a> and this image: <img src="../folder/image.png"/>`
-	expected := `This <a href="http://example.org/test.html" rel="noopener noreferrer" referrerpolicy="no-referrer" target="_blank">link is relative</a> and this image: <img src="http://example.org/folder/image.png" loading="lazy"/>`
+	input := `This <a href="/test.html">link is relative</a> and this image: <img src="../folder/image.png">`
+	expected := `This <a href="http://example.org/test.html" rel="noopener noreferrer" referrerpolicy="no-referrer" target="_blank">link is relative</a> and this image: <img src="http://example.org/folder/image.png" loading="lazy">`
 	output := sanitizeHTMLWithDefaultOptions("http://example.org/", input)
 
 	if expected != output {
@@ -798,8 +798,8 @@ func TestXmlEntities(t *testing.T) {
 }
 
 func TestEspaceAttributes(t *testing.T) {
-	input := `<td rowspan="<b>test</b>">test</td>`
-	expected := `<td rowspan="&lt;b&gt;test&lt;/b&gt;">test</td>`
+	input := `<td rowspan="<b>injection</b>">text</td>`
+	expected := `text`
 	output := sanitizeHTMLWithDefaultOptions("http://example.org/", input)
 
 	if expected != output {
@@ -978,7 +978,7 @@ func TestHiddenParagraph(t *testing.T) {
 
 func TestAttributesAreStripped(t *testing.T) {
 	input := `<p style="color: red;">Some text.<hr style="color: blue"/>Test.</p>`
-	expected := `<p>Some text.<hr/>Test.</p>`
+	expected := `<p>Some text.</p><hr>Test.<p></p>`
 
 	output := sanitizeHTMLWithDefaultOptions("http://example.org/", input)
 	if expected != output {


### PR DESCRIPTION
As stated in [golang.org/x/net/html's documentation](https://pkg.go.dev/golang.org/x/net):

> If your use case requires semantically well-formed HTML documents, as defined
by the WHATWG specification, the parser should be used rather than the tokenizer.

The sanitizer is modifying the HTML document, and I'm pretty sure we don't want to implement a WHATWG-compliant parser ourself, as there are _so many_ edge cases everywhere. Picking the parser instead of the tokenizer ensures that miniflux has the same view of the DOM than web browsers, removing the risk of disparities, and thus injection-related security issues. Another benefit of this commit is to make the code way more readable/simple.

The only changes made to the testsuites are:

- Removing the trailing `/` on self-contained tags, as the spec doesn't require them. Adding them systematically could also have been done, but as the testsuite isn't consistent in this regard, it would have significantly increased the size of the commit to normalize it.
- Some weird things that were wrong in the first place, like how `<td rowspan="<b>injection</b>">text</td>` is interpreted by the browser as `text`, and not as `<td rowspan="&lt;b&gt;test&lt;/b&gt;">test</td>`.

Care has been taken to re-use as much code from the tokenizer-based sanitizer as possible.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
