### PR TITLE
refactor(oauth2): make Google and OIDC providers mutually exclusive

### DIFF
--- a/internal/oauth2/google.go
+++ b/internal/oauth2/google.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"miniflux.app/v2/internal/model"
 
@@ -66,7 +67,7 @@ func (g *googleProvider) GetProfile(ctx context.Context, code, codeVerifier stri
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("google: unexpected status code %d from userinfo endpoint", resp.StatusCode)
 	}
 

--- a/internal/oauth2/manager.go
+++ b/internal/oauth2/manager.go
@@ -27,7 +27,6 @@ func (m *Manager) AddProvider(name string, provider Provider) {
 
 func NewManager(ctx context.Context, clientID, clientSecret, redirectURL, oidcDiscoveryEndpoint string) *Manager {
 	m := &Manager{providers: make(map[string]Provider)}
-	m.AddProvider("google", NewGoogleProvider(clientID, clientSecret, redirectURL))
 
 	if oidcDiscoveryEndpoint != "" {
 		if clientSecret == "" {
@@ -41,6 +40,8 @@ func NewManager(ctx context.Context, clientID, clientSecret, redirectURL, oidcDi
 		} else {
 			m.AddProvider("oidc", genericOidcProvider)
 		}
+	} else {
+		m.AddProvider("google", NewGoogleProvider(clientID, clientSecret, redirectURL))
 	}
 
 	return m


### PR DESCRIPTION
Register either the OIDC provider when a discovery endpoint is configured, or the Google provider otherwise, but never both. Also scope the empty client secret warning to OIDC configuration.
