### PR TITLE
ci: add workflow to close stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Close Stale Pull Requests
+permissions: read-all
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs within 14 days.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Please feel free to reopen it if you would like to continue working on it.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
Marks pull requests as stale after 60 days of inactivity and closes them 14 days later. Issues are excluded. Runs daily and can be triggered manually via `workflow_dispatch`.