### PR TITLE
feat(sanitizer): add iOS Shortcuts `shortcuts:` scheme to validURISchemes

### DIFF
--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -180,6 +180,7 @@ var (
 		"sftp:",
 		"sip:",
 		"sips:",
+		"shortcuts:",
 		"skype:",
 		"spotify:",
 		"ssh:",


### PR DESCRIPTION
Miniflux sanitizer filters allowed URL schemes, but `shortcuts:` is not included. `shortcuts:` is an official Apple scheme (https://support.apple.com/guide/shortcuts/run-a-shortcut-from-a-url-apd624386f42/ios), similar eg. to already added `itms-apps`

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
