### PR TITLE
perf(ui): don't ask postgres for entries content if we're not using it

### DIFF
--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -25,11 +25,20 @@ type EntryQueryBuilder struct {
 	limit           int
 	offset          int
 	fetchEnclosures bool
+	excludeContent  bool
 }
 
 // WithEnclosures fetches enclosures for each entry.
 func (e *EntryQueryBuilder) WithEnclosures() *EntryQueryBuilder {
 	e.fetchEnclosures = true
+	return e
+}
+
+// WithoutContent excludes the content column from the query results,
+// replacing it with an empty string. This significantly reduces data
+// transfer from PostgreSQL on list pages where content is not displayed.
+func (e *EntryQueryBuilder) WithoutContent() *EntryQueryBuilder {
+	e.excludeContent = true
 	return e
 }
 
@@ -298,7 +307,7 @@ func (e *EntryQueryBuilder) fetchEntries(withCount bool) (model.Entries, int, er
 			e.comments_url,
 			e.author,
 			e.share_code,
-			e.content,
+			` + e.contentColumn() + `,
 			e.status,
 			e.starred,
 			e.reading_time,
@@ -477,6 +486,13 @@ func (e *EntryQueryBuilder) GetEntryIDs() ([]int64, error) {
 	}
 
 	return entryIDs, nil
+}
+
+func (e *EntryQueryBuilder) contentColumn() string {
+	if e.excludeContent {
+		return "'' AS content"
+	}
+	return "e.content"
 }
 
 func (e *EntryQueryBuilder) buildCondition() string {

--- a/internal/ui/category_entries.go
+++ b/internal/ui/category_entries.go
@@ -38,6 +38,7 @@ func (h *handler) showCategoryEntriesPage(w http.ResponseWriter, r *http.Request
 	builder.WithSorting(user.EntryOrder, user.EntryDirection)
 	builder.WithSorting("id", user.EntryDirection)
 	builder.WithStatus(model.EntryStatusUnread)
+	builder.WithoutContent()
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/category_entries_all.go
+++ b/internal/ui/category_entries_all.go
@@ -38,6 +38,7 @@ func (h *handler) showCategoryEntriesAllPage(w http.ResponseWriter, r *http.Requ
 	builder.WithSorting(user.EntryOrder, user.EntryDirection)
 	builder.WithSorting("id", user.EntryDirection)
 	builder.WithoutStatus(model.EntryStatusRemoved)
+	builder.WithoutContent()
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/category_entries_starred.go
+++ b/internal/ui/category_entries_starred.go
@@ -39,6 +39,7 @@ func (h *handler) showCategoryEntriesStarredPage(w http.ResponseWriter, r *http.
 	builder.WithSorting("id", user.EntryDirection)
 	builder.WithoutStatus(model.EntryStatusRemoved)
 	builder.WithStarred(true)
+	builder.WithoutContent()
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/feed_entries.go
+++ b/internal/ui/feed_entries.go
@@ -40,6 +40,7 @@ func (h *handler) showFeedEntriesPage(w http.ResponseWriter, r *http.Request) {
 	builder.WithSorting("id", user.EntryDirection)
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
+	builder.WithoutContent()
 
 	entries, count, err := builder.GetEntriesWithCount()
 	if err != nil {

--- a/internal/ui/feed_entries_all.go
+++ b/internal/ui/feed_entries_all.go
@@ -38,6 +38,7 @@ func (h *handler) showFeedEntriesAllPage(w http.ResponseWriter, r *http.Request)
 	builder.WithoutStatus(model.EntryStatusRemoved)
 	builder.WithSorting(user.EntryOrder, user.EntryDirection)
 	builder.WithSorting("id", user.EntryDirection)
+	builder.WithoutContent()
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/history_entries.go
+++ b/internal/ui/history_entries.go
@@ -25,6 +25,7 @@ func (h *handler) showHistoryPage(w http.ResponseWriter, r *http.Request) {
 	builder.WithStatus(model.EntryStatusRead)
 	builder.WithSorting("changed_at", "DESC")
 	builder.WithSorting("published_at", "DESC")
+	builder.WithoutContent()
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -34,6 +34,7 @@ func (h *handler) showSearchPage(w http.ResponseWriter, r *http.Request) {
 			builder.WithStatus(model.EntryStatusUnread)
 		}
 		builder.WithoutStatus(model.EntryStatusRemoved)
+		builder.WithoutContent()
 		builder.WithOffset(offset)
 		builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/shared_entries.go
+++ b/internal/ui/shared_entries.go
@@ -26,6 +26,7 @@ func (h *handler) sharedEntries(w http.ResponseWriter, r *http.Request) {
 	builder.WithSorting("id", user.EntryDirection)
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
+	builder.WithoutContent()
 
 	entries, count, err := builder.GetEntriesWithCount()
 	if err != nil {

--- a/internal/ui/starred_entries.go
+++ b/internal/ui/starred_entries.go
@@ -28,6 +28,7 @@ func (h *handler) showStarredPage(w http.ResponseWriter, r *http.Request) {
 	builder.WithSorting("id", user.EntryDirection)
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
+	builder.WithoutContent()
 
 	entries, count, err := builder.GetEntriesWithCount()
 	if err != nil {

--- a/internal/ui/tag_entries_all.go
+++ b/internal/ui/tag_entries_all.go
@@ -34,6 +34,7 @@ func (h *handler) showTagEntriesAllPage(w http.ResponseWriter, r *http.Request) 
 	builder.WithSorting("status", "asc")
 	builder.WithSorting(user.EntryOrder, user.EntryDirection)
 	builder.WithSorting("id", user.EntryDirection)
+	builder.WithoutContent()
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 

--- a/internal/ui/unread_entries.go
+++ b/internal/ui/unread_entries.go
@@ -28,6 +28,7 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 	builder.WithOffset(offset)
 	builder.WithLimit(user.EntriesPerPage)
 	builder.WithGloballyVisible()
+	builder.WithoutContent()
 
 	entries, countUnread, err := builder.GetEntriesWithCount()
 	if err != nil {
@@ -43,6 +44,7 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 		builder.WithSorting("id", user.EntryDirection)
 		builder.WithLimit(user.EntriesPerPage)
 		builder.WithGloballyVisible()
+		builder.WithoutContent()
 
 		entries, countUnread, err = builder.GetEntriesWithCount()
 		if err != nil {


### PR DESCRIPTION
No need for postgresql to look up and send our way entries content if we're not going to make use of it in the first place.