### PR TITLE
fix(integration): fix bugs, naming, and inconsistencies across sub-packages

### DIFF
--- a/internal/integration/apprise/apprise.go
+++ b/internal/integration/apprise/apprise.go
@@ -25,7 +25,7 @@ type Client struct {
 }
 
 func NewClient(serviceURL, baseURL string) *Client {
-	return &Client{serviceURL, baseURL}
+	return &Client{servicesURL: serviceURL, baseURL: baseURL}
 }
 
 func (c *Client) SendNotification(feed *model.Feed, entries model.Entries) error {
@@ -70,7 +70,7 @@ func (c *Client) SendNotification(feed *model.Feed, entries model.Entries) error
 		if err != nil {
 			return fmt.Errorf("apprise: unable to send request: %v", err)
 		}
-		response.Body.Close()
+		defer response.Body.Close()
 
 		if response.StatusCode >= 400 {
 			return fmt.Errorf("apprise: unable to send a notification: url=%s status=%d", apiEndpoint, response.StatusCode)

--- a/internal/integration/archiveorg/archiveorg.go
+++ b/internal/integration/archiveorg/archiveorg.go
@@ -4,10 +4,15 @@
 package archiveorg
 
 import (
-	"log/slog"
+	"fmt"
 	"net/http"
 	"net/url"
+	"time"
+
+	"miniflux.app/v2/internal/version"
 )
+
+const defaultClientTimeout = 30 * time.Second
 
 // See https://docs.google.com/document/d/1Nsv52MvSjbLb2PCpHlat0gkzw0EvtSgpKHu4mk0MnrA/edit?tab=t.0
 const options = "delay_wb_availability=1&if_not_archived_within=15d"
@@ -18,26 +23,25 @@ func NewClient() *Client {
 	return &Client{}
 }
 
-func (c *Client) SendURL(entryURL, title string) {
-	// We're using a goroutine here as submissions to archive.org might take a long time
-	// and trigger a timeout on miniflux' side.
-	go func(entryURL string) {
-		res, err := http.Get("https://web.archive.org/save/" + url.QueryEscape(entryURL) + "?" + options)
-		if err != nil {
-			slog.Error("archiveorg: unable to send request: %v",
-				slog.Any("err", err),
-				slog.String("title", title),
-				slog.String("url", entryURL),
-			)
-			return
-		}
-		if res.StatusCode > 299 {
-			slog.Error("archiveorg: failed with status code",
-				slog.String("title", title),
-				slog.String("url", entryURL),
-				slog.Int("code", res.StatusCode),
-			)
-		}
-		res.Body.Close()
-	}(entryURL)
+func (c *Client) SendURL(entryURL string) error {
+	requestURL := "https://web.archive.org/save/" + url.QueryEscape(entryURL) + "?" + options
+	request, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("archiveorg: unable to create request: %v", err)
+	}
+
+	request.Header.Set("User-Agent", "Miniflux/"+version.Version)
+
+	httpClient := &http.Client{Timeout: defaultClientTimeout}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("archiveorg: unable to send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("archiveorg: unexpected status code: url=%s status=%d", requestURL, response.StatusCode)
+	}
+
+	return nil
 }

--- a/internal/integration/betula/betula.go
+++ b/internal/integration/betula/betula.go
@@ -41,7 +41,6 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string, tags []string) erro
 		return fmt.Errorf("betula: unable to create request: %v", err)
 	}
 
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("User-Agent", "Miniflux/"+version.Version)
 	request.AddCookie(&http.Cookie{Name: "betula-token", Value: c.token})
 

