### PR TITLE
feat(config): allow disabling local auth without user creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ module miniflux.app/v2
 // +heroku goVersion go1.26
 go 1.26.0
 
-
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/andybalholm/brotli v1.2.1

--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -1799,8 +1799,8 @@ func TestValidateDisableLocalAuthWithOAuth2ButNoUserCreation(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Unexpected parse error: %v", err)
 	}
-	if err := configParser.options.Validate(); err == nil {
-		t.Fatal("Expected error when local auth is disabled with OAuth2 but without user creation")
+	if err := configParser.options.Validate(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 
@@ -1829,8 +1829,8 @@ func TestValidateDisableLocalAuthWithAuthProxyButNoUserCreation(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Unexpected parse error: %v", err)
 	}
-	if err := configParser.options.Validate(); err == nil {
-		t.Fatal("Expected error when local auth is disabled with auth proxy but without user creation")
+	if err := configParser.options.Validate(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -57,13 +57,8 @@ func (c *configOptions) Validate() error {
 	}
 
 	if c.DisableLocalAuth() {
-		switch {
-		case c.OAuth2Provider() == "" && c.AuthProxyHeader() == "":
+		if c.OAuth2Provider() == "" && c.AuthProxyHeader() == "" {
 			return errors.New("DISABLE_LOCAL_AUTH is enabled but neither OAUTH2_PROVIDER nor AUTH_PROXY_HEADER is set. Please enable at least one authentication source")
-		case c.OAuth2Provider() != "" && !c.IsOAuth2UserCreationAllowed():
-			return errors.New("DISABLE_LOCAL_AUTH is enabled and an OAUTH2_PROVIDER is configured, but OAUTH2_USER_CREATION is not enabled")
-		case c.AuthProxyHeader() != "" && !c.IsAuthProxyUserCreationAllowed():
-			return errors.New("DISABLE_LOCAL_AUTH is enabled and an AUTH_PROXY_HEADER is configured, but AUTH_PROXY_USER_CREATION is not enabled")
 		}
 	}
 

--- a/miniflux.1
+++ b/miniflux.1
@@ -165,6 +165,8 @@ Default is empty.
 .B AUTH_PROXY_USER_CREATION
 Set to 1 to create users based on proxy authentication information\&.
 .br
+When disabled, users must already exist in Miniflux to sign in through the proxy\&.
+.br
 Disabled by default\&.
 .TP
 .B BASE_URL
@@ -266,6 +268,10 @@ Disable local authentication\&.
 .br
 When set to true, the username/password form is hidden from the login screen, and the
 options to change username/password or unlink OAuth2 account are hidden from the settings page.
+.br
+This option requires an alternative authentication source such as OAuth2 or auth proxy\&.
+.br
+If remote user creation is disabled, only existing users can sign in\&.
 .br
 Default is false\&.
 .TP
@@ -501,6 +507,8 @@ Default is empty\&.
 .TP
 .B OAUTH2_USER_CREATION
 Set to 1 to authorize OAuth2 user creation\&.
+.br
+When disabled, users must already exist in Miniflux or have a linked OAuth2 account to sign in\&.
 .br
 Disabled by default\&.
 .TP


### PR DESCRIPTION
Lift the validation that rejected DISABLE_LOCAL_AUTH=1 combined with OAUTH2_USER_CREATION=0 or AUTH_PROXY_USER_CREATION=0. Admins can now pre-create users and forbid auto-registration while still forcing all logins through OAuth2 or an auth proxy.

Fixes: #3163
