### PR TITLE
chore: add go:fix inline to deprecated client.New

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,6 +22,8 @@ type Client struct {
 // New returns a new Miniflux client.
 //
 // Deprecated: use NewClient instead.
+//
+//go:fix inline
 func New(endpoint string, credentials ...string) *Client {
 	return NewClient(endpoint, credentials...)
 }


### PR DESCRIPTION
Add a go:fix inline directive to client.New so Go 1.26 can automatically rewrite callers to NewClient().

This keeps the deprecated wrapper in place while making migration easier for library users.
