### PR TITLE
Docker basic.yml: added `restart: always` to db definition

### DIFF
--- a/contrib/docker-compose/basic.yml
+++ b/contrib/docker-compose/basic.yml
@@ -21,6 +21,7 @@ services:
   db:
     image: postgres:latest
     container_name: postgres
+    restart: always
     environment:
       - POSTGRES_USER=miniflux
       - POSTGRES_PASSWORD=secret


### PR DESCRIPTION
After restarting my server, Miniflux wouldn't load. It's the same problem described in #1816. 
The solution, as suggested in one of the comments, was to add `restart: always` to the `db` service definition.

`unless-stopped` would also be fine, but since the `miniflux` service already has `always`, I kept it coherent.

Sorry for any mistakes, it's my first PR here :) 