### PR TITLE
perf(storage): extract a query from a cursor lock

### DIFF
--- a/internal/storage/feed_query_builder.go
+++ b/internal/storage/feed_query_builder.go
@@ -194,16 +194,16 @@ func (f *feedQueryBuilder) GetFeeds() (model.Feeds, error) {
 
 	query = fmt.Sprintf(query, f.buildCondition(), f.buildSorting())
 
+	readCounters, unreadCounters, err := f.fetchFeedCounter()
+	if err != nil {
+		return nil, err
+	}
+
 	rows, err := f.store.db.Query(query, f.args...)
 	if err != nil {
 		return nil, fmt.Errorf(`store: unable to fetch feeds: %w`, err)
 	}
 	defer rows.Close()
-
-	readCounters, unreadCounters, err := f.fetchFeedCounter()
-	if err != nil {
-		return nil, err
-	}
 
 	feeds := make(model.Feeds, 0)
 	for rows.Next() {


### PR DESCRIPTION
The fetchFeedCounter query should happen before the the db.Query call, so that a single database connection can be (re)used, instead of using a second one.