### PR TITLE
perf(fetcher): save 6 bytes per requests

### DIFF
--- a/internal/reader/fetcher/request_builder.go
+++ b/internal/reader/fetcher/request_builder.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	defaultHTTPClientTimeout = 20 * time.Second
-	defaultAcceptHeader      = "application/xml, application/atom+xml, application/rss+xml, application/rdf+xml, application/feed+json, text/html, */*;q=0.9"
+	defaultAcceptHeader      = "application/xml,application/atom+xml,application/rss+xml,application/rdf+xml,application/feed+json,text/html,*/*;q=0.9"
 )
 
 var (
@@ -237,7 +237,7 @@ func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, erro
 	if r.disableCompression {
 		req.Header.Set("Accept-Encoding", "identity")
 	} else {
-		req.Header.Set("Accept-Encoding", "br, gzip")
+		req.Header.Set("Accept-Encoding", "br,gzip")
 	}
 
 	// Set default Accept header if not already set.

--- a/internal/reader/fetcher/request_builder_test.go
+++ b/internal/reader/fetcher/request_builder_test.go
@@ -303,8 +303,8 @@ func TestRequestBuilder_WithoutCompression(t *testing.T) {
 
 func TestRequestBuilder_WithCompression(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Accept-Encoding") != "br, gzip" {
-			t.Errorf("Expected Accept-Encoding to be 'br, gzip', got '%s'", r.Header.Get("Accept-Encoding"))
+		if r.Header.Get("Accept-Encoding") != "br,gzip" {
+			t.Errorf("Expected Accept-Encoding to be 'br,gzip', got '%s'", r.Header.Get("Accept-Encoding"))
 		}
 		w.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
While this change might seem petty, making sure that an http(s) request fits in a single packet might have significant positive performance impact.