### PR TITLE
fix(ui): rename flash message template variables

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -114,11 +114,11 @@
         </nav>
     </header>
     {{ end }}
-    {{ if .successMessage }}
-        <div role="alert" class="flash-message alert alert-success">{{ .successMessage }}</div>
+    {{ if .flashSuccessMessage }}
+        <div role="alert" class="flash-message alert alert-success">{{ .flashSuccessMessage }}</div>
     {{ end }}
-    {{ if .errorMessage }}
-        <div role="alert" class="flash-error-message alert alert-error">{{ .errorMessage }}</div>
+    {{ if .flashErrorMessage }}
+        <div role="alert" class="flash-error-message alert alert-error">{{ .flashErrorMessage }}</div>
     {{ end }}
 
     {{template "page_header" .}}

--- a/internal/ui/view/view.go
+++ b/internal/ui/view/view.go
@@ -34,17 +34,17 @@ func (v *view) Render(template string) []byte {
 func New(tpl *template.Engine, r *http.Request) *view {
 	webSession := request.WebSession(r)
 	theme := webSession.Theme()
-	successMessage, errorMessage := webSession.ConsumeMessages()
+	flashSuccessMessage, flashErrorMessage := webSession.ConsumeMessages()
 	return &view{tpl, r, map[string]any{
-		"menu":            "",
-		"csrf":            webSession.CSRF(),
-		"successMessage":  successMessage,
-		"errorMessage":    errorMessage,
-		"theme":           theme,
-		"language":        webSession.Language(),
-		"theme_checksum":  static.StylesheetBundles[theme+".css"].Checksum,
-		"app_js_checksum": static.JavascriptBundles["app.js"].Checksum,
-		"sw_js_checksum":  static.JavascriptBundles["service-worker.js"].Checksum,
-		"webAuthnEnabled": config.Opts.WebAuthn(),
+		"menu":                "",
+		"csrf":                webSession.CSRF(),
+		"flashSuccessMessage": flashSuccessMessage,
+		"flashErrorMessage":   flashErrorMessage,
+		"theme":               theme,
+		"language":            webSession.Language(),
+		"theme_checksum":      static.StylesheetBundles[theme+".css"].Checksum,
+		"app_js_checksum":     static.JavascriptBundles["app.js"].Checksum,
+		"sw_js_checksum":      static.JavascriptBundles["service-worker.js"].Checksum,
+		"webAuthnEnabled":     config.Opts.WebAuthn(),
 	}}
 }


### PR DESCRIPTION
The flash message keys `successMessage` and `errorMessage` collided with per-template form validation variables set by handlers (e.g. add subscription), causing form errors to also render in the global flash banner. Rename the flash keys to `flashSuccessMessage` and `flashErrorMessage` to keep them distinct from form-scoped variables.