### PR TITLE
refactor(metric): support graceful shutdown of metrics collector

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -38,9 +38,10 @@ func startDaemon(store *storage.Storage) {
 		httpServers = server.StartWebServer(store, pool)
 	}
 
+	metricsCtx, cancelMetrics := context.WithCancel(context.Background())
 	if config.Opts.HasMetricsCollector() {
 		collector := metric.NewCollector(store, config.Opts.MetricsRefreshInterval())
-		go collector.GatherStorageMetrics()
+		go collector.GatherStorageMetrics(metricsCtx)
 	}
 
 	if systemd.HasNotifySocket() {
@@ -75,6 +76,7 @@ func startDaemon(store *storage.Storage) {
 
 	<-stop
 	slog.Debug("Shutting down the process")
+	cancelMetrics()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -4,6 +4,7 @@
 package metric // import "miniflux.app/v2/internal/metric"
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -162,8 +163,17 @@ func NewCollector(store *storage.Storage, refreshInterval time.Duration) *collec
 }
 
 // GatherStorageMetrics polls the database to fetch metrics.
-func (c *collector) GatherStorageMetrics() {
-	for range time.Tick(c.refreshInterval) {
+func (c *collector) GatherStorageMetrics(ctx context.Context) {
+	ticker := time.NewTicker(c.refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Debug("Stopping metric collector")
+			return
+		case <-ticker.C:
+		}
 		slog.Debug("Collecting metrics from the database")
 
 		usersGauge.Set(float64(c.store.CountUsers()))


### PR DESCRIPTION
Replace time.Tick with time.NewTicker and accept a context.Context so the polling goroutine can be stopped cleanly during shutdown.