### PR TITLE
refactor(timezone): simplify AvailableTimezones and fix test typos

### DIFF
--- a/internal/timezone/timezone.go
+++ b/internal/timezone/timezone.go
@@ -521,11 +521,5 @@ func IsValid(timezone string) bool {
 
 // AvailableTimezones returns an iterator over supported timezone names.
 func AvailableTimezones() iter.Seq[string] {
-	return func(yield func(string) bool) {
-		for _, tz := range timezones {
-			if !yield(tz) {
-				return
-			}
-		}
-	}
+	return slices.Values(timezones)
 }

--- a/internal/timezone/timezone_test.go
+++ b/internal/timezone/timezone_test.go
@@ -100,7 +100,7 @@ func TestIsValid(t *testing.T) {
 
 	for _, tz := range validTZ {
 		if !IsValid(tz) {
-			t.Fatalf(`Timezone %q should be valid an it's not`, tz)
+			t.Fatalf(`Timezone %q should be valid and it's not`, tz)
 		}
 	}
 
@@ -111,7 +111,7 @@ func TestIsValid(t *testing.T) {
 
 	for _, tz := range invalidTZ {
 		if IsValid(tz) {
-			t.Fatalf(`Timezone %q should be invalid an it's not`, tz)
+			t.Fatalf(`Timezone %q should be invalid and it's not`, tz)
 		}
 	}
 }


### PR DESCRIPTION
Replace hand-rolled iterator with slices.Values and correct "an it's not" to "and it's not" in test error messages.
