### PR TITLE
refactor(oauth2): select provider explicitly by OAUTH2_PROVIDER value

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,10 +92,8 @@ func Parse() {
 		printErrorAndExit(err)
 	}
 
-	if oauth2Provider := config.Opts.OAuth2Provider(); oauth2Provider != "" {
-		if oauth2Provider != "oidc" && oauth2Provider != "google" {
-			printErrorAndExit(fmt.Errorf(`unsupported OAuth2 provider: %q (Possible values are "google" or "oidc")`, oauth2Provider))
-		}
+	if config.Opts.OAuth2Provider() == "oidc" && config.Opts.OAuth2OIDCDiscoveryEndpoint() == "" {
+		printErrorAndExit(errors.New("OAUTH2_OIDC_DISCOVERY_ENDPOINT must be configured when using the OIDC provider"))
 	}
 
 	if config.Opts.DisableLocalAuth() {

--- a/internal/oauth2/manager.go
+++ b/internal/oauth2/manager.go
@@ -29,25 +29,30 @@ func (m *Manager) AddProvider(name string, provider Provider) {
 	m.providers[name] = provider
 }
 
-// NewManager creates a Manager and registers either an OIDC provider (if a discovery
-// endpoint is provided) or a Google provider as the default.
-func NewManager(ctx context.Context, clientID, clientSecret, redirectURL, oidcDiscoveryEndpoint string) *Manager {
+// NewManager creates a Manager and registers the specified OAuth2 provider.
+// The provider argument must be "oidc" or "google".
+func NewManager(ctx context.Context, provider, clientID, clientSecret, redirectURL, oidcDiscoveryEndpoint string) *Manager {
 	m := &Manager{providers: make(map[string]Provider)}
 
-	if oidcDiscoveryEndpoint != "" {
+	switch provider {
+	case "oidc":
 		if clientSecret == "" {
 			slog.Warn("OIDC client secret is empty or missing.")
 		}
 
-		if genericOidcProvider, err := NewOidcProvider(ctx, clientID, clientSecret, redirectURL, oidcDiscoveryEndpoint); err != nil {
+		if oidcProvider, err := NewOidcProvider(ctx, clientID, clientSecret, redirectURL, oidcDiscoveryEndpoint); err != nil {
 			slog.Error("Failed to initialize OIDC provider",
 				slog.Any("error", err),
 			)
 		} else {
-			m.AddProvider("oidc", genericOidcProvider)
+			m.AddProvider("oidc", oidcProvider)
 		}
-	} else {
+	case "google":
 		m.AddProvider("google", NewGoogleProvider(clientID, clientSecret, redirectURL))
+	default:
+		slog.Error("Unsupported OAuth2 provider",
+			slog.String("provider", provider),
+		)
 	}
 
 	return m

--- a/internal/ui/oauth2.go
+++ b/internal/ui/oauth2.go
@@ -13,6 +13,7 @@ import (
 func getOAuth2Manager(ctx context.Context) *oauth2.Manager {
 	return oauth2.NewManager(
 		ctx,
+		config.Opts.OAuth2Provider(),
 		config.Opts.OAuth2ClientID(),
 		config.Opts.OAuth2ClientSecret(),
 		config.Opts.OAuth2RedirectURL(),


### PR DESCRIPTION
NewManager now dispatches on the configured provider name instead of inferring it from the presence of a discovery endpoint. The CLI validates that OAUTH2_OIDC_DISCOVERY_ENDPOINT is set when the OIDC provider is selected.