### PR TITLE
feat(ui): add stdlib cross-origin protection middleware

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -181,6 +181,6 @@ func Serve(store *storage.Storage, pool *worker.Pool) http.Handler {
 		w.Write([]byte("User-agent: *\nDisallow: /"))
 	})
 
-	// Apply middleware chain: web session -> CSRF validation -> handlers.
-	return webSessionMiddleware.handle(csrfMiddleware.handle(mux))
+	// Apply middleware chain: cross-origin protection -> web session -> CSRF validation -> handlers.
+	return http.NewCrossOriginProtection().Handler(webSessionMiddleware.handle(csrfMiddleware.handle(mux)))
 }


### PR DESCRIPTION
Wrap the UI handler chain with http.CrossOriginProtection as the outermost layer so cross-origin unsafe-method requests are rejected via Sec-Fetch-Site/Origin checks before session lookup or token CSRF validation runs. Stacks with the existing per-session token CSRF for defense in depth; API handlers are unaffected.