### PR TITLE
Optimize a bit SanitizeHTML

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -294,13 +294,13 @@ func filterAndRenderHTML(buf *strings.Builder, n *html.Node, parsedBaseUrl *url.
 			// The tag doesn't have every required attributes but we're still interested in its content
 			return filterAndRenderHTMLChildren(buf, n, parsedBaseUrl, sanitizerOptions, depth-1)
 		}
-		buf.WriteString("<")
+		buf.WriteByte('<')
 		buf.WriteString(n.Data)
 		if htmlAttributes != "" {
 			buf.WriteByte(' ')
 			buf.WriteString(htmlAttributes)
 		}
-		buf.WriteString(">")
+		buf.WriteByte('>')
 
 		if isSelfContainedTag(tag) {
 			return nil
@@ -313,7 +313,7 @@ func filterAndRenderHTML(buf *strings.Builder, n *html.Node, parsedBaseUrl *url.
 
 		buf.WriteString("</")
 		buf.WriteString(n.Data)
-		buf.WriteString(">")
+		buf.WriteByte('>')
 	default:
 	}
 	return nil


### PR DESCRIPTION
Benchmark Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| allocs/op | 26,190 | 24,901 | **-4.9%** |
| B/op | 2,829,500 | 2,729,760 | **-3.5%** |
| ns/op (median) | ~12,938k | ~12,226k | **~-5.5%** |

I think it also makes the code a bit more explicit.