### PR TITLE
ci(workflows): add consistent repository_owner guards

### DIFF
--- a/.github/workflows/debian_packages.yml
+++ b/.github/workflows/debian_packages.yml
@@ -13,7 +13,7 @@ on:
       - 'packaging/debian/**' # Only run on changes to the debian packaging files
 jobs:
   test-packages:
-    if: (github.event_name == 'schedule' && github.repository_owner == 'miniflux' )
+    if: (github.event_name == 'schedule' && github.repository_owner == 'miniflux')
       || github.event_name == 'pull_request'
     name: Test Packages
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
         if-no-files-found: error
         retention-days: 3
   publish-packages:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner == 'miniflux'
     name: Publish Packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rpm_packages.yml
+++ b/.github/workflows/rpm_packages.yml
@@ -14,7 +14,8 @@ on:
       - '.github/workflows/rpm_packages.yml'
 jobs:
   test-package:
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request'
+    if: (github.event_name == 'schedule' && github.repository_owner == 'miniflux')
+      || github.event_name == 'pull_request'
     name: Test Packages
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +44,7 @@ jobs:
         if-no-files-found: error
         retention-days: 3
   publish-package:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner == 'miniflux'
     name: Publish Packages
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add missing owner checks to prevent forks from running scheduled and publish jobs unnecessarily.
