### PR TITLE
fix(oauth2): clear state and code verifier from session after use

### DIFF
--- a/internal/ui/oauth2_callback.go
+++ b/internal/ui/oauth2_callback.go
@@ -63,8 +63,11 @@ func (h *handler) oauth2Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	printer := locale.NewPrinter(request.UserLanguage(r))
 	sess := session.New(h.store, request.SessionID(r))
+	sess.SetOAuth2State("")
+	sess.SetOAuth2CodeVerifier("")
+
+	printer := locale.NewPrinter(request.UserLanguage(r))
 
 	if request.IsAuthenticated(r) {
 		loggedUser, err := h.store.UserByID(request.UserID(r))


### PR DESCRIPTION
Prevents replay of the one-time-use PKCE code verifier and CSRF state values by clearing them from the app session immediately after the OAuth2 callback consumes them.