### PR TITLE
Add WebPush support (fix #337)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module miniflux.app/v2
 // +heroku goVersion go1.26
 
 require (
+	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/andybalholm/brotli v1.2.1
 	github.com/coreos/go-oidc/v3 v3.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
+github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
+github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -23,6 +25,7 @@ github.com/go-webauthn/webauthn v0.16.3 h1:RorP0c6VbaKP0i0Jxf/vAf7EFb2lmdLW8GLKI
 github.com/go-webauthn/webauthn v0.16.3/go.mod h1:R2xjJxSPat5PYKg5r6cUmqXgbHtbv4GmF6uGkqFMLNI=
 github.com/go-webauthn/x v0.2.2 h1:zIiipvMbr48CXi5RG0XdBJR94kd8I5LfzHPb/q+YYmk=
 github.com/go-webauthn/x v0.2.2/go.mod h1:IpJ5qyWB9NRhLX3C7gIfjTU7RZLXEP6kzFkoVSE7Fz4=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -89,6 +89,12 @@ func NewConfigOptions() *configOptions {
 				valueType:         secretFileType,
 				targetKey:         "ADMIN_USERNAME",
 			},
+			"ADMIN_EMAIL": {
+				parsedStringValue: "",
+				rawValue:          "",
+				valueType:         stringType,
+				targetKey:         "ADMIN_EMAIL",
+			},
 			"AUTH_PROXY_HEADER": {
 				parsedStringValue: "",
 				rawValue:          "",
@@ -614,6 +620,10 @@ func (c *configOptions) AdminPassword() string {
 
 func (c *configOptions) AdminUsername() string {
 	return c.options["ADMIN_USERNAME"].parsedStringValue
+}
+
+func (c *configOptions) AdminEmail() string {
+	return c.options["ADMIN_EMAIL"].parsedStringValue
 }
 
 func (c *configOptions) AuthProxyHeader() string {

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -119,20 +119,6 @@ var migrations = [...]func(tx *sql.Tx) error{
 				foreign key (icon_id) references icons(id) on delete cascade
 			);
 
-			CREATE TABLE webpush_subscriptions (
-				id BIGSERIAL,
-				user_id int not null,
-				endpoint text not null,
-				auth text,
-				p256dh text,
-				foreign key (user_id) references users(id) on delete cascade,
-				primary key (id)
-			);
-
-			CREATE TABLE vapid_key (
-				private_key text not null,
-				public_key text not null
-			);
 		`
 		_, err = tx.Exec(sql)
 		return err
@@ -1444,6 +1430,25 @@ var migrations = [...]func(tx *sql.Tx) error{
 	},
 	func(tx *sql.Tx) (err error) {
 		_, err = tx.Exec(`ALTER TABLE feeds ADD COLUMN ignore_entry_updates bool default 'f'`)
+		return err
+	},
+	func(tx *sql.Tx) (err error) {
+		_, err = tx.Exec(`
+			CREATE TABLE webpush_subscriptions (
+				id BIGSERIAL,
+				user_id int not null,
+				endpoint text not null,
+				auth text,
+				p256dh text,
+				foreign key (user_id) references users(id) on delete cascade,
+				primary key (id)
+			);
+
+			CREATE TABLE vapid_key (
+				private_key text not null,
+				public_key text not null
+			);
+		`)
 		return err
 	},
 }

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -6,6 +6,7 @@ package database // import "miniflux.app/v2/internal/database"
 import (
 	"database/sql"
 
+	"github.com/SherClockHolmes/webpush-go"
 	"miniflux.app/v2/internal/crypto"
 )
 
@@ -1449,6 +1450,14 @@ var migrations = [...]func(tx *sql.Tx) error{
 				public_key text not null
 			);
 		`)
+		if err != nil {
+			return err
+		}
+		privateKey, publicKey, err := webpush.GenerateVAPIDKeys()
+		_, err = tx.Exec(`
+			INSERT INTO vapid_key (private_key, public_key)
+			VALUES ($1, $2) `,
+			privateKey, publicKey)
 		return err
 	},
 }

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1436,13 +1436,12 @@ var migrations = [...]func(tx *sql.Tx) error{
 	func(tx *sql.Tx) (err error) {
 		_, err = tx.Exec(`
 			CREATE TABLE webpush_subscriptions (
-				id BIGSERIAL,
 				user_id int not null,
 				endpoint text not null,
 				auth text,
 				p256dh text,
 				foreign key (user_id) references users(id) on delete cascade,
-				primary key (id)
+				primary key (endpoint)
 			);
 
 			CREATE TABLE vapid_key (

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1440,6 +1440,7 @@ var migrations = [...]func(tx *sql.Tx) error{
 				endpoint text not null,
 				auth text,
 				p256dh text,
+				authscheme text,
 				foreign key (user_id) references users(id) on delete cascade,
 				primary key (endpoint)
 			);

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -118,6 +118,16 @@ var migrations = [...]func(tx *sql.Tx) error{
 				foreign key (feed_id) references feeds(id) on delete cascade,
 				foreign key (icon_id) references icons(id) on delete cascade
 			);
+
+			CREATE TABLE webpush_subscriptions (
+				id BIGSERIAL,
+				user_id int not null,
+				endpoint text not null,
+				auth text,
+				p256dh text,
+				foreign key (user_id) references users(id) on delete cascade,
+				primary key (id)
+			);
 		`
 		_, err = tx.Exec(sql)
 		return err

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -128,6 +128,11 @@ var migrations = [...]func(tx *sql.Tx) error{
 				foreign key (user_id) references users(id) on delete cascade,
 				primary key (id)
 			);
+
+			CREATE TABLE vapid_key (
+				private_key text not null,
+				public_key text not null
+			);
 		`
 		_, err = tx.Exec(sql)
 		return err

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1454,6 +1454,9 @@ var migrations = [...]func(tx *sql.Tx) error{
 			return err
 		}
 		privateKey, publicKey, err := webpush.GenerateVAPIDKeys()
+		if err != nil {
+			return err
+		}
 		_, err = tx.Exec(`
 			INSERT INTO vapid_key (private_key, public_key)
 			VALUES ($1, $2) `,

--- a/internal/http/server/routes.go
+++ b/internal/http/server/routes.go
@@ -65,7 +65,6 @@ func newRouter(store *storage.Storage, pool *worker.Pool) http.Handler {
 	rootMux.HandleFunc("/healthz", livenessProbe)
 	rootMux.HandleFunc("/readiness", readinessProbe)
 	rootMux.HandleFunc("/readyz", readinessProbe)
-	
 
 	basePath := config.Opts.BasePath()
 	if basePath != "" {

--- a/internal/http/server/routes.go
+++ b/internal/http/server/routes.go
@@ -42,6 +42,9 @@ func newRouter(store *storage.Storage, pool *worker.Pool) http.Handler {
 		appMux.Handle("GET /metrics", metricsHandler())
 	}
 
+	// Make the public VAPID key accessible
+	appMux.Handle("/vapid", newVAPIDProbe(store))
+
 	// UI routing (catch-all).
 	appMux.Handle("/", ui.Serve(store, pool))
 
@@ -62,6 +65,7 @@ func newRouter(store *storage.Storage, pool *worker.Pool) http.Handler {
 	rootMux.HandleFunc("/healthz", livenessProbe)
 	rootMux.HandleFunc("/readiness", readinessProbe)
 	rootMux.HandleFunc("/readyz", readinessProbe)
+	
 
 	basePath := config.Opts.BasePath()
 	if basePath != "" {

--- a/internal/http/server/vapid.go
+++ b/internal/http/server/vapid.go
@@ -12,7 +12,6 @@ import (
 
 func newVAPIDProbe(store *storage.Storage) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		_, publicKey, err := store.GetVAPIDKeys()
 
 		if err != nil {

--- a/internal/http/server/vapid.go
+++ b/internal/http/server/vapid.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server // import "miniflux.app/v2/internal/http/server"
+
+import (
+	"fmt"
+	"net/http"
+
+	"miniflux.app/v2/internal/storage"
+)
+
+func newVAPIDProbe(store *storage.Storage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		_, publicKey, err := store.GetVAPIDKeys()
+
+		if err != nil {
+			http.Error(w, fmt.Sprintf("VAPID public key not found. Error: %q", err), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(publicKey))
+	}
+}

--- a/internal/model/webpush.go
+++ b/internal/model/webpush.go
@@ -4,7 +4,7 @@
 package model // import "miniflux.app/v2/internal/model"
 
 // A request to subscribe to a new webpush
-type WebPushSubscriptionRequest struct {
+type WebPushSubscription struct {
 	Endpoint string `json:"endpoint"`
 	Key      string `json:"key"`
 	Auth     string `json:"auth"`

--- a/internal/model/webpush.go
+++ b/internal/model/webpush.go
@@ -5,9 +5,10 @@ package model // import "miniflux.app/v2/internal/model"
 
 // A request to subscribe to a new webpush
 type WebPushSubscription struct {
-	Endpoint string `json:"endpoint"`
-	Key      string `json:"key"`
-	Auth     string `json:"auth"`
+	Endpoint   string `json:"endpoint"`
+	Key        string `json:"key"`
+	Auth       string `json:"auth"`
+	AuthScheme string `json:"authscheme"`
 }
 
 type Notification struct {

--- a/internal/model/webpush.go
+++ b/internal/model/webpush.go
@@ -11,6 +11,7 @@ type WebPushSubscription struct {
 }
 
 type Notification struct {
-	FeedTitle 		string `json:"feed_title"`
-	EntryTitle 		string `json:"entry_content"`
+	FeedTitle    string `json:"feed_title"`
+	EntryTitle   string `json:"entry_title"`
+	EntryContent string `json:"entry_content"`
 }

--- a/internal/model/webpush.go
+++ b/internal/model/webpush.go
@@ -9,3 +9,8 @@ type WebPushSubscription struct {
 	Key      string `json:"key"`
 	Auth     string `json:"auth"`
 }
+
+type Notification struct {
+	FeedTitle 		string `json:"feed_title"`
+	EntryTitle 		string `json:"entry_content"`
+}

--- a/internal/model/webpush.go
+++ b/internal/model/webpush.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model // import "miniflux.app/v2/internal/model"
+
+// A request to subscribe to a new webpush
+type WebPushSubscriptionRequest struct {
+	Endpoint string `json:"endpoint"`
+	Key      string `json:"key"`
+	Auth     string `json:"auth"`
+}

--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -179,7 +179,7 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 				EntryTitle:   entry.Title,
 				EntryContent: strings.TrimSpace(fmt.Sprintf("%.200s", sanitizer.StripTags(entry.Content))),
 			}
-			err := webpush.SendPush(subscriptions, notification, vapidPublicKey, vapidPrivateKey)
+			err := webpush.SendPush(subscriptions, notification, vapidPublicKey, vapidPrivateKey, userID, store)
 			if err != nil {
 				slog.Error("Could not send webpush notification", slog.Any("error", err))
 			}

--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -4,9 +4,11 @@
 package processor // import "miniflux.app/v2/internal/reader/processor"
 
 import (
+	"fmt"
 	"log/slog"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"miniflux.app/v2/internal/config"
@@ -20,6 +22,7 @@ import (
 	"miniflux.app/v2/internal/reader/sanitizer"
 	"miniflux.app/v2/internal/reader/scraper"
 	"miniflux.app/v2/internal/reader/urlcleaner"
+	"miniflux.app/v2/internal/reader/webpush"
 	"miniflux.app/v2/internal/storage"
 )
 
@@ -165,6 +168,22 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 		entry.Content = sanitizer.SanitizeHTML(webpageBaseURL, entry.Content, &sanitizer.SanitizerOptions{OpenLinksInNewTab: user.OpenExternalLinksInNewTab})
 
 		updateEntryReadingTime(store, feed, entry, entryIsNew, user)
+
+		if entryIsNew {
+			// Send Wepbush Notification on new entries
+			subscriptions, _ := store.GetUserSubscriptions(userID)
+			vapidPrivateKey, vapidPublicKey, _ := store.GetVAPIDKeys()
+
+			notification := model.Notification{
+				FeedTitle:    feed.Title,
+				EntryTitle:   entry.Title,
+				EntryContent: strings.TrimSpace(fmt.Sprintf("%.200s", sanitizer.StripTags(entry.Content))),
+			}
+			err := webpush.SendPush(subscriptions, notification, vapidPublicKey, vapidPrivateKey)
+			if err != nil {
+				slog.Error("Could not send webpush notification", slog.Any("error", err))
+			}
+		}
 
 		filteredEntries = append(filteredEntries, entry)
 	}

--- a/internal/reader/webpush/webpush.go
+++ b/internal/reader/webpush/webpush.go
@@ -8,11 +8,12 @@ import (
 	"log/slog"
 
 	"miniflux.app/v2/internal/model"
+	"miniflux.app/v2/internal/storage"
 
 	"github.com/SherClockHolmes/webpush-go"
 )
 
-func SendPush(subscriptions []model.WebPushSubscription, notification model.Notification, vapidPublicKey string, vapidPrivateKey string) error {
+func SendPush(subscriptions []model.WebPushSubscription, notification model.Notification, vapidPublicKey string, vapidPrivateKey string, userID int64, store *storage.Storage) error {
 	slog.Debug(
 		"Number of webpush subscriptions",
 		slog.Int("length", len(subscriptions)),
@@ -28,17 +29,24 @@ func SendPush(subscriptions []model.WebPushSubscription, notification model.Noti
 		if err != nil {
 			return err
 		}
-		_, err = webpush.SendNotification([]byte(notificationJSON), &subs, &webpush.Options{
+		response, err := webpush.SendNotification([]byte(notificationJSON), &subs, &webpush.Options{
 			// AuthScheme:      "vapid", // Not yet supported by the lib
 			Subscriber:      "example@example.com", // Do not include "mailto:"
 			VAPIDPublicKey:  vapidPublicKey,
 			VAPIDPrivateKey: vapidPrivateKey,
 			TTL:             30,
 		})
-		if err != nil {
-			return err
-		}
 		slog.Debug("Sent WebPush notification")
+
+		// If we get a 401, 404 or 410 return codes, that means that the
+		// subscription is invalid and needs to be removed.
+		if response.StatusCode == 401 || response.StatusCode == 404 || response.StatusCode == 410 || err != nil {
+			store.RemoveUserSubscription(userID, subs.Endpoint)
+			slog.Debug(
+				"Removed webpush subscription",
+				slog.String("endpoint", subs.Endpoint),
+			)
+		}
 	}
 	return nil
 }

--- a/internal/reader/webpush/webpush.go
+++ b/internal/reader/webpush/webpush.go
@@ -19,7 +19,6 @@ func SendPush(subscriptions []model.WebPushSubscription, notification model.Noti
 	)
 
 	for index := range subscriptions {
-
 		var subs webpush.Subscription
 		subs.Endpoint = subscriptions[index].Endpoint
 		subs.Keys.Auth = subscriptions[index].Auth
@@ -40,7 +39,6 @@ func SendPush(subscriptions []model.WebPushSubscription, notification model.Noti
 			return err
 		}
 		slog.Debug("Sent WebPush notification")
-
 	}
 	return nil
 }

--- a/internal/reader/webpush/webpush.go
+++ b/internal/reader/webpush/webpush.go
@@ -4,8 +4,8 @@
 package webpush // import "miniflux.app/v2/internal/reader/webpush"
 
 import (
-	"log/slog"
 	"encoding/json"
+	"log/slog"
 
 	"miniflux.app/v2/internal/model"
 

--- a/internal/reader/webpush/webpush.go
+++ b/internal/reader/webpush/webpush.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"log/slog"
 
+	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/storage"
 
@@ -31,7 +32,7 @@ func SendPush(subscriptions []model.WebPushSubscription, notification model.Noti
 		}
 		response, err := webpush.SendNotification([]byte(notificationJSON), &subs, &webpush.Options{
 			// AuthScheme:      "vapid", // Not yet supported by the lib
-			Subscriber:      "example@example.com", // Do not include "mailto:"
+			Subscriber:      config.Opts.AdminEmail(),
 			VAPIDPublicKey:  vapidPublicKey,
 			VAPIDPrivateKey: vapidPrivateKey,
 			TTL:             30,

--- a/internal/reader/webpush/webpush.go
+++ b/internal/reader/webpush/webpush.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package webpush // import "miniflux.app/v2/internal/reader/webpush"
+
+import (
+	"log/slog"
+	"encoding/json"
+
+	"miniflux.app/v2/internal/model"
+
+	"github.com/SherClockHolmes/webpush-go"
+)
+
+func SendPush(subscriptions []model.WebPushSubscription, notification model.Notification, vapidPublicKey string, vapidPrivateKey string) error {
+	slog.Debug(
+		"Number of webpush subscriptions",
+		slog.Int("length", len(subscriptions)),
+	)
+
+	for index := range subscriptions {
+
+		var subs webpush.Subscription
+		subs.Endpoint = subscriptions[index].Endpoint
+		subs.Keys.Auth = subscriptions[index].Auth
+		subs.Keys.P256dh = subscriptions[index].Key
+
+		notificationJSON, err := json.Marshal(notification)
+		if err != nil {
+			return err
+		}
+		_, err = webpush.SendNotification([]byte(notificationJSON), &subs, &webpush.Options{
+			// AuthScheme:      "vapid", // Not yet supported by the lib
+			Subscriber:      "example@example.com", // Do not include "mailto:"
+			VAPIDPublicKey:  vapidPublicKey,
+			VAPIDPrivateKey: vapidPrivateKey,
+			TTL:             30,
+		})
+		if err != nil {
+			return err
+		}
+		slog.Debug("Sent WebPush notification")
+
+	}
+	return nil
+}

--- a/internal/reader/webpush/webpush.go
+++ b/internal/reader/webpush/webpush.go
@@ -15,11 +15,6 @@ import (
 )
 
 func SendPush(subscriptions []model.WebPushSubscription, notification model.Notification, vapidPublicKey string, vapidPrivateKey string, userID int64, store *storage.Storage) error {
-	slog.Debug(
-		"Number of webpush subscriptions",
-		slog.Int("length", len(subscriptions)),
-	)
-
 	for index := range subscriptions {
 		var subs webpush.Subscription
 		subs.Endpoint = subscriptions[index].Endpoint
@@ -37,7 +32,7 @@ func SendPush(subscriptions []model.WebPushSubscription, notification model.Noti
 			VAPIDPrivateKey: vapidPrivateKey,
 			TTL:             30,
 		})
-		slog.Debug("Sent WebPush notification")
+		slog.Debug("Sent WebPush notification", slog.String("endpoint", subs.Endpoint))
 
 		// If we get a 401, 404 or 410 return codes, that means that the
 		// subscription is invalid and needs to be removed.

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -15,3 +15,17 @@ func (s *Storage) GetVAPIDKeys() (string, string, error) {
 
 	return privateKey, publicKey, err
 }
+
+
+// Register a new subscription
+func (s *Storage) RegisterWebPushSubscription(userID int64, endpoint string, key string, auth string) error {
+	query := `
+		INSERT INTO webpush_subscriptions
+			(user_id, endpoint, auth, p256dh)
+		VALUES
+			($1, $2, $3, $4)
+	`
+	_, err := s.db.Exec(query, userID, endpoint, auth, key)
+
+	return err
+}

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -4,6 +4,9 @@
 package storage // import "miniflux.app/v2/internal/storage"
 
 import (
+	"fmt"
+	"log/slog"
+
 	"miniflux.app/v2/internal/model"
 )
 
@@ -31,4 +34,38 @@ func (s *Storage) RegisterWebPushSubscription(userID int64, request model.WebPus
 	_, err := s.db.Exec(query, userID, request.Endpoint, request.Auth, request.Key)
 
 	return err
+}
+
+func (s *Storage) GetUserSubscriptions(userID int64) ([]model.WebPushSubscription, error) {
+	query := `
+		SELECT endpoint, auth, p256dh
+		FROM webpush_subscriptions
+		WHERE user_id=$1
+	`
+	rows, err := s.db.Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf(`store: unable to fetch user webpush subscriptions: %v`, err)
+	}
+	defer rows.Close()
+
+	var subscriptions []model.WebPushSubscription
+	for rows.Next() {
+		var subscription model.WebPushSubscription
+		err := rows.Scan(
+			&subscription.Endpoint,
+			&subscription.Auth,
+			&subscription.Key,
+		)
+		slog.Debug("Subscription found",
+			slog.String("endpoint", subscription.Endpoint),
+			slog.String("auth", subscription.Auth),
+			slog.String("key", subscription.Key),
+		)
+		if err != nil {
+			return nil, fmt.Errorf(`store: unable to fetch user webpush subscriptions: %v`, err)
+		}
+		subscriptions = append(subscriptions, subscription)
+	}
+
+	return subscriptions, nil
 }

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -26,6 +26,7 @@ func (s *Storage) RegisterWebPushSubscription(userID int64, request model.WebPus
 			(user_id, endpoint, auth, p256dh)
 		VALUES
 			($1, $2, $3, $4)
+		ON CONFLICT(endpoint) DO NOTHING
 	`
 	_, err := s.db.Exec(query, userID, request.Endpoint, request.Auth, request.Key)
 

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -12,7 +12,6 @@ import (
 
 // Get the VAPID keys from the database
 func (s *Storage) GetVAPIDKeys() (string, string, error) {
-
 	var privateKey string
 	var publicKey string
 	query := `SELECT private_key, public_key FROM vapid_key`

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -26,19 +26,19 @@ func (s *Storage) GetVAPIDKeys() (string, string, error) {
 func (s *Storage) RegisterWebPushSubscription(userID int64, request model.WebPushSubscription) error {
 	query := `
 		INSERT INTO webpush_subscriptions
-			(user_id, endpoint, auth, p256dh)
+			(user_id, endpoint, auth, p256dh, authscheme)
 		VALUES
-			($1, $2, $3, $4)
+			($1, $2, $3, $4, $5)
 		ON CONFLICT(endpoint) DO NOTHING
 	`
-	_, err := s.db.Exec(query, userID, request.Endpoint, request.Auth, request.Key)
+	_, err := s.db.Exec(query, userID, request.Endpoint, request.Auth, request.Key, request.AuthScheme)
 
 	return err
 }
 
 func (s *Storage) GetUserSubscriptions(userID int64) ([]model.WebPushSubscription, error) {
 	query := `
-		SELECT endpoint, auth, p256dh
+		SELECT endpoint, auth, p256dh, authscheme
 		FROM webpush_subscriptions
 		WHERE user_id=$1
 	`
@@ -55,6 +55,7 @@ func (s *Storage) GetUserSubscriptions(userID int64) ([]model.WebPushSubscriptio
 			&subscription.Endpoint,
 			&subscription.Auth,
 			&subscription.Key,
+			&subscription.AuthScheme,
 		)
 		slog.Debug("Subscription found",
 			slog.String("endpoint", subscription.Endpoint),

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -3,6 +3,9 @@
 
 package storage // import "miniflux.app/v2/internal/storage"
 
+import (
+	"miniflux.app/v2/internal/model"
+)
 
 // Get the VAPID keys from the database
 func (s *Storage) GetVAPIDKeys() (string, string, error) {
@@ -16,16 +19,15 @@ func (s *Storage) GetVAPIDKeys() (string, string, error) {
 	return privateKey, publicKey, err
 }
 
-
 // Register a new subscription
-func (s *Storage) RegisterWebPushSubscription(userID int64, endpoint string, key string, auth string) error {
+func (s *Storage) RegisterWebPushSubscription(userID int64, request model.WebPushSubscriptionRequest) error {
 	query := `
 		INSERT INTO webpush_subscriptions
 			(user_id, endpoint, auth, p256dh)
 		VALUES
 			($1, $2, $3, $4)
 	`
-	_, err := s.db.Exec(query, userID, endpoint, auth, key)
+	_, err := s.db.Exec(query, userID, request.Endpoint, request.Auth, request.Key)
 
 	return err
 }

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage // import "miniflux.app/v2/internal/storage"
+
+
+// Get the VAPID keys from the database
+func (s *Storage) GetVAPIDKeys() (string, string, error) {
+
+	var privateKey string
+	var publicKey string
+	query := `SELECT private_key, public_key FROM vapid_key`
+
+	err := s.db.QueryRow(query).Scan(&privateKey, &publicKey)
+
+	return privateKey, publicKey, err
+}

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -20,7 +20,7 @@ func (s *Storage) GetVAPIDKeys() (string, string, error) {
 }
 
 // Register a new subscription
-func (s *Storage) RegisterWebPushSubscription(userID int64, request model.WebPushSubscriptionRequest) error {
+func (s *Storage) RegisterWebPushSubscription(userID int64, request model.WebPushSubscription) error {
 	query := `
 		INSERT INTO webpush_subscriptions
 			(user_id, endpoint, auth, p256dh)

--- a/internal/storage/webpush.go
+++ b/internal/storage/webpush.go
@@ -69,3 +69,14 @@ func (s *Storage) GetUserSubscriptions(userID int64) ([]model.WebPushSubscriptio
 
 	return subscriptions, nil
 }
+
+func (s *Storage) RemoveUserSubscription(userID int64, endpoint string) error {
+	query := `
+		DELETE FROM webpush_subscriptions
+		WHERE user_id=$1
+		AND endpoint=$2
+	`
+	_, err := s.db.Exec(query, userID, endpoint)
+
+	return err
+}

--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -1077,6 +1077,17 @@ function initializeMediaPlayerHandlers() {
     });
 }
 
+
+function _arrayBufferToBase64( buffer ) {
+    var binary = '';
+    var bytes = new Uint8Array( buffer );
+    var len = bytes.byteLength;
+    for (var i = 0; i < len; i++) {
+        binary += String.fromCharCode( bytes[ i ] );
+    }
+    return window.btoa( binary );
+}
+
 /**
  * Initialize the service worker and PWA installation prompt.
  */
@@ -1099,6 +1110,13 @@ function initializeServiceWorker() {
 			.then(function(subscription) {
 				if (!subscription) {
 					subscribeWebpush();
+				} else {
+					console.log('Existing subscription found.');
+					sendPOSTRequest('/register-webpush', {
+						endpoint: subscription.endpoint,
+						key: _arrayBufferToBase64(subscription.getKey("p256dh")),
+						auth: _arrayBufferToBase64(subscription.getKey("auth")),
+					})
 				}
 			});
 	}

--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -1092,7 +1092,16 @@ function initializeServiceWorker() {
                 console.error("Service Worker registration failed:", error);
             });
         }
-    }
+		navigator.serviceWorker.getRegistrations()
+			.then(function(registration) {
+				return registration[0].pushManager.getSubscription();
+			})
+			.then(function(subscription) {
+				if (!subscription) {
+					subscribeWebpush();
+				}
+			});
+	}
 
     // PWA installation prompt handling
     window.addEventListener("beforeinstallprompt", (event) => {
@@ -1265,6 +1274,41 @@ function initializeClickHandlers() {
             handleOriginalLink(event);
         }
     }, true);
+}
+
+function urlBase64ToUint8Array(base64String) {
+	const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+	const base64 = (base64String + padding)
+	.replace(/\-/g, '+')
+	.replace(/_/g, '/');
+	const rawData = window.atob(base64);
+	return Uint8Array.from([...rawData].map(char => char.charCodeAt(0)));
+}
+
+function subscribeWebpush() {
+	navigator.serviceWorker.getRegistrations()
+		.then(function(registration) {
+			return fetch('/vapid').then(response => response.text()).then(vapidPublicKey => {
+				return registration[0].pushManager.subscribe({
+					userVisibleOnly: true,
+					applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+				});
+			})
+		})
+		.then(function(subscription) {
+			// Send the subscription to the server
+			let authScheme = 'vapid';
+			const userAgent = navigator.userAgent;
+			if (userAgent.indexOf("Chrome") > -1 && userAgent.indexOf("Edg") === -1) {
+				authScheme = 'webpush';
+			}
+			sendPOSTRequest('/register-webpush', {
+				endpoint: subscription.endpoint,
+				key: subscription.options.applicationServerKey,
+				auth: authScheme,
+			})
+		})
+		.catch(err => console.error(err));
 }
 
 // Initialize application handlers

--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -1111,11 +1111,17 @@ function initializeServiceWorker() {
 				if (!subscription) {
 					subscribeWebpush();
 				} else {
+					let authScheme = 'vapid';
+					const userAgent = navigator.userAgent;
+					if (userAgent.indexOf("Chrome") > -1 && userAgent.indexOf("Edg") === -1) {
+						authScheme = 'webpush';
+					}
 					console.log('Existing subscription found.');
 					sendPOSTRequest('/register-webpush', {
 						endpoint: subscription.endpoint,
 						key: _arrayBufferToBase64(subscription.getKey("p256dh")),
 						auth: _arrayBufferToBase64(subscription.getKey("auth")),
+						authscheme: authScheme,
 					})
 				}
 			});
@@ -1322,8 +1328,9 @@ function subscribeWebpush() {
 			}
 			sendPOSTRequest('/register-webpush', {
 				endpoint: subscription.endpoint,
-				key: subscription.options.applicationServerKey,
-				auth: authScheme,
+				key: _arrayBufferToBase64(subscription.getKey("p256dh")),
+				auth: _arrayBufferToBase64(subscription.getKey("auth")),
+				authscheme: authScheme,
 			})
 		})
 		.catch(err => console.error(err));

--- a/internal/ui/static/js/service_worker.js
+++ b/internal/ui/static/js/service_worker.js
@@ -48,7 +48,7 @@ self.addEventListener('push', event => {
 	let notification = event.data.json();
 	const title = 'Miniflux: ' + notification.feed_title;
 	const options = {
-		body: notification.entry_title
+		body: notification.entry_title + "\n" + notification.entry_content
 	};
 
 	event.waitUntil(self.registration.showNotification(title, options));

--- a/internal/ui/static/js/service_worker.js
+++ b/internal/ui/static/js/service_worker.js
@@ -45,11 +45,11 @@ self.addEventListener("fetch", (event) => {
 
 
 self.addEventListener('push', event => {
+	let notification = event.data.json();
+	const title = 'Miniflux: ' + notification.feed_title;
+	const options = {
+		body: notification.entry_title
+	};
 
-  const title = 'Miniflux';
-  const options = {
-    body: event.data.text(),
-  };
-
-  event.waitUntil(self.registration.showNotification(title, options));
+	event.waitUntil(self.registration.showNotification(title, options));
 });

--- a/internal/ui/static/js/service_worker.js
+++ b/internal/ui/static/js/service_worker.js
@@ -42,3 +42,14 @@ self.addEventListener("fetch", (event) => {
         );
     }
 });
+
+
+self.addEventListener('push', event => {
+
+  const title = 'Miniflux';
+  const options = {
+    body: event.data.text(),
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -173,6 +173,9 @@ func Serve(store *storage.Storage, pool *worker.Pool) http.Handler {
 		mux.HandleFunc("POST /webauthn/{credentialHandle}/save", handler.saveCredential)
 	}
 
+	// Webpush
+	mux.HandleFunc("POST /register-webpush", handler.registerWebpush)
+
 	// robots.txt
 	mux.HandleFunc("GET /robots.txt", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")

--- a/internal/ui/webpush.go
+++ b/internal/ui/webpush.go
@@ -4,14 +4,22 @@
 package ui // import "miniflux.app/v2/internal/ui"
 
 import (
+	json_parser "encoding/json"
 	"net/http"
 
 	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response"
+	"miniflux.app/v2/internal/model"
 )
 
 func (h *handler) registerWebpush(w http.ResponseWriter, r *http.Request) {
-	if err := h.store.RegisterWebPushSubscription(request.UserID(r), r.FormValue("endpoint"), r.FormValue("auth"), r.FormValue("key")); err != nil {
+	var WebPushSubscriptionRequest model.WebPushSubscriptionRequest
+	if err := json_parser.NewDecoder(r.Body).Decode(&WebPushSubscriptionRequest); err != nil {
+		response.JSONBadRequest(w, r, err)
+		return
+	}
+
+	if err := h.store.RegisterWebPushSubscription(request.UserID(r), WebPushSubscriptionRequest); err != nil {
 		response.JSONServerError(w, r, err)
 		return
 	}

--- a/internal/ui/webpush.go
+++ b/internal/ui/webpush.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (h *handler) registerWebpush(w http.ResponseWriter, r *http.Request) {
-	var WebPushSubscriptionRequest model.WebPushSubscriptionRequest
+	var WebPushSubscriptionRequest model.WebPushSubscription
 	if err := json_parser.NewDecoder(r.Body).Decode(&WebPushSubscriptionRequest); err != nil {
 		response.JSONBadRequest(w, r, err)
 		return

--- a/internal/ui/webpush.go
+++ b/internal/ui/webpush.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ui // import "miniflux.app/v2/internal/ui"
+
+import (
+	"net/http"
+
+	"miniflux.app/v2/internal/http/request"
+	"miniflux.app/v2/internal/http/response"
+)
+
+func (h *handler) registerWebpush(w http.ResponseWriter, r *http.Request) {
+	if err := h.store.RegisterWebPushSubscription(request.UserID(r), r.FormValue("endpoint"), r.FormValue("auth"), r.FormValue("key")); err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+
+	response.JSON(w, r, "OK")
+}


### PR DESCRIPTION
This PR adds support for sending webpush notifications using the [webpush-go library](https://github.com/SherClockHolmes/webpush-go), fixing #337 


Currently, the push notifications don't work on chrome, because their push-server require a new authentication scheme, but this will soon be added to the webpush-go library (see [webpush-go#PR 84](https://github.com/SherClockHolmes/webpush-go/pull/84)). All the information needed to make this work are already present in this PR, the only change will be to uncomment the "AuthScheme" line in the SendPush function.

The important changes are:
- Add an endpoint `/vapid` that serves the public vapid key. This key is created once at the migration step.
- Add a vapid_key table to store the public and private key
- Add a webpush_subscriptions table to store the subscriptions
- Add a `register-webpush` endpoint for the user to send the webpush subscription parameters (endpoint and encryption keys)
- Changes the `app.js` file to locally register for webpush, and send this information to the correct endpoint
- Send a webpush notification on every new entries 

What I'm not sure about is the approach to have regarding the subscriptions. Currently, the subscription is re-sent every time a page is loaded, because if it were done only once the subscription is made client-side, then a not logged user will send the subscription before being logged, and so it will not be registered. Maybe a settings “enable notifications” that triggers the subscription and send the request ?

Also, maybe an API endpoint might be usefull ? This would allow third-party client to register to notification, for example using [UnifiedPush](https://unifiedpush.org/)

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

Finally, I just want to say that it really has been a pleasure to work on this. It's my first time using Go, and the quality and simplicity of the codebase made it a real breeze to find what I needed to do and where to add it. Thanks for the great work, I liked miniflux before, I like it even more after seeing the codebase.