### PR TITLE
fix(api): use exact equality for single status and avoid redundant removed exclusion

### DIFF
--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -174,8 +174,13 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 	builder.WithEnclosures()
 
 	switch len(statuses) {
+	// If no status filter is specified, show everything except removed entries.
 	case 0:
 		builder.WithoutStatus(model.EntryStatusRemoved)
+	// Use exact equality for a single status so the query planner can choose a
+	// time-ordered index (published_at, created_at, etc.), avoiding a full sort
+	// on large result sets. ANY($1) with a one-element array causes the planner
+	// to pick a suboptimal index.
 	case 1:
 		builder.WithStatus(statuses[0])
 	default:

--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -182,15 +182,9 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 		}
 	}
 
-	// Use exact equality for a single status so the query planner can choose a
-	// time-ordered index, avoiding a full sort on large result sets.
-	// ANY($1) with a one-element array prevents the planner from doing so.
-	switch len(filtered) {
-	case 0:
+	if len(filtered) == 0 {
 		builder.WithoutStatus(model.EntryStatusRemoved)
-	case 1:
-		builder.WithStatus(filtered[0])
-	default:
+	} else {
 		builder.WithStatuses(filtered)
 	}
 

--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -173,18 +173,25 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 	builder.WithTags(tags)
 	builder.WithEnclosures()
 
-	switch len(statuses) {
-	// If no status filter is specified, show everything except removed entries.
+	// Removed entries have their content cleared; always exclude them
+	// regardless of what the caller requests.
+	filtered := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		if s != model.EntryStatusRemoved {
+			filtered = append(filtered, s)
+		}
+	}
+
+	// Use exact equality for a single status so the query planner can choose a
+	// time-ordered index, avoiding a full sort on large result sets.
+	// ANY($1) with a one-element array prevents the planner from doing so.
+	switch len(filtered) {
 	case 0:
 		builder.WithoutStatus(model.EntryStatusRemoved)
-	// Use exact equality for a single status so the query planner can choose a
-	// time-ordered index (published_at, created_at, etc.), avoiding a full sort
-	// on large result sets. ANY($1) with a one-element array causes the planner
-	// to pick a suboptimal index.
 	case 1:
-		builder.WithStatus(statuses[0])
+		builder.WithStatus(filtered[0])
 	default:
-		builder.WithStatuses(statuses)
+		builder.WithStatuses(filtered)
 	}
 
 	if request.HasQueryParam(r, "globally_visible") {

--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -167,13 +167,20 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 	builder := h.store.NewEntryQueryBuilder(userID)
 	builder.WithFeedID(feedID)
 	builder.WithCategoryID(categoryID)
-	builder.WithStatuses(statuses)
 	builder.WithSorting(order, direction)
 	builder.WithOffset(offset)
 	builder.WithLimit(limit)
 	builder.WithTags(tags)
 	builder.WithEnclosures()
-	builder.WithoutStatus(model.EntryStatusRemoved)
+
+	switch len(statuses) {
+	case 0:
+		builder.WithoutStatus(model.EntryStatusRemoved)
+	case 1:
+		builder.WithStatus(statuses[0])
+	default:
+		builder.WithStatuses(statuses)
+	}
 
 	if request.HasQueryParam(r, "globally_visible") {
 		globallyVisible := request.QueryBoolParam(r, "globally_visible", true)

--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -149,8 +149,15 @@ func (e *EntryQueryBuilder) WithStatus(status string) *EntryQueryBuilder {
 }
 
 // WithStatuses filter by a list of entry statuses.
+// 0 statuses: no-op; 1 status: exact equality; 2+: ANY().
 func (e *EntryQueryBuilder) WithStatuses(statuses []string) *EntryQueryBuilder {
-	if len(statuses) > 0 {
+	switch len(statuses) {
+	case 0:
+		// no-op
+	case 1:
+		e.conditions = append(e.conditions, "e.status = $"+strconv.Itoa(len(e.args)+1))
+		e.args = append(e.args, statuses[0])
+	default:
 		e.conditions = append(e.conditions, fmt.Sprintf("e.status = ANY($%d)", len(e.args)+1))
 		e.args = append(e.args, pq.StringArray(statuses))
 	}


### PR DESCRIPTION
## Problem

`findEntries` unconditionally calls both `WithStatuses(statuses)` and `WithoutStatus(model.EntryStatusRemoved)`, producing redundant SQL like:

```sql
e.status = ANY('{unread}') AND e.status <> 'removed'
```

Two issues with this:
1. When `statuses` is non-empty, `ANY(array)` already implicitly excludes `removed` — the second condition is always a no-op.
2. `ANY($N)` prevents the query planner from inspecting the value at planning time, causing severe row count misestimation and suboptimal index usage on large datasets.

## Fix

Branch on `len(statuses)` instead:

```go
switch len(statuses) {
case 0:
    builder.WithoutStatus(model.EntryStatusRemoved)
case 1:
    builder.WithStatus(statuses[0])
default:
    builder.WithStatuses(statuses)
}
```

Single-value status requests now use exact equality, giving the planner accurate selectivity estimates. The `removed` exclusion is preserved for the no-status case.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
