### PR TITLE
feat: add validation for TRUSTED_REVERSE_PROXY_NETWORKS config

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -5,6 +5,7 @@ package config // import "miniflux.app/v2/internal/config"
 
 import (
 	"maps"
+	"net"
 	"net/url"
 	"slices"
 	"strings"
@@ -564,6 +565,15 @@ func NewConfigOptions() *configOptions {
 				parsedStringList: []string{},
 				rawValue:         "",
 				valueType:        stringListType,
+				validator: func(rawValue string) error {
+					for ip := range strings.SplitSeq(rawValue, ",") {
+						if _, _, err := net.ParseCIDR(ip); err != nil {
+							return err
+						}
+					}
+
+					return nil
+				},
 			},
 			"WATCHDOG": {
 				parsedBoolValue: true,

--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -1643,6 +1643,11 @@ func TestTrustedReverseProxyNetworksOptionParsing(t *testing.T) {
 	if !slices.Contains(allowedNetworks, "192.168.1.0/24") {
 		t.Errorf("Expected 192.168.1.0/24 in allowed networks")
 	}
+
+	// Test invalid value
+	if err := configParser.parseLines([]string{"TRUSTED_REVERSE_PROXY_NETWORKS=127.0.0.1"}); err == nil {
+		t.Fatal("Expected error when parsing invalid CIDR notation IP 127.0.0.1, got nil")
+	}
 }
 
 func TestYouTubeEmbedDomainOptionParsing(t *testing.T) {


### PR DESCRIPTION
Currently if the IP is not in CIDR notation it will just silently fail, which can be very confusing. This commit changes that, as well as adds a test.

I'm unsure if it should go into its own validator function like the other validator functions I could see, but I think it's pretty simple, and not too many lines of code.

For an empty value it will output

> invalid value for key TRUSTED_REVERSE_PROXY_NETWORKS: invalid CIDR address: 

For an invalid CIDR value it will output

> invalid value for key TRUSTED_REVERSE_PROXY_NETWORKS: invalid CIDR address: 127.0.0.1

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
