### PR TITLE
fix(locale): apply Arabic plural rules to ar_SA

### DIFF
--- a/internal/locale/plural.go
+++ b/internal/locale/plural.go
@@ -7,7 +7,7 @@ package locale // import "miniflux.app/v2/internal/locale"
 // And http://www.unicode.org/cldr/charts/29/supplemental/language_plural_rules.html
 func getPluralForm(lang string, n int) int {
 	switch lang {
-	case "ar_AR":
+	case "ar_SA":
 		switch {
 		case n == 0:
 			return 0

--- a/internal/locale/plural_test.go
+++ b/internal/locale/plural_test.go
@@ -14,8 +14,8 @@ func TestPluralRules(t *testing.T) {
 			2: 1, // n > 1
 			5: 1, // n > 1
 		},
-		// Arabic (ar_AR) - 6 forms
-		"ar_AR": {
+		// Arabic (ar_SA) - 6 forms
+		"ar_SA": {
 			0:   0, // n == 0
 			1:   1, // n == 1
 			2:   2, // n == 2

--- a/internal/locale/printer_test.go
+++ b/internal/locale/printer_test.go
@@ -305,7 +305,7 @@ func TestPluralWithIndexOutOfBounds(t *testing.T) {
 
 func TestPluralWithVariousLanguageRules(t *testing.T) {
 	defaultCatalog = catalog{
-		"ar_AR": translationDict{
+		"ar_SA": translationDict{
 			plurals: map[string][]string{
 				"items": {"no items", "one item", "two items", "few items", "many items", "other items"},
 			},
@@ -329,11 +329,11 @@ func TestPluralWithVariousLanguageRules(t *testing.T) {
 		expected string
 	}{
 		// Arabic tests
-		{"ar_AR", "items", 0, "no items"},
-		{"ar_AR", "items", 1, "one item"},
-		{"ar_AR", "items", 2, "two items"},
-		{"ar_AR", "items", 5, "few items"},   // n%100 >= 3 && n%100 <= 10
-		{"ar_AR", "items", 15, "many items"}, // n%100 >= 11
+		{"ar_SA", "items", 0, "no items"},
+		{"ar_SA", "items", 1, "one item"},
+		{"ar_SA", "items", 2, "two items"},
+		{"ar_SA", "items", 5, "few items"},   // n%100 >= 3 && n%100 <= 10
+		{"ar_SA", "items", 15, "many items"}, // n%100 >= 11
 
 		// Polish tests
 		{"pl_PL", "files", 1, "one file"},


### PR DESCRIPTION
The plural-form switch handled Arabic under ar_AR, but the supported locale and translation file use ar_SA.

That mismatch made Arabic requests fall back to the default two-form rule, so plural translations selected the wrong string at runtime.