--- a/internal/integration/discord/discord.go
+++ b/internal/integration/discord/discord.go
@@ -82,7 +82,7 @@ func (c *Client) SendDiscordMsg(feed *model.Feed, entries model.Entries) error {
 		if err != nil {
 			return fmt.Errorf("discord: unable to send request: %v", err)
 		}
-		response.Body.Close()
+		defer response.Body.Close()
 
 		if response.StatusCode >= 400 {
 			return fmt.Errorf("discord: unable to send a notification: url=%s status=%d", c.webhookURL, response.StatusCode)

--- a/internal/integration/espial/espial.go
+++ b/internal/integration/espial/espial.go
@@ -38,7 +38,7 @@ func (c *Client) CreateLink(entryURL, entryTitle, espialTags string) error {
 
 	requestBody, err := json.Marshal(&espialDocument{
 		Title:  entryTitle,
-		Url:    entryURL,
+		URL:    entryURL,
 		ToRead: true,
 		Tags:   espialTags,
 	})
@@ -75,7 +75,7 @@ func (c *Client) CreateLink(entryURL, entryTitle, espialTags string) error {
 
 type espialDocument struct {
 	Title  string `json:"title,omitempty"`
-	Url    string `json:"url,omitempty"`
+	URL    string `json:"url,omitempty"`
 	ToRead bool   `json:"toread,omitempty"`
 	Tags   string `json:"tags,omitempty"`
 }

--- a/internal/integration/instapaper/instapaper.go
+++ b/internal/integration/instapaper/instapaper.go
@@ -40,7 +40,6 @@ func (c *Client) AddURL(entryURL, entryTitle string) error {
 	}
 
 	request.SetBasicAuth(c.username, c.password)
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("User-Agent", "Miniflux/"+version.Version)
 
 	httpClient := &http.Client{Timeout: defaultClientTimeout}

--- a/internal/integration/linkace/linkace.go
+++ b/internal/integration/linkace/linkace.go
@@ -44,7 +44,7 @@ func (c *Client) AddURL(entryURL, entryTitle string) error {
 		return fmt.Errorf("linkace: invalid API endpoint: %v", err)
 	}
 	requestBody, err := json.Marshal(&createItemRequest{
-		Url:           entryURL,
+		URL:           entryURL,
 		Title:         entryTitle,
 		Tags:          strings.FieldsFunc(c.tags, tagsSplitFn),
 		Private:       c.private,
@@ -80,7 +80,7 @@ func (c *Client) AddURL(entryURL, entryTitle string) error {
 
 type createItemRequest struct {
 	Title         string   `json:"title,omitempty"`
-	Url           string   `json:"url"`
+	URL           string   `json:"url"`
 	Tags          []string `json:"tags,omitempty"`
 	Private       bool     `json:"is_private,omitempty"`
 	CheckDisabled bool     `json:"check_disabled,omitempty"`

--- a/internal/integration/linkding/linkding.go
+++ b/internal/integration/linkding/linkding.go
@@ -44,7 +44,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 	}
 
 	requestBody, err := json.Marshal(&linkdingBookmark{
-		Url:      entryURL,
+		URL:      entryURL,
 		Title:    entryTitle,
 		TagNames: strings.FieldsFunc(c.tags, tagsSplitFn),
 		Unread:   c.unread,
@@ -78,7 +78,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 }
 
 type linkdingBookmark struct {
-	Url      string   `json:"url,omitempty"`
+	URL      string   `json:"url,omitempty"`
 	Title    string   `json:"title,omitempty"`
 	TagNames []string `json:"tag_names,omitempty"`
 	Unread   bool     `json:"unread,omitempty"`

--- a/internal/integration/ntfy/ntfy.go
+++ b/internal/integration/ntfy/ntfy.go
@@ -32,7 +32,16 @@ func NewClient(ntfyURL, ntfyTopic, ntfyApiToken, ntfyUsername, ntfyPassword, ntf
 	if ntfyURL == "" {
 		ntfyURL = defaultNtfyURL
 	}
-	return &Client{ntfyURL, ntfyTopic, ntfyApiToken, ntfyUsername, ntfyPassword, ntfyIconURL, ntfyInternalLinks, ntfyPriority}
+	return &Client{
+		ntfyURL:           ntfyURL,
+		ntfyTopic:         ntfyTopic,
+		ntfyApiToken:      ntfyApiToken,
+		ntfyUsername:      ntfyUsername,
+		ntfyPassword:      ntfyPassword,
+		ntfyIconURL:       ntfyIconURL,
+		ntfyInternalLinks: ntfyInternalLinks,
+		ntfyPriority:      ntfyPriority,
+	}
 }
 
 func (c *Client) SendMessages(feed *model.Feed, entries model.Entries) error {

--- a/internal/integration/nunuxkeeper/nunuxkeeper.go
+++ b/internal/integration/nunuxkeeper/nunuxkeeper.go
@@ -43,7 +43,7 @@ func (c *Client) AddEntry(entryURL, entryTitle, entryContent string) error {
 		ContentType: "text/html",
 	})
 	if err != nil {
-		return fmt.Errorf("notion: unable to encode request body: %v", err)
+		return fmt.Errorf("nunux-keeper: unable to encode request body: %v", err)
 	}
 
 	request, err := http.NewRequest(http.MethodPost, apiEndpoint, bytes.NewReader(requestBody))

--- a/internal/integration/pinboard/pinboard.go
+++ b/internal/integration/pinboard/pinboard.go
@@ -57,7 +57,6 @@ func (c *Client) CreateBookmark(entryURL, entryTitle, pinboardTags string, markA
 		return fmt.Errorf("pinboard: unable to create request: %v", err)
 	}
 
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("User-Agent", "Miniflux/"+version.Version)
 
 	httpClient := &http.Client{Timeout: defaultClientTimeout}
@@ -90,7 +89,6 @@ func (c *Client) getBookmark(entryURL string) (*Post, error) {
 		return nil, fmt.Errorf("pinboard: unable to create request: %v", err)
 	}
 
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("User-Agent", "Miniflux/"+version.Version)
 
 	httpClient := &http.Client{Timeout: defaultClientTimeout}

--- a/internal/integration/pinboard/post.go
+++ b/internal/integration/pinboard/post.go
@@ -13,7 +13,7 @@ import (
 // Post a Pinboard bookmark.  "inspiration" from https://github.com/drags/pinboard/blob/master/posts.go#L32-L42
 type Post struct {
 	XMLName     xml.Name  `xml:"post"`
-	Url         string    `xml:"href,attr"`
+	URL         string    `xml:"href,attr"`
 	Description string    `xml:"description,attr"`
 	Tags        string    `xml:"tag,attr"`
 	Extended    string    `xml:"extended,attr"`
@@ -30,7 +30,7 @@ type posts struct {
 
 func NewPost(url string, description string) *Post {
 	return &Post{
-		Url:         url,
+		URL:         url,
 		Description: description,
 		Date:        time.Now(),
 		Toread:      "no",
@@ -48,7 +48,7 @@ func (p *Post) SetToread() {
 }
 
 func (p *Post) AddValues(values url.Values) {
-	values.Add("url", p.Url)
+	values.Add("url", p.URL)
 	values.Add("description", p.Description)
 	values.Add("tags", p.Tags)
 	if p.Toread != "" {

--- a/internal/integration/readeck/readeck.go
+++ b/internal/integration/readeck/readeck.go
@@ -48,7 +48,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string, entryContent string
 	var request *http.Request
 	if c.onlyURL {
 		requestBodyJson, err := json.Marshal(&readeckBookmark{
-			Url:    entryURL,
+			URL:    entryURL,
 			Title:  entryTitle,
 			Labels: labelsSplit,
 		})
@@ -91,7 +91,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string, entryContent string
 		}
 
 		contentBodyHeader, err := json.Marshal(&partContentHeader{
-			Url:           entryURL,
+			URL:           entryURL,
 			ContentHeader: contentHeader{ContentType: "text/html; charset=utf-8"},
 		})
 		if err != nil {
@@ -135,7 +135,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string, entryContent string
 }
 
 type readeckBookmark struct {
-	Url    string   `json:"url"`
+	URL    string   `json:"url"`
 	Title  string   `json:"title"`
 	Labels []string `json:"labels,omitempty"`
 }
@@ -145,6 +145,6 @@ type contentHeader struct {
 }
 
 type partContentHeader struct {
-	Url           string        `json:"url"`
+	URL           string        `json:"url"`
 	ContentHeader contentHeader `json:"headers"`
 }

--- a/internal/integration/shiori/shiori.go
+++ b/internal/integration/shiori/shiori.go
@@ -80,7 +80,7 @@ func (c *Client) CreateBookmark(entryURL, entryTitle string) error {
 	return nil
 }
 
-func (c *Client) authenticate() (token string, err error) {
+func (c *Client) authenticate() (string, error) {
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/v1/auth/login")
 	if err != nil {
 		return "", fmt.Errorf("shiori: invalid API endpoint: %v", err)

--- a/internal/integration/slack/slack.go
+++ b/internal/integration/slack/slack.go
@@ -86,7 +86,7 @@ func (c *Client) SendSlackMsg(feed *model.Feed, entries model.Entries) error {
 		if err != nil {
 			return fmt.Errorf("slack: unable to send request: %v", err)
 		}
-		response.Body.Close()
+		defer response.Body.Close()
 
 		if response.StatusCode >= 400 {
 			return fmt.Errorf("slack: unable to send a notification: url=%s status=%d", c.webhookURL, response.StatusCode)

--- a/internal/integration/wallabag/wallabag.go
+++ b/internal/integration/wallabag/wallabag.go
@@ -30,7 +30,15 @@ type Client struct {
 }
 
 func NewClient(baseURL, clientID, clientSecret, username, password, tags string, onlyURL bool) *Client {
-	return &Client{baseURL, clientID, clientSecret, username, password, tags, onlyURL}
+	return &Client{
+		baseURL:      baseURL,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		username:     username,
+		password:     password,
+		tags:         tags,
+		onlyURL:      onlyURL,
+	}
 }
 
 func (c *Client) CreateEntry(entryURL, entryTitle, entryContent string) error {
@@ -49,7 +57,7 @@ func (c *Client) CreateEntry(entryURL, entryTitle, entryContent string) error {
 func (c *Client) createEntry(accessToken, entryURL, entryTitle, entryContent, tags string) error {
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/api/entries.json")
 	if err != nil {
-		return fmt.Errorf("wallbag: unable to generate entries endpoint: %v", err)
+		return fmt.Errorf("wallabag: unable to generate entries endpoint: %v", err)
 	}
 
 	if c.onlyURL {
@@ -63,12 +71,12 @@ func (c *Client) createEntry(accessToken, entryURL, entryTitle, entryContent, ta
 		Tags:    tags,
 	})
 	if err != nil {
-		return fmt.Errorf("wallbag: unable to encode request body: %v", err)
+		return fmt.Errorf("wallabag: unable to encode request body: %v", err)
 	}
 
 	request, err := http.NewRequest(http.MethodPost, apiEndpoint, bytes.NewReader(requestBody))
 	if err != nil {
-		return fmt.Errorf("wallbag: unable to create request: %v", err)
+		return fmt.Errorf("wallabag: unable to create request: %v", err)
 	}
 
 	request.Header.Set("Content-Type", "application/json")
@@ -100,12 +108,12 @@ func (c *Client) getAccessToken() (string, error) {
 
 	apiEndpoint, err := urllib.JoinBaseURLAndPath(c.baseURL, "/oauth/v2/token")
 	if err != nil {
-		return "", fmt.Errorf("wallbag: unable to generate token endpoint: %v", err)
+		return "", fmt.Errorf("wallabag: unable to generate token endpoint: %v", err)
 	}
 
 	request, err := http.NewRequest(http.MethodPost, apiEndpoint, strings.NewReader(values.Encode()))
 	if err != nil {
-		return "", fmt.Errorf("wallbag: unable to create request: %v", err)
+		return "", fmt.Errorf("wallabag: unable to create request: %v", err)
 	}
 
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
Bugs fixed:
- pushover: inverted error-check logic (err != nil → err == nil)
- nunuxkeeper: wrong error prefix ("notion:" → "nunux-keeper:")
- wallabag: typo "wallbag" in five error messages
- omnivore: potential panic on empty errors array
- rssbridge: off-by-one status check (> 400 → >= 400)
- archiveorg: slog called with printf-style %v format verb
- integration: redundant TelegramBotEnabled check (dead code)
- integration: webhook failure logged at Debug instead of Warn

Non-idiomatic Go fixed:
- archiveorg: replace http.Get() with proper http.Client, add User-Agent header, remove unnecessary goroutine, return error
- apprise/discord/slack: use defer for response.Body.Close()
- omnivore: return concrete struct instead of interface from NewClient
- pushover: rename New() to NewClient() for consistency
- wallabag/ntfy: use named fields in struct literal initialization
- shiori: remove unnecessary named return values
- instapaper/pinboard/betula: remove Content-Type on bodyless requests
- rssbridge: add missing User-Agent header

Naming and style:
- Rename Url→URL, ClientRequestId→ClientRequestID in struct fields (espial, linkace, linkding, readeck, pinboard, omnivore)
- Rename SaveUrl→SaveURL method (omnivore)
- Unexport internal-only types (pushover, omnivore)
- Fix variable typo successReponse→successResponse (omnivore)
- Normalize error prefixes to lowercase "pkg:" style (pushover, rssbridge)
- Fix grammar "Rewrited"→"Rewrote" (rssbridge)
