### PR TITLE
security(session): Invalidate cookies on logout

### DIFF
--- a/internal/ui/logout.go
+++ b/internal/ui/logout.go
@@ -6,22 +6,37 @@ package ui // import "miniflux.app/v2/internal/ui"
 import (
 	"net/http"
 
+	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/http/request"
 	"miniflux.app/v2/internal/http/response"
 )
 
 func (h *handler) logout(w http.ResponseWriter, r *http.Request) {
-	user, err := h.store.UserByID(request.UserID(r))
-	if err != nil {
-		response.HTMLServerError(w, r, err)
-		return
-	}
-
 	if s := request.WebSession(r); s != nil {
-		s.ClearUser()
-		s.SetLanguage(user.Language)
-		s.SetTheme(user.Theme)
+		if err := h.store.RemoveUserWebSession(request.UserID(r), s.ID); err != nil {
+			response.HTMLServerError(w, r, err)
+			return
+		}
 	}
 
+	clearSessionCookie(w)
 	response.HTMLRedirect(w, r, h.routePath("/"))
+}
+
+// clearSessionCookie expires the session cookie on the client.
+func clearSessionCookie(w http.ResponseWriter) {
+	path := config.Opts.BasePath()
+	if path == "" {
+		path = "/"
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     path,
+		Secure:   config.Opts.HTTPS(),
+		HttpOnly: true,
+		MaxAge:   -1,
+		SameSite: http.SameSiteLaxMode,
+	})
 }


### PR DESCRIPTION
Instead of only invalidating the user_id via ClearUser, destroy the session altogether via RemoveUserWebSession, and expire the cookie on the user side.

This ensures that cookies are completely invalidated upon logout.