### PR TITLE
fix: block RFC 6598 shared address space as non-public

### DIFF
--- a/internal/urllib/url.go
+++ b/internal/urllib/url.go
@@ -7,9 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"net/url"
 	"strings"
 )
+
+var rfc6598SharedAddressSpacePrefix = netip.MustParsePrefix("100.64.0.0/10")
 
 // IsRelativePath reports whether the link is a relative path (no scheme, host, or scheme-relative // form).
 func IsRelativePath(link string) bool {
@@ -158,6 +161,10 @@ func JoinBaseURLAndPath(baseURL, path string) (string, error) {
 // link-local, multicast, or unspecified.
 func IsNonPublicIP(ip net.IP) bool {
 	if ip == nil {
+		return true
+	}
+
+	if addr, ok := netip.AddrFromSlice(ip); ok && rfc6598SharedAddressSpacePrefix.Contains(addr.Unmap()) {
 		return true
 	}
 

--- a/internal/urllib/url_test.go
+++ b/internal/urllib/url_test.go
@@ -226,6 +226,7 @@ func TestIsNonPublicIP(t *testing.T) {
 	}{
 		{"nil", "", true},
 		{"private IPv4", "192.168.1.10", true},
+		{"shared address space IPv4", "100.64.0.1", true},
 		{"loopback IPv4", "127.0.0.1", true},
 		{"link-local IPv4", "169.254.42.1", true},
 		{"multicast IPv4", "224.0.0.1", true},


### PR DESCRIPTION
Treat 100.64.0.0/10 as non-public in urllib.IsNonPublicIP.

This closes a gap where RFC 6598 shared address space was not classified as non-public, which could allow outbound requests to CGNAT addresses through code paths that rely on this helper.
