### PR TITLE
refactor(sanitizer): remove workaround that strip large img width attribute

### DIFF
--- a/internal/reader/sanitizer/sanitizer_test.go
+++ b/internal/reader/sanitizer/sanitizer_test.go
@@ -79,16 +79,6 @@ func TestImgWithWidthAndHeightAttribute(t *testing.T) {
 	}
 }
 
-func TestImgWithWidthAttributeLargerThanMinifluxLayout(t *testing.T) {
-	input := `<img src="https://example.org/image.png" width="1200" height="675">`
-	expected := `<img src="https://example.org/image.png" loading="lazy">`
-	output := sanitizeHTMLWithDefaultOptions("http://example.org/", input)
-
-	if output != expected {
-		t.Errorf(`Wrong output: %s`, output)
-	}
-}
-
 func TestImgWithIncorrectWidthAndHeightAttribute(t *testing.T) {
 	input := `<img src="https://example.org/image.png" width="10px" height="20px">`
 	expected := `<img src="https://example.org/image.png" loading="lazy">`
@@ -295,7 +285,7 @@ func TestSourceWithSrcsetAndMedia(t *testing.T) {
 
 func TestMediumImgWithSrcset(t *testing.T) {
 	input := `<img alt="Image for post" class="t u v ef aj" src="https://miro.medium.com/max/5460/1*aJ9JibWDqO81qMfNtqgqrw.jpeg" srcset="https://miro.medium.com/max/552/1*aJ9JibWDqO81qMfNtqgqrw.jpeg 276w, https://miro.medium.com/max/1000/1*aJ9JibWDqO81qMfNtqgqrw.jpeg 500w" sizes="500px" width="2730" height="3407">`
-	expected := `<img alt="Image for post" src="https://miro.medium.com/max/5460/1*aJ9JibWDqO81qMfNtqgqrw.jpeg" srcset="https://miro.medium.com/max/552/1*aJ9JibWDqO81qMfNtqgqrw.jpeg 276w, https://miro.medium.com/max/1000/1*aJ9JibWDqO81qMfNtqgqrw.jpeg 500w" sizes="500px" loading="lazy">`
+	expected := `<img alt="Image for post" src="https://miro.medium.com/max/5460/1*aJ9JibWDqO81qMfNtqgqrw.jpeg" srcset="https://miro.medium.com/max/552/1*aJ9JibWDqO81qMfNtqgqrw.jpeg 276w, https://miro.medium.com/max/1000/1*aJ9JibWDqO81qMfNtqgqrw.jpeg 500w" sizes="500px" width="2730" height="3407" loading="lazy">`
 	output := sanitizeHTMLWithDefaultOptions("http://example.org/", input)
 
 	if output != expected {


### PR DESCRIPTION
The browser will do the right thing by default even if the image width is larger than Miniflux's layout.
