### PR TITLE
perf(urlcleaner): misc performance improvements

### DIFF
--- a/internal/reader/urlcleaner/urlcleaner.go
+++ b/internal/reader/urlcleaner/urlcleaner.go
@@ -131,20 +131,29 @@ func RemoveTrackingParameters(parsedFeedURL, parsedSiteURL, parsedInputUrl *url.
 		return "", errors.New("urlcleaner: one of the URLs is nil")
 	}
 
+	if parsedInputUrl.RawQuery == "" {
+		return parsedInputUrl.String(), nil
+	}
+
 	queryParams := parsedInputUrl.Query()
 	hasTrackers := false
+	feedHostname := parsedFeedURL.Hostname()
+	siteHostname := parsedSiteURL.Hostname()
 
 	// Remove tracking parameters
 	for param := range queryParams {
 		lowerParam := strings.ToLower(param)
+
 		if isTrackingParam(lowerParam) {
 			queryParams.Del(param)
 			hasTrackers = true
+			continue
 		}
+
 		if trackingParamsOutbound[lowerParam] {
 			// handle duplicate parameters like ?a=b&a=c&a=d…
 			for _, value := range queryParams[param] {
-				if value == parsedFeedURL.Hostname() || value == parsedSiteURL.Hostname() {
+				if value == feedHostname || value == siteHostname {
 					queryParams.Del(param)
 					hasTrackers = true
 					break


### PR DESCRIPTION
- Don't clean an url without any parameters
- Don't recompute the Hostname for parsedFeedURL and parsedSiteURL in a loop
- Don't keep processing a parameter once it has been detected as a tracking one.