### PR TITLE
refactor(icon): remove two loops

### DIFF
--- a/internal/reader/icon/finder_test.go
+++ b/internal/reader/icon/finder_test.go
@@ -246,12 +246,10 @@ func TestFindIconURLsFromHTMLDocument_DataURLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The function processes queries in order: rel="icon", then rel="shortcut icon", etc.
-	// So both rel="icon" links are found first, then the rel="shortcut icon" link
 	expected := []string{
 		"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAGAhGAQ+QAAAABJRU5ErkJggg==",
-		"https://example.org/regular-icon.ico",
 		"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+		"https://example.org/regular-icon.ico",
 	}
 
 	if len(iconURLs) != len(expected) {


### PR DESCRIPTION
1. If the websiteURL is equal to the RootURL, there is no need to check them both.
2. Group the icon-looking-queries into a single one.