### PR TITLE
refactor(workflows): don't run useless on forks job forks

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     name: Build
+    if: github.repository_owner == 'miniflux'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   mirror:
+    if: github.repository_owner == 'miniflux'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   docker-images:
     name: Docker Images
+    if: github.repository_owner == 'miniflux'
     permissions:
       packages: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is no need to build binaries and docker images, as well as mirroring to codeberg, on fork repositories.