### PR TITLE
refactor(encoding): fold a duplicate function

### DIFF
--- a/internal/reader/encoding/encoding.go
+++ b/internal/reader/encoding/encoding.go
@@ -12,7 +12,8 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-// CharsetReader is used when the XML encoding is specified for the input document.
+// CharsetReader returns an io.Reader that converts the content of r to UTF-8,
+// it should be used when the XML encoding is specified for the input document.
 //
 // The document is converted in UTF-8 only if a different encoding is specified
 // and the document is not already UTF-8.
@@ -23,26 +24,7 @@ import (
 // - Feeds with encoding specified in both places
 // - Feeds with encoding specified only in XML document and not in HTTP header
 // - Feeds with wrong encoding defined and already in UTF-8
-func CharsetReader(charsetLabel string, input io.Reader) (io.Reader, error) {
-	buffer, err := io.ReadAll(input)
-	if err != nil {
-		return nil, fmt.Errorf(`encoding: unable to read input: %w`, err)
-	}
-
-	r := bytes.NewReader(buffer)
-
-	// The document is already UTF-8, do not do anything (avoid double-encoding).
-	// That means the specified encoding in XML prolog is wrong.
-	if utf8.Valid(buffer) {
-		return r, nil
-	}
-
-	// Transform document to UTF-8 from the specified encoding in XML prolog.
-	return charset.NewReaderLabel(charsetLabel, r)
-}
-
-// NewCharsetReader returns an io.Reader that converts the content of r to UTF-8.
-func NewCharsetReader(r io.Reader, contentType string) (io.Reader, error) {
+func CharsetReader(contentType string, r io.Reader) (io.Reader, error) {
 	buffer, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf(`encoding: unable to read input: %w`, err)
@@ -54,7 +36,8 @@ func NewCharsetReader(r io.Reader, contentType string) (io.Reader, error) {
 func NewCharsetReaderFromBytes(buffer []byte, contentType string) (io.Reader, error) {
 	internalReader := bytes.NewReader(buffer)
 
-	// The document is already UTF-8, do not do anything.
+	// The document is already UTF-8, do not do anything (avoid double-encoding).
+	// That means the specified encoding in XML prolog is wrong.
 	if utf8.Valid(buffer) {
 		return internalReader, nil
 	}

--- a/internal/reader/encoding/encoding_test.go
+++ b/internal/reader/encoding/encoding_test.go
@@ -187,7 +187,7 @@ func TestNewReaderWithUTF8Document(t *testing.T) {
 		t.Fatalf("Unable to open file: %v", err)
 	}
 
-	reader, err := NewCharsetReader(f, "text/html; charset=UTF-8")
+	reader, err := CharsetReader("text/html; charset=UTF-8", f)
 	if err != nil {
 		t.Fatalf("Unable to create reader: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestNewReaderWithUTF8DocumentAndNoContentEncoding(t *testing.T) {
 		t.Fatalf("Unable to open file: %v", err)
 	}
 
-	reader, err := NewCharsetReader(f, "text/html")
+	reader, err := CharsetReader("text/html", f)
 	if err != nil {
 		t.Fatalf("Unable to create reader: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestNewReaderWithISO88591Document(t *testing.T) {
 		t.Fatalf("Unable to open file: %v", err)
 	}
 
-	reader, err := NewCharsetReader(f, "text/html; charset=ISO-8859-1")
+	reader, err := CharsetReader("text/html; charset=ISO-8859-1", f)
 	if err != nil {
 		t.Fatalf("Unable to create reader: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestNewReaderWithISO88591DocumentAndNoContentType(t *testing.T) {
 		t.Fatalf("Unable to open file: %v", err)
 	}
 
-	reader, err := NewCharsetReader(f, "")
+	reader, err := CharsetReader("", f)
 	if err != nil {
 		t.Fatalf("Unable to create reader: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestNewReaderWithISO88591DocumentWithMetaAfter1024Bytes(t *testing.T) {
 		t.Fatalf("Unable to open file: %v", err)
 	}
 
-	reader, err := NewCharsetReader(f, "text/html")
+	reader, err := CharsetReader("text/html", f)
 	if err != nil {
 		t.Fatalf("Unable to create reader: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestNewReaderWithUTF8DocumentWithMetaAfter1024Bytes(t *testing.T) {
 		t.Fatalf("Unable to open file: %v", err)
 	}
 
-	reader, err := NewCharsetReader(f, "text/html")
+	reader, err := CharsetReader("text/html", f)
 	if err != nil {
 		t.Fatalf("Unable to create reader: %v", err)
 	}

--- a/internal/reader/icon/finder.go
+++ b/internal/reader/icon/finder.go
@@ -247,7 +247,7 @@ func resizeIcon(icon *model.Icon) *model.Icon {
 }
 
 func findIconURLsFromHTMLDocument(documentURL string, body io.Reader, contentType string) ([]string, error) {
-	htmlDocumentReader, err := encoding.NewCharsetReader(body, contentType)
+	htmlDocumentReader, err := encoding.CharsetReader(contentType, body)
 	if err != nil {
 		return nil, fmt.Errorf("icon: unable to create charset reader: %w", err)
 	}

--- a/internal/reader/scraper/scraper.go
+++ b/internal/reader/scraper/scraper.go
@@ -39,9 +39,9 @@ func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string
 		rules = getPredefinedScraperRules(pageURL)
 	}
 
-	htmlDocumentReader, err := encoding.NewCharsetReader(
-		responseHandler.Body(config.Opts.HTTPClientMaxBodySize()),
+	htmlDocumentReader, err := encoding.CharsetReader(
 		responseHandler.ContentType(),
+		responseHandler.Body(config.Opts.HTTPClientMaxBodySize()),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Turns out CharsetReader and NewCharsetReader are doing the very same thing.