### PR TITLE
fix(ui): redirect to category feeds page after marking feed as read

### DIFF
--- a/internal/template/templates/common/feed_list.html
+++ b/internal/template/templates/common/feed_list.html
@@ -83,7 +83,11 @@
                             data-label-yes="{{ t "confirm.yes" }}"
                             data-label-no="{{ t "confirm.no" }}"
                             data-label-loading="{{ t "confirm.loading" }}"
-                            data-url="{{ routePath "/feed/%d/mark-all-as-read" .ID }}">
+                            {{ if $.categoryID }}
+                            data-url="{{ routePath "/category/%d/feed/%d/mark-all-as-read" $.categoryID .ID }}"
+                        {{ else }}
+                            data-url="{{ routePath "/feed/%d/mark-all-as-read" .ID }}"
+                        {{ end }}>
                                 {{ icon "read" }}<span class="icon-label">{{ t "menu.mark_all_as_read" }}</span>
                         </button>
                     </li>

--- a/internal/ui/category_mark_feed_as_read.go
+++ b/internal/ui/category_mark_feed_as_read.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ui // import "miniflux.app/v2/internal/ui"
+
+import (
+	"net/http"
+
+	"miniflux.app/v2/internal/http/request"
+	"miniflux.app/v2/internal/http/response"
+)
+
+func (h *handler) markCategoryFeedAsRead(w http.ResponseWriter, r *http.Request) {
+	feedID := request.RouteInt64Param(r, "feedID")
+	categoryID := request.RouteInt64Param(r, "categoryID")
+	userID := request.UserID(r)
+
+	if !h.store.CategoryFeedExists(userID, categoryID, feedID) {
+		response.HTMLNotFound(w, r)
+		return
+	}
+
+	checkedAt, err := h.store.CheckedAt(userID, feedID)
+	if err != nil {
+		response.HTMLNotFound(w, r)
+		return
+	}
+
+	if err = h.store.MarkFeedAsRead(userID, feedID, checkedAt); err != nil {
+		response.HTMLServerError(w, r, err)
+		return
+	}
+
+	response.HTMLRedirect(w, r, h.routePath("/category/%d/feeds", categoryID))
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -82,6 +82,7 @@ func Serve(store *storage.Storage, pool *worker.Pool) http.Handler {
 	mux.HandleFunc("POST /category/save", handler.saveCategory)
 	mux.HandleFunc("GET /category/{categoryID}/feeds", handler.showCategoryFeedsPage)
 	mux.HandleFunc("POST /category/{categoryID}/feed/{feedID}/remove", handler.removeCategoryFeed)
+	mux.HandleFunc("POST /category/{categoryID}/feed/{feedID}/mark-all-as-read", handler.markCategoryFeedAsRead)
 	mux.HandleFunc("GET /category/{categoryID}/feeds/refresh", handler.refreshCategoryFeedsPage)
 	mux.HandleFunc("GET /category/{categoryID}/entries", handler.showCategoryEntriesPage)
 	mux.HandleFunc("GET /category/{categoryID}/entries/refresh", handler.refreshCategoryEntriesPage)


### PR DESCRIPTION
When marking a feed as read from the category feeds page (/category/n/feeds), the redirect now returns to the same category feeds page instead of the global /feeds page.
