### PR TITLE
fix(oauth2): scope OIDC client secret warning to OIDC configuration

### DIFF
--- a/internal/oauth2/manager.go
+++ b/internal/oauth2/manager.go
@@ -30,6 +30,10 @@ func NewManager(ctx context.Context, clientID, clientSecret, redirectURL, oidcDi
 	m.AddProvider("google", NewGoogleProvider(clientID, clientSecret, redirectURL))
 
 	if oidcDiscoveryEndpoint != "" {
+		if clientSecret == "" {
+			slog.Warn("OIDC client secret is empty or missing.")
+		}
+
 		if genericOidcProvider, err := NewOidcProvider(ctx, clientID, clientSecret, redirectURL, oidcDiscoveryEndpoint); err != nil {
 			slog.Error("Failed to initialize OIDC provider",
 				slog.Any("error", err),
@@ -37,10 +41,6 @@ func NewManager(ctx context.Context, clientID, clientSecret, redirectURL, oidcDi
 		} else {
 			m.AddProvider("oidc", genericOidcProvider)
 		}
-	}
-
-	if clientSecret == "" {
-		slog.Warn("OIDC client secret is empty or missing.")
 	}
 
 	return m


### PR DESCRIPTION
The warning was firing even when only Google OAuth was configured and no OIDC discovery endpoint was set.
