### PR TITLE
refactor(storage): take category sort order as parameter

### DIFF
--- a/internal/api/category_handlers.go
+++ b/internal/api/category_handlers.go
@@ -115,7 +115,12 @@ func (h *handler) getCategoriesHandler(w http.ResponseWriter, r *http.Request) {
 	includeCounts := request.QueryStringParam(r, "counts", "false")
 
 	if includeCounts == "true" {
-		categories, err = h.store.CategoriesWithFeedCount(request.UserID(r))
+		user, userErr := h.store.UserByID(request.UserID(r))
+		if userErr != nil {
+			response.JSONServerError(w, r, userErr)
+			return
+		}
+		categories, err = h.store.CategoriesWithFeedCount(user.ID, user.CategoriesSortingOrder)
 	} else {
 		categories, err = h.store.Categories(request.UserID(r))
 	}

--- a/internal/storage/category.go
+++ b/internal/storage/category.go
@@ -109,13 +109,8 @@ func (s *Storage) Categories(userID int64) (model.Categories, error) {
 	return categories, nil
 }
 
-// CategoriesWithFeedCount returns all categories with the number of feeds.
-func (s *Storage) CategoriesWithFeedCount(userID int64) (model.Categories, error) {
-	user, err := s.UserByID(userID)
-	if err != nil {
-		return nil, err
-	}
-
+// CategoriesWithFeedCount returns all categories with the number of feeds, sorted according to sortOrder.
+func (s *Storage) CategoriesWithFeedCount(userID int64, sortOrder string) (model.Categories, error) {
 	query := `
 		SELECT
 			c.id,
@@ -132,7 +127,7 @@ func (s *Storage) CategoriesWithFeedCount(userID int64) (model.Categories, error
 			user_id=$2
 	`
 
-	if user.CategoriesSortingOrder == "alphabetical" {
+	if sortOrder == "alphabetical" {
 		query += `
 			ORDER BY
 				c.title ASC

--- a/internal/ui/category_list.go
+++ b/internal/ui/category_list.go
@@ -18,7 +18,7 @@ func (h *handler) showCategoryListPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	categories, err := h.store.CategoriesWithFeedCount(user.ID)
+	categories, err := h.store.CategoriesWithFeedCount(user.ID, user.CategoriesSortingOrder)
 	if err != nil {
 		response.HTMLServerError(w, r, err)
 		return


### PR DESCRIPTION
Previously `CategoriesWithFeedCount` loaded the user via `UserByID` just to read `CategoriesSortingOrder`. Pass it in explicitly so the UI path (which already has the user loaded) avoids a redundant lookup.