### PR TITLE
security(ui): don't redirect to weird external url

### DIFF
--- a/internal/ui/entry_category.go
+++ b/internal/ui/entry_category.go
@@ -11,6 +11,7 @@ import (
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/storage"
 	"miniflux.app/v2/internal/ui/view"
+	"miniflux.app/v2/internal/urllib"
 )
 
 func (h *handler) showCategoryEntryPage(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +49,7 @@ func (h *handler) showCategoryEntryPage(w http.ResponseWriter, r *http.Request) 
 		entry.Status = model.EntryStatusRead
 	}
 
-	if user.AlwaysOpenExternalLinks {
+	if user.AlwaysOpenExternalLinks && urllib.IsSafeExternalURL(entry.URL) {
 		response.HTMLRedirect(w, r, entry.URL)
 		return
 	}

--- a/internal/ui/entry_feed.go
+++ b/internal/ui/entry_feed.go
@@ -11,6 +11,7 @@ import (
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/storage"
 	"miniflux.app/v2/internal/ui/view"
+	"miniflux.app/v2/internal/urllib"
 )
 
 func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +49,7 @@ func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
 		entry.Status = model.EntryStatusRead
 	}
 
-	if user.AlwaysOpenExternalLinks {
+	if user.AlwaysOpenExternalLinks && urllib.IsSafeExternalURL(entry.URL) {
 		response.HTMLRedirect(w, r, entry.URL)
 		return
 	}

--- a/internal/ui/unread_entry_category.go
+++ b/internal/ui/unread_entry_category.go
@@ -11,6 +11,7 @@ import (
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/storage"
 	"miniflux.app/v2/internal/ui/view"
+	"miniflux.app/v2/internal/urllib"
 )
 
 func (h *handler) showUnreadCategoryEntryPage(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +86,7 @@ func (h *handler) showUnreadCategoryEntryPage(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	if user.AlwaysOpenExternalLinks {
+	if user.AlwaysOpenExternalLinks && urllib.IsSafeExternalURL(entry.URL) {
 		response.HTMLRedirect(w, r, entry.URL)
 		return
 	}

--- a/internal/ui/unread_entry_feed.go
+++ b/internal/ui/unread_entry_feed.go
@@ -11,6 +11,7 @@ import (
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/storage"
 	"miniflux.app/v2/internal/ui/view"
+	"miniflux.app/v2/internal/urllib"
 )
 
 func (h *handler) showUnreadFeedEntryPage(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +86,7 @@ func (h *handler) showUnreadFeedEntryPage(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	if user.AlwaysOpenExternalLinks {
+	if user.AlwaysOpenExternalLinks && urllib.IsSafeExternalURL(entry.URL) {
 		response.HTMLRedirect(w, r, entry.URL)
 		return
 	}

--- a/internal/urllib/url.go
+++ b/internal/urllib/url.go
@@ -119,6 +119,26 @@ func IsHTTPS(websiteURL string) bool {
 	return strings.EqualFold(parsedURL.Scheme, "https")
 }
 
+// IsSafeExternalURL reports whether rawURL is safe to use as the target of a
+// server-issued HTTP redirect. Entry URLs come from arbitrary remote feeds,
+// so they may contain dangerous schemes such as javascript: or data: which
+// would execute on the Miniflux origin if returned in a Location header.
+// Only absolute http(s) URLs with a non-empty host are accepted.
+func IsSafeExternalURL(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return true
+	}
+	return false
+}
+
 // Domain returns the host component of the given URL.
 func Domain(websiteURL string) string {
 	parsedURL, err := url.Parse(websiteURL)


### PR DESCRIPTION
When the user enables `AlwaysOpenExternalLinks`, the handler calls `response.HTMLRedirect(w, r, entry.URL)` without validating the url scheme. As `entry.URL` comes from arbitrary remote feeds and is not constrained to `http(s)`, a feed entry with `javascript:…` or `data:text/html,…` could become a one-click XSS on the Miniflux origin.

There are a bunch of mitigating factors so this isn't really exploitable in the real world™, but better safe than sorry.