### PR TITLE
feat(ui): replace rule inputs with textareas for multiline support

### DIFF
--- a/internal/reader/filter/filter.go
+++ b/internal/reader/filter/filter.go
@@ -99,38 +99,50 @@ func IsBlockedEntry(blockRules filterRules, allowRules filterRules, feed *model.
 // matchesEntryRegexRules checks if the entry matches the regex rules defined in the feed or user settings.
 // It returns true if the entry matches the regex pattern, and a boolean indicating if the regex is valid.
 func matchesEntryRegexRules(regexPattern string, feed *model.Feed, entry *model.Entry) (bool, bool) {
+	regexPattern = strings.TrimSpace(regexPattern)
 	if regexPattern == "" {
 		return false, true // No pattern means rule is valid but doesn't match
 	}
 
-	compiledRegex, err := regexp.Compile(regexPattern)
-	if err != nil {
-		slog.Warn("Failed on regexp compilation",
-			slog.String("regex_pattern", regexPattern),
-			slog.Any("error", err),
-		)
-		return false, false // Invalid regex pattern
+	valid := false
+
+	for line := range strings.SplitSeq(regexPattern, "\n") {
+		pattern := strings.TrimSpace(line)
+		if pattern == "" {
+			continue
+		}
+
+		compiledRegex, err := regexp.Compile(pattern)
+		if err != nil {
+			slog.Warn("Failed on regexp compilation",
+				slog.String("regex_pattern", pattern),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		valid = true
+
+		containsMatchingTag := slices.ContainsFunc(entry.Tags, func(tag string) bool {
+			return compiledRegex.MatchString(tag)
+		})
+
+		if compiledRegex.MatchString(entry.URL) ||
+			compiledRegex.MatchString(entry.Title) ||
+			compiledRegex.MatchString(entry.Author) ||
+			containsMatchingTag {
+			slog.Debug("Entry matches regex rule",
+				slog.String("entry_url", entry.URL),
+				slog.String("entry_title", entry.Title),
+				slog.String("entry_author", entry.Author),
+				slog.String("feed_url", feed.FeedURL),
+				slog.String("regex_pattern", pattern),
+			)
+			return true, true // Pattern matches and is valid
+		}
 	}
 
-	containsMatchingTag := slices.ContainsFunc(entry.Tags, func(tag string) bool {
-		return compiledRegex.MatchString(tag)
-	})
-
-	if compiledRegex.MatchString(entry.URL) ||
-		compiledRegex.MatchString(entry.Title) ||
-		compiledRegex.MatchString(entry.Author) ||
-		containsMatchingTag {
-		slog.Debug("Entry matches regex rule",
-			slog.String("entry_url", entry.URL),
-			slog.String("entry_title", entry.Title),
-			slog.String("entry_author", entry.Author),
-			slog.String("feed_url", feed.FeedURL),
-			slog.String("regex_pattern", regexPattern),
-		)
-		return true, true // Pattern matches and is valid
-	}
-
-	return false, true // Pattern is valid but doesn't match
+	return false, valid
 }
 
 func matchesEntryFilterRules(rules filterRules, feed *model.Feed, entry *model.Entry) bool {

--- a/internal/reader/filter/filter_test.go
+++ b/internal/reader/filter/filter_test.go
@@ -443,6 +443,27 @@ func TestMatchesEntryRegexRules(t *testing.T) {
 			description:   "Valid regex matching title should return true for both",
 		},
 		{
+			name:          "matches title with regex whitespace",
+			regexPattern:  "Test Entry",
+			expectedMatch: true,
+			expectedValid: true,
+			description:   "Whitespace inside an existing single-line regex should remain part of that regex",
+		},
+		{
+			name:          "matches title with trailing newline",
+			regexPattern:  "Test.*Title\n",
+			expectedMatch: true,
+			expectedValid: true,
+			description:   "Trailing newlines from textarea input should be ignored",
+		},
+		{
+			name:          "matches second multiline regex",
+			regexPattern:  "NoMatch\nTest.*Title",
+			expectedMatch: true,
+			expectedValid: true,
+			description:   "Newline-delimited regex patterns should be evaluated independently",
+		},
+		{
 			name:          "matches URL",
 			regexPattern:  "example\\.com",
 			expectedMatch: true,
@@ -496,6 +517,27 @@ func TestMatchesEntryRegexRules(t *testing.T) {
 				t.Errorf("matchesEntryRegexRules() valid = %v, expected %v (%s)", valid, tt.expectedValid, tt.description)
 			}
 		})
+	}
+}
+
+func TestIsBlockedEntryWithMultilineRegexRules(t *testing.T) {
+	entry := createTestEntry()
+	feed := createTestFeed()
+
+	feed.BlocklistRules = "NoMatch\nTest.*Title\n"
+	if !IsBlockedEntry(filterRules{}, filterRules{}, feed, entry) {
+		t.Errorf("IsBlockedEntry() should block entry matching a multiline blocklist regex")
+	}
+
+	feed.BlocklistRules = ""
+	feed.KeeplistRules = "NoMatch\nTest.*Title\n"
+	if IsBlockedEntry(filterRules{}, filterRules{}, feed, entry) {
+		t.Errorf("IsBlockedEntry() should keep entry matching a multiline keeplist regex")
+	}
+
+	feed.KeeplistRules = "NoMatch\nOtherNoMatch\n"
+	if !IsBlockedEntry(filterRules{}, filterRules{}, feed, entry) {
+		t.Errorf("IsBlockedEntry() should block entry when no multiline keeplist regex matches")
 	}
 }
 

--- a/internal/reader/rewrite/url_rewrite.go
+++ b/internal/reader/rewrite/url_rewrite.go
@@ -6,6 +6,7 @@ package rewrite // import "miniflux.app/v2/internal/reader/rewrite"
 import (
 	"log/slog"
 	"regexp"
+	"strings"
 
 	"miniflux.app/v2/internal/model"
 )
@@ -17,33 +18,40 @@ func RewriteEntryURL(feed *model.Feed, entry *model.Entry) string {
 		return entry.URL
 	}
 
-	var rewrittenURL = entry.URL
-	parts := customReplaceRuleRegex.FindStringSubmatch(feed.UrlRewriteRules)
+	rewrittenURL := entry.URL
 
-	if len(parts) == 3 {
-		re, err := regexp.Compile(parts[1])
-		if err != nil {
-			slog.Error("Failed on regexp compilation",
-				slog.String("url_rewrite_rules", feed.UrlRewriteRules),
-				slog.Any("error", err),
-			)
-			return rewrittenURL
+	for line := range strings.SplitSeq(strings.TrimSpace(feed.UrlRewriteRules), "\n") {
+		rule := strings.TrimSpace(line)
+		if rule == "" {
+			continue
 		}
-		rewrittenURL = re.ReplaceAllString(entry.URL, parts[2])
-		slog.Debug("Rewriting entry URL",
-			slog.String("original_entry_url", entry.URL),
-			slog.String("rewritten_entry_url", rewrittenURL),
-			slog.Int64("feed_id", feed.ID),
-			slog.String("feed_url", feed.FeedURL),
-		)
-	} else {
-		slog.Debug("Cannot find search and replace terms for replace rule",
-			slog.String("original_entry_url", entry.URL),
-			slog.String("rewritten_entry_url", rewrittenURL),
-			slog.Int64("feed_id", feed.ID),
-			slog.String("feed_url", feed.FeedURL),
-			slog.String("url_rewrite_rules", feed.UrlRewriteRules),
-		)
+
+		parts := customReplaceRuleRegex.FindStringSubmatch(rule)
+		if len(parts) == 3 {
+			re, err := regexp.Compile(parts[1])
+			if err != nil {
+				slog.Error("Failed on regexp compilation",
+					slog.String("url_rewrite_rules", rule),
+					slog.Any("error", err),
+				)
+				continue
+			}
+			rewrittenURL = re.ReplaceAllString(rewrittenURL, parts[2])
+			slog.Debug("Rewriting entry URL",
+				slog.String("original_entry_url", entry.URL),
+				slog.String("rewritten_entry_url", rewrittenURL),
+				slog.Int64("feed_id", feed.ID),
+				slog.String("feed_url", feed.FeedURL),
+			)
+		} else {
+			slog.Debug("Cannot find search and replace terms for replace rule",
+				slog.String("original_entry_url", entry.URL),
+				slog.String("rewritten_entry_url", rewrittenURL),
+				slog.Int64("feed_id", feed.ID),
+				slog.String("feed_url", feed.FeedURL),
+				slog.String("url_rewrite_rules", rule),
+			)
+		}
 	}
 
 	return rewrittenURL

--- a/internal/reader/rewrite/url_rewrite_test.go
+++ b/internal/reader/rewrite/url_rewrite_test.go
@@ -57,6 +57,33 @@ func TestRewriteEntryURL(t *testing.T) {
 			description: "Should rewrite URL according to the regex pattern",
 		},
 		{
+			name: "ValidRewriteRuleWithTrailingNewline",
+			feed: &model.Feed{
+				ID:              1,
+				FeedURL:         "https://example.com/feed.xml",
+				UrlRewriteRules: "rewrite(\"^https://example.com/article/(.+)\"|\"https://example.com/full-article/$1\")\n",
+			},
+			entry: &model.Entry{
+				URL: "https://example.com/article/123",
+			},
+			expectedURL: "https://example.com/full-article/123",
+			description: "Should tolerate trailing newlines from textarea input",
+		},
+		{
+			name: "MultipleRewriteRules",
+			feed: &model.Feed{
+				ID:      1,
+				FeedURL: "https://example.com/feed.xml",
+				UrlRewriteRules: "rewrite(\"^https://example.com/article/(.+)\"|\"https://example.com/full-article/$1\")\n" +
+					"rewrite(\"^https://example.com/story/(.+)\"|\"https://example.com/full-story/$1\")",
+			},
+			entry: &model.Entry{
+				URL: "https://example.com/story/456",
+			},
+			expectedURL: "https://example.com/full-story/456",
+			description: "Should evaluate each newline-delimited rewrite rule",
+		},
+		{
 			name: "ComplexRegexRewrite",
 			feed: &model.Feed{
 				ID:              1,

--- a/internal/reader/scraper/scraper.go
+++ b/internal/reader/scraper/scraper.go
@@ -84,11 +84,17 @@ func findContentUsingCustomRules(page io.Reader, rules string) (baseURL string, 
 	}
 
 	var buf strings.Builder
-	document.Find(rules).Each(func(i int, s *goquery.Selection) {
-		if content, err := goquery.OuterHtml(s); err == nil {
-			buf.WriteString(content)
+	for rule := range strings.SplitSeq(strings.TrimSpace(rules), "\n") {
+		rule = strings.TrimSpace(rule)
+		if rule == "" {
+			continue
 		}
-	})
+		document.Find(rule).Each(func(i int, s *goquery.Selection) {
+			if content, err := goquery.OuterHtml(s); err == nil {
+				buf.WriteString(content)
+			}
+		})
+	}
 
 	return baseURL, buf.String(), nil
 }

--- a/internal/reader/scraper/scraper_test.go
+++ b/internal/reader/scraper/scraper_test.go
@@ -78,6 +78,47 @@ func TestSelectorRules(t *testing.T) {
 	}
 }
 
+func TestSelectorRulesWithMultilineInput(t *testing.T) {
+	html := `<html><body><main><article><p>Article</p><img src="image.jpg"><iframe src="video.html"></iframe></article></main></body></html>`
+
+	_, actualResult, err := findContentUsingCustomRules(strings.NewReader(html), "article > img\narticle > iframe\n")
+	if err != nil {
+		t.Fatalf(`Scraping error: %v`, err)
+	}
+
+	expectedResult := `<img src="image.jpg"/><iframe src="video.html"></iframe>`
+	if actualResult != expectedResult {
+		t.Errorf(`Unexpected result for multiline selectors, got %q instead of %q`, actualResult, expectedResult)
+	}
+}
+
+func TestSelectorRulesPreserveExistingCSSSelectorSyntax(t *testing.T) {
+	html := `<html><body><main><article><p>Article</p><img src="image.jpg"><iframe src="video.html"></iframe></article></main></body></html>`
+
+	tests := map[string]string{
+		"comma separated selector group": `<p>Article</p><img src="image.jpg"/>`,
+		"whitespace descendant selector": `<img src="image.jpg"/>`,
+	}
+
+	rules := map[string]string{
+		"comma separated selector group": "article > p, article > img",
+		"whitespace descendant selector": "main article img",
+	}
+
+	for name, rule := range rules {
+		t.Run(name, func(t *testing.T) {
+			_, actualResult, err := findContentUsingCustomRules(strings.NewReader(html), rule)
+			if err != nil {
+				t.Fatalf(`Scraping error: %v`, err)
+			}
+
+			if actualResult != tests[name] {
+				t.Errorf(`Unexpected result for %q, got %q instead of %q`, rule, actualResult, tests[name])
+			}
+		})
+	}
+}
+
 func TestParseBaseURLWithCustomRules(t *testing.T) {
 	html := `<html><head><base href="https://example.com/"></head><body><img src="image.jpg"></body></html>`
 	baseURL, _, err := findContentUsingCustomRules(strings.NewReader(html), "img")

--- a/internal/template/templates/views/add_subscription.html
+++ b/internal/template/templates/views/add_subscription.html
@@ -71,7 +71,7 @@
                         {{ icon "external-link" }}
                     </a>
                 </div>
-                <input type="text" name="scraper_rules" id="form-scraper-rules" value="{{ .form.ScraperRules }}" spellcheck="false">
+                <textarea name="scraper_rules" id="form-scraper-rules" cols="40" rows="10" spellcheck="false">{{ .form.ScraperRules }}</textarea>
 
                 <div class="form-label-row">
                     <label for="form-rewrite-rules">
@@ -82,7 +82,7 @@
                         {{ icon "external-link" }}
                     </a>
                 </div>
-                <input type="text" name="rewrite_rules" id="form-rewrite-rules" value="{{ .form.RewriteRules }}" spellcheck="false">
+                <textarea name="rewrite_rules" id="form-rewrite-rules" cols="40" rows="10" spellcheck="false">{{ .form.RewriteRules }}</textarea>
 
                 <div class="form-label-row">
                     <label for="form-urlrewrite-rules">
@@ -93,7 +93,7 @@
                         {{ icon "external-link" }}
                     </a>
                 </div>
-                <input type="text" name="urlrewrite_rules" id="form-urlrewrite-rules" value="{{ .form.UrlRewriteRules }}" spellcheck="false">
+                <textarea name="urlrewrite_rules" id="form-urlrewrite-rules" cols="40" rows="10" spellcheck="false">{{ .form.UrlRewriteRules }}</textarea>
 
                 <div class="form-label-row">
                     <label for="form-blocklist-rules">
@@ -104,7 +104,7 @@
                         {{ icon "external-link" }}
                     </a>
                 </div>
-                <input type="text" name="blocklist_rules" id="form-blocklist-rules" value="{{ .form.BlocklistRules }}" spellcheck="false">
+                <textarea name="blocklist_rules" id="form-blocklist-rules" cols="40" rows="10" spellcheck="false">{{ .form.BlocklistRules }}</textarea>
 
                 <div class="form-label-row">
                     <label for="form-keeplist-rules">
@@ -115,7 +115,7 @@
                         {{ icon "external-link" }}
                     </a>
                 </div>
-                <input type="text" name="keeplist_rules" id="form-keeplist-rules" value="{{ .form.KeeplistRules }}" spellcheck="false">
+                <textarea name="keeplist_rules" id="form-keeplist-rules" cols="40" rows="10" spellcheck="false">{{ .form.KeeplistRules }}</textarea>
 
                 <div class="form-label-row">
                     <label for="form-block-filter-rules">

--- a/internal/template/templates/views/edit_feed.html
+++ b/internal/template/templates/views/edit_feed.html
@@ -129,7 +129,7 @@
                     {{ icon "external-link" }}
                 </a>
             </div>
-            <input type="text" name="scraper_rules" id="form-scraper-rules" value="{{ .form.ScraperRules }}" spellcheck="false">
+            <textarea name="scraper_rules" id="form-scraper-rules" cols="40" rows="10" spellcheck="false">{{ .form.ScraperRules }}</textarea>
 
             <div class="form-label-row">
                 <label for="form-rewrite-rules">
@@ -140,7 +140,7 @@
                     {{ icon "external-link" }}
                 </a>
             </div>
-            <input type="text" name="rewrite_rules" id="form-rewrite-rules" value="{{ .form.RewriteRules }}" spellcheck="false">
+            <textarea name="rewrite_rules" id="form-rewrite-rules" cols="40" rows="10" spellcheck="false">{{ .form.RewriteRules }}</textarea>
 
             <div class="form-label-row">
                 <label for="form-urlrewrite-rules">
@@ -151,7 +151,7 @@
                     {{ icon "external-link" }}
                 </a>
             </div>
-            <input type="text" name="urlrewrite_rules" id="form-urlrewrite-rules" value="{{ .form.UrlRewriteRules }}" spellcheck="false">
+            <textarea name="urlrewrite_rules" id="form-urlrewrite-rules" cols="40" rows="10" spellcheck="false">{{ .form.UrlRewriteRules }}</textarea>
 
             <div class="form-label-row">
                 <label for="form-blocklist-rules">
@@ -162,7 +162,7 @@
                     {{ icon "external-link" }}
                 </a>
             </div>
-            <input type="text" name="blocklist_rules" id="form-blocklist-rules" value="{{ .form.BlocklistRules }}" spellcheck="false">
+            <textarea name="blocklist_rules" id="form-blocklist-rules" cols="40" rows="10" spellcheck="false">{{ .form.BlocklistRules }}</textarea>
 
             <div class="form-label-row">
                 <label for="form-keeplist-rules">
@@ -173,7 +173,7 @@
                     {{ icon "external-link" }}
                 </a>
             </div>
-            <input type="text" name="keeplist_rules" id="form-keeplist-rules" value="{{ .form.KeeplistRules }}" spellcheck="false">
+            <textarea name="keeplist_rules" id="form-keeplist-rules" cols="40" rows="10" spellcheck="false">{{ .form.KeeplistRules }}</textarea>
 
             <div class="form-label-row">
                 <label for="form-block-filter-rules">


### PR DESCRIPTION
It is valid to use multiple rules for feed processing, and textarea  with multiline support is more suitable for display/editing, than single-lined input. All rules properly handle whitespaces and newlines, so there is no regression.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
