### PR TITLE
feat: add FETCHER_ALLOW_PRIVATE_NETWORKS option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ integration-test:
 	CREATE_ADMIN=1 \
 	RUN_MIGRATIONS=1 \
 	LOG_LEVEL=debug \
+	FETCHER_ALLOW_PRIVATE_NETWORKS=1 \
 	go run main.go >/tmp/miniflux.log 2>&1 & echo "$$!" > "/tmp/miniflux.pid"
 
 	while ! nc -z localhost 8080; do sleep 1; done

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -219,6 +219,11 @@ func NewConfigOptions() *configOptions {
 				rawValue:        "0",
 				valueType:       boolType,
 			},
+			"FETCHER_ALLOW_PRIVATE_NETWORKS": {
+				parsedBoolValue: false,
+				rawValue:        "0",
+				valueType:       boolType,
+			},
 			"FETCH_BILIBILI_WATCH_TIME": {
 				parsedBoolValue: false,
 				rawValue:        "0",
@@ -293,11 +298,6 @@ func NewConfigOptions() *configOptions {
 				rawValue:        "0",
 				valueType:       boolType,
 			},
-			"ICON_FETCH_ALLOW_PRIVATE_NETWORKS": {
-				parsedBoolValue: false,
-				rawValue:        "0",
-				valueType:       boolType,
-			},
 			"INVIDIOUS_INSTANCE": {
 				parsedStringValue: "yewtu.be",
 				rawValue:          "yewtu.be",
@@ -352,11 +352,6 @@ func NewConfigOptions() *configOptions {
 			"MEDIA_PROXY_CUSTOM_URL": {
 				rawValue:  "",
 				valueType: urlType,
-			},
-			"MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS": {
-				parsedBoolValue: false,
-				rawValue:        "0",
-				valueType:       boolType,
 			},
 			"MEDIA_PROXY_HTTP_CLIENT_TIMEOUT": {
 				parsedDuration: 120 * time.Second,
@@ -791,8 +786,8 @@ func (c *configOptions) HTTPS() bool {
 	return c.options["HTTPS"].parsedBoolValue
 }
 
-func (c *configOptions) IconFetchAllowPrivateNetworks() bool {
-	return c.options["ICON_FETCH_ALLOW_PRIVATE_NETWORKS"].parsedBoolValue
+func (c *configOptions) FetcherAllowPrivateNetworks() bool {
+	return c.options["FETCHER_ALLOW_PRIVATE_NETWORKS"].parsedBoolValue
 }
 
 func (c *configOptions) InvidiousInstance() string {
@@ -845,10 +840,6 @@ func (c *configOptions) MaintenanceMode() bool {
 
 func (c *configOptions) MediaCustomProxyURL() *url.URL {
 	return c.options["MEDIA_PROXY_CUSTOM_URL"].parsedURLValue
-}
-
-func (c *configOptions) MediaProxyAllowPrivateNetworks() bool {
-	return c.options["MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS"].parsedBoolValue
 }
 
 func (c *configOptions) MediaProxyHTTPClientTimeout() time.Duration {

--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -1351,27 +1351,27 @@ func TestHTTPClientTimeoutOptionParsing(t *testing.T) {
 	}
 }
 
-func TestIconFetchAllowPrivateNetworksOptionParsing(t *testing.T) {
+func TestFetcherAllowPrivateNetworksOptionParsing(t *testing.T) {
 	configParser := NewConfigParser()
 
-	if configParser.options.IconFetchAllowPrivateNetworks() {
-		t.Fatalf("Expected ICON_FETCH_ALLOW_PRIVATE_NETWORKS to be disabled by default")
+	if configParser.options.FetcherAllowPrivateNetworks() {
+		t.Fatalf("Expected FETCHER_ALLOW_PRIVATE_NETWORKS to be disabled by default")
 	}
 
-	if err := configParser.parseLines([]string{"ICON_FETCH_ALLOW_PRIVATE_NETWORKS=1"}); err != nil {
+	if err := configParser.parseLines([]string{"FETCHER_ALLOW_PRIVATE_NETWORKS=1"}); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if !configParser.options.IconFetchAllowPrivateNetworks() {
-		t.Fatalf("Expected ICON_FETCH_ALLOW_PRIVATE_NETWORKS to be enabled")
+	if !configParser.options.FetcherAllowPrivateNetworks() {
+		t.Fatalf("Expected FETCHER_ALLOW_PRIVATE_NETWORKS to be enabled")
 	}
 
-	if err := configParser.parseLines([]string{"ICON_FETCH_ALLOW_PRIVATE_NETWORKS=0"}); err != nil {
+	if err := configParser.parseLines([]string{"FETCHER_ALLOW_PRIVATE_NETWORKS=0"}); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if configParser.options.IconFetchAllowPrivateNetworks() {
-		t.Fatalf("Expected ICON_FETCH_ALLOW_PRIVATE_NETWORKS to be disabled")
+	if configParser.options.FetcherAllowPrivateNetworks() {
+		t.Fatalf("Expected FETCHER_ALLOW_PRIVATE_NETWORKS to be disabled")
 	}
 }
 
@@ -1439,30 +1439,6 @@ func TestMediaProxyHTTPClientTimeoutOptionParsing(t *testing.T) {
 
 	if configParser.options.MediaProxyHTTPClientTimeout().Seconds() != 60 {
 		t.Fatalf("Expected MEDIA_PROXY_HTTP_CLIENT_TIMEOUT to be 60 seconds")
-	}
-}
-
-func TestMediaProxyAllowPrivateNetworksOptionParsing(t *testing.T) {
-	configParser := NewConfigParser()
-
-	if configParser.options.MediaProxyAllowPrivateNetworks() {
-		t.Fatalf("Expected MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS to be disabled by default")
-	}
-
-	if err := configParser.parseLines([]string{"MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS=1"}); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if !configParser.options.MediaProxyAllowPrivateNetworks() {
-		t.Fatalf("Expected MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS to be enabled")
-	}
-
-	if err := configParser.parseLines([]string{"MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS=0"}); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if configParser.options.MediaProxyAllowPrivateNetworks() {
-		t.Fatalf("Expected MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS to be disabled")
 	}
 }
 

--- a/internal/reader/icon/finder_test.go
+++ b/internal/reader/icon/finder_test.go
@@ -398,24 +398,6 @@ func TestResizeIconWebp(t *testing.T) {
 	}
 }
 
-func TestEnsureRemoteIconURLAllowedRejectsPrivateNetworks(t *testing.T) {
-	if err := ensureRemoteIconURLAllowed("http://192.168.0.1/favicon.ico", false); err == nil {
-		t.Fatal("Expected private network hosts to be rejected")
-	}
-}
-
-func TestEnsureRemoteIconURLAllowedAllowsPublicNetworks(t *testing.T) {
-	if err := ensureRemoteIconURLAllowed("https://1.1.1.1/favicon.ico", false); err != nil {
-		t.Fatalf("Expected public network hosts to be allowed: %v", err)
-	}
-}
-
-func TestEnsureRemoteIconURLAllowedAllowsPrivateWhenEnabled(t *testing.T) {
-	if err := ensureRemoteIconURLAllowed("http://10.0.0.5/icon.png", true); err != nil {
-		t.Fatalf("Expected private network hosts to be allowed when explicitly enabled: %v", err)
-	}
-}
-
 func TestResizeInvalidImage(t *testing.T) {
 	icon := model.Icon{
 		Content:  []byte("invalid data"),

--- a/miniflux.1
+++ b/miniflux.1
@@ -1,5 +1,5 @@
 .\" Manpage for miniflux.
-.TH "MINIFLUX" "1" "January 5, 2026" "\ \&" "\ \&"
+.TH "MINIFLUX" "1" "February 28, 2026" "\ \&" "\ \&"
 
 .SH NAME
 miniflux \- Minimalist and opinionated feed reader
@@ -274,6 +274,11 @@ Set the value to 1 to disable the internal scheduler service\&.
 .br
 Default is false (The internal scheduler service is enabled)\&.
 .TP
+.B FETCHER_ALLOW_PRIVATE_NETWORKS
+Set to 1 to allow outgoing fetcher requests to private or loopback networks\&.
+.br
+Disabled by default, private networks are refused\&.
+.TP
 .B FETCH_BILIBILI_WATCH_TIME
 Set the value to 1 to scrape video duration from Bilibili website and
 use it as a reading time\&.
@@ -340,11 +345,6 @@ Forces cookies to use secure flag and send HSTS header\&.
 .br
 Default is disabled\&.
 .TP
-.B ICON_FETCH_ALLOW_PRIVATE_NETWORKS
-Set to 1 to allow downloading favicons that resolve to private or loopback networks\&.
-.br
-Disabled by default, private networks are refused\&.
-.TP
 .B INVIDIOUS_INSTANCE
 Set a custom invidious instance to use\&.
 .br
@@ -401,11 +401,6 @@ Default is empty, Miniflux does the proxying\&.
 Time limit in seconds before the media proxy HTTP client cancels the request\&.
 .br
 Default is 120 seconds\&.
-.TP
-.B MEDIA_PROXY_ALLOW_PRIVATE_NETWORKS
-Set to 1 to allow proxying media that resolves to private or loopback networks\&.
-.br
-Disabled by default, private networks are refused\&.
 .TP
 .B MEDIA_PROXY_RESOURCE_TYPES
 A comma-separated list of media types to proxify. Supported values are: image, audio, video\&.


### PR DESCRIPTION
Block outbound requests to private networks made by the fetcher by default. The restriction now applies to all outgoing requests performed by the fetcher.

Previous PR #3947 intentionally enforced this restriction only for the media proxy and icon fetching, considering the self-hosted nature of Miniflux.