### PR TITLE
fix(ui): remove sensitive values from log messages

### DIFF
--- a/internal/ui/middleware.go
+++ b/internal/ui/middleware.go
@@ -106,8 +106,6 @@ func (m *middleware) handleAppSession(next http.Handler) http.Handler {
 			if !crypto.ConstantTimeCmp(session.Data.CSRF, formValue) && !crypto.ConstantTimeCmp(session.Data.CSRF, headerValue) {
 				slog.Warn("Invalid or missing CSRF token",
 					slog.String("url", r.RequestURI),
-					slog.String("form_csrf", formValue),
-					slog.String("header_csrf", headerValue),
 				)
 
 				if r.URL.Path == "/login" {
@@ -144,7 +142,6 @@ func (m *middleware) getAppSessionValueFromCookie(r *http.Request) *model.Sessio
 	session, err := m.store.AppSession(cookieValue)
 	if err != nil {
 		slog.Debug("Unable to fetch app session from the database; another session will be created",
-			slog.String("cookie_value", cookieValue),
 			slog.Any("error", err),
 		)
 		return nil
@@ -189,7 +186,6 @@ func (m *middleware) getUserSessionFromCookie(r *http.Request) *model.UserSessio
 	session, err := m.store.UserSessionByToken(cookieValue)
 	if err != nil {
 		slog.Error("Unable to fetch user session from the database",
-			slog.String("cookie_value", cookieValue),
 			slog.Any("error", err),
 		)
 		return nil

--- a/internal/ui/oauth2_callback.go
+++ b/internal/ui/oauth2_callback.go
@@ -35,10 +35,7 @@ func (h *handler) oauth2Callback(w http.ResponseWriter, r *http.Request) {
 
 	state := request.QueryStringParam(r, "state", "")
 	if subtle.ConstantTimeCompare([]byte(state), []byte(request.OAuth2State(r))) == 0 {
-		slog.Warn("Invalid OAuth2 state value received",
-			slog.String("expected", request.OAuth2State(r)),
-			slog.String("received", state),
-		)
+		slog.Warn("Invalid OAuth2 state value received")
 		response.HTMLRedirect(w, r, h.routePath("/"))
 		return
 	}


### PR DESCRIPTION
Stop logging CSRF tokens, OAuth2 state values, and session cookie values to avoid leaking secrets into application logs.
