### PR TITLE
perf(ui): add `immutable` to Cache-Control

### DIFF
--- a/internal/http/response/builder.go
+++ b/internal/http/response/builder.go
@@ -78,7 +78,7 @@ func (b *Builder) WithoutCompression() *Builder {
 func (b *Builder) WithCaching(etag string, duration time.Duration, callback func(*Builder)) {
 	etag = normalizeETag(etag)
 	b.headers["ETag"] = etag
-	b.headers["Cache-Control"] = "public"
+	b.headers["Cache-Control"] = "public, immutable"
 	b.headers["Expires"] = time.Now().Add(duration).UTC().Format(http.TimeFormat)
 
 	if ifNoneMatch(b.r.Header.Get("If-None-Match"), etag) {

--- a/internal/http/response/builder_test.go
+++ b/internal/http/response/builder_test.go
@@ -155,7 +155,7 @@ func TestBuildResponseWithCachingEnabled(t *testing.T) {
 		t.Fatalf(`Unexpected body, got %s instead of %s`, actualBody, expectedBody)
 	}
 
-	expectedHeader := "public"
+	expectedHeader := "public, immutable"
 	actualHeader := resp.Header.Get("Cache-Control")
 	if actualHeader != expectedHeader {
 		t.Fatalf(`Unexpected cache control header, got %q instead of %q`, actualHeader, expectedHeader)
@@ -212,7 +212,7 @@ func TestBuildResponseWithCachingAndIfNoneMatch(t *testing.T) {
 				t.Fatalf(`Unexpected body, got %q instead of %q`, actual, tt.expectedBody)
 			}
 
-			if resp.Header.Get("Cache-Control") != "public" {
+			if resp.Header.Get("Cache-Control") != "public, immutable" {
 				t.Fatalf(`Unexpected Cache-Control header: %q`, resp.Header.Get("Cache-Control"))
 			}
 


### PR DESCRIPTION
The immutable response directive indicates that the response will not be updated while it's fresh, saving an http query.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control