### PR TITLE
refactor(metric): replace hardcoded status labels with constants

### DIFF
--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -13,6 +13,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Status label values for histogram metrics.
+const (
+	StatusSuccess = "success"
+	StatusError   = "error"
+)
+
 // Prometheus Metrics.
 var (
 	BackgroundFeedRefreshDuration = prometheus.NewHistogramVec(

--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -119,9 +119,9 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 			}
 
 			if config.Opts.HasMetricsCollector() {
-				status := "success"
+				status := metric.StatusSuccess
 				if scraperErr != nil {
-					status = "error"
+					status = metric.StatusError
 				}
 				metric.ScraperRequestDuration.WithLabelValues(status).Observe(time.Since(startTime).Seconds())
 			}
@@ -199,9 +199,9 @@ func ProcessEntryWebPage(feed *model.Feed, entry *model.Entry, user *model.User)
 	)
 
 	if config.Opts.HasMetricsCollector() {
-		status := "success"
+		status := metric.StatusSuccess
 		if scraperErr != nil {
-			status = "error"
+			status = metric.StatusError
 		}
 		metric.ScraperRequestDuration.WithLabelValues(status).Observe(time.Since(startTime).Seconds())
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -39,9 +39,9 @@ func (w *worker) Run(c <-chan model.Job) {
 		localizedError := feedHandler.RefreshFeed(w.store, job.UserID, job.FeedID, false)
 
 		if config.Opts.HasMetricsCollector() {
-			status := "success"
+			status := metric.StatusSuccess
 			if localizedError != nil {
-				status = "error"
+				status = metric.StatusError
 			}
 			metric.BackgroundFeedRefreshDuration.WithLabelValues(status).Observe(time.Since(startTime).Seconds())
 		}


### PR DESCRIPTION
Export StatusSuccess and StatusError constants from the metric package to prevent typos and improve grep-ability across call sites.
