### PR TITLE
fix(cli): bypass logger setup for info and version flags

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -120,6 +120,16 @@ func Parse() {
 		return
 	}
 
+	if flagInfo {
+		info()
+		return
+	}
+
+	if flagVersion {
+		fmt.Println(version.Version)
+		return
+	}
+
 	if flagDebugMode {
 		config.Opts.SetLogLevel("debug")
 	}
@@ -145,16 +155,6 @@ func Parse() {
 
 	if flagHealthCheck != "" {
 		doHealthCheck(flagHealthCheck)
-		return
-	}
-
-	if flagInfo {
-		info()
-		return
-	}
-
-	if flagVersion {
-		fmt.Println(version.Version)
 		return
 	}
 


### PR DESCRIPTION
Return early for `--info` and `--version`.
Avoid failing these read-only commands when log file initialization is broken.
