### PR TITLE
perf(storage): factorize away a query

### DIFF
--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -245,6 +245,9 @@ func (s *Storage) getEntryIDByHash(tx *sql.Tx, feedID int64, entryHash string) (
 		entryHash,
 	).Scan(&entryID)
 
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
 	if err != nil {
 		return 0, fmt.Errorf(`store: unable to fetch entry ID: %v`, err)
 	}
@@ -264,16 +267,13 @@ func (s *Storage) InsertEntryForFeed(userID, feedID int64, entry *model.Entry) (
 	}
 	defer tx.Rollback()
 
-	exists, err := s.entryExists(tx, entry)
+	entryID, err := s.getEntryIDByHash(tx, entry.FeedID, entry.Hash)
 	if err != nil {
 		return false, err
 	}
+	alreadyExistingEntry := entryID > 0
 
-	if exists {
-		entryID, err := s.getEntryIDByHash(tx, entry.FeedID, entry.Hash)
-		if err != nil {
-			return false, err
-		}
+	if alreadyExistingEntry {
 		entry.ID = entryID
 	} else {
 		if err := s.createEntry(tx, entry); err != nil {
@@ -285,7 +285,7 @@ func (s *Storage) InsertEntryForFeed(userID, feedID int64, entry *model.Entry) (
 		return false, err
 	}
 
-	return !exists, nil
+	return !alreadyExistingEntry, nil
 }
 
 func (s *Storage) IsNewEntry(feedID int64, entryHash string) bool {


### PR DESCRIPTION
In InsertEntryForFeed, there is no need to check if an entry exists and then get its hash. Instead, try to get its hash, and consider the ErrNoRows error as an existence check.