### PR TITLE
feat(ui): add previous/next entry navigation to the actions toolbar

### DIFF
--- a/internal/template/templates/common/pagination.html
+++ b/internal/template/templates/common/pagination.html
@@ -39,3 +39,34 @@
     </div>
 </div>
 {{ end }}
+
+{{ define "pagination_header" }}
+<li>
+    {{ if .ShowFirst }}
+        <a class="page-button" href="{{ .Route }}{{ queryString (dict "offset" .FirstOffset "q" .SearchQuery "unread" .UnreadOnly) }}" data-page="first">{{ icon "chevrons-left" }}<span class="icon-label">{{ t "pagination.first" }}</span></a>
+    {{ else }}
+        <a class="page-button" aria-disabled="true" tabindex="-1">{{ icon "chevrons-left" }}<span class="icon-label">{{ t "pagination.first" }}</span></a>
+    {{ end }}
+</li>
+<li>
+    {{ if .ShowPrev }}
+        <a class="page-button" href="{{ .Route }}{{ queryString (dict "offset" .PrevOffset "q" .SearchQuery "unread" .UnreadOnly) }}" data-page="previous" rel="prev">{{ icon "chevron-left" }}<span class="icon-label">{{ t "pagination.previous" }}</span></a>
+    {{ else }}
+        <a class="page-button" aria-disabled="true" tabindex="-1">{{ icon "chevron-left" }}<span class="icon-label">{{ t "pagination.previous" }}</span></a>
+    {{ end }}
+</li>
+<li>
+    {{ if .ShowNext }}
+        <a class="page-button" href="{{ .Route }}{{ queryString (dict "offset" .NextOffset "q" .SearchQuery "unread" .UnreadOnly) }}" data-page="next" rel="next">{{ icon "chevron-right" }}<span class="icon-label">{{ t "pagination.next" }}</span></a>
+    {{ else }}
+        <a class="page-button" aria-disabled="true" tabindex="-1">{{ icon "chevron-right" }}<span class="icon-label">{{ t "pagination.next" }}</span></a>
+    {{ end }}
+</li>
+<li>
+    {{ if .ShowLast }}
+        <a class="page-button" href="{{ .Route }}{{ queryString (dict "offset" .LastOffset "q" .SearchQuery "unread" .UnreadOnly) }}" data-page="last">{{ icon "chevrons-right" }}<span class="icon-label">{{ t "pagination.last" }}</span></a>
+    {{ else }}
+        <a class="page-button" aria-disabled="true" tabindex="-1">{{ icon "chevrons-right" }}<span class="icon-label">{{ t "pagination.last" }}</span></a>
+    {{ end }}
+</li>
+{{ end }}

--- a/internal/template/templates/views/category_entries.html
+++ b/internal/template/templates/views/category_entries.html
@@ -72,6 +72,9 @@
                     </button>
                 </form>
             </li>
+            {{ if .entries }}
+            {{ template "pagination_header" .pagination }}
+            {{ end }}
         </ul>
     </nav>
 </section>
@@ -81,9 +84,6 @@
 {{ if not .entries }}
     <p role="alert" class="alert">{{ t "alert.no_category_entry" }}</p>
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination }}
-    </div>
     <div class="items">
         {{ range .entries }}
         <article

--- a/internal/template/templates/views/entry.html
+++ b/internal/template/templates/views/entry.html
@@ -135,6 +135,20 @@
                         >{{ icon "comment" }}<span class="icon-label">{{ t "entry.comments.label" }}</span></a>
                 </li>
                 {{ end }}
+                <li>
+                    {{ if .prevEntry }}
+                    <a href="{{ .prevEntryRoute }}{{ queryString (dict "q" .searchQuery "unread" .searchUnreadOnly) }}" title="{{ .prevEntry.Title }}" class="page-button" data-page="previous" rel="prev">{{ icon "chevron-left" }}<span class="icon-label">{{ t "pagination.previous" }}</span></a>
+                    {{ else }}
+                    <a class="page-button" aria-disabled="true" tabindex="-1">{{ icon "chevron-left" }}<span class="icon-label">{{ t "pagination.previous" }}</span></a>
+                    {{ end }}
+                </li>
+                <li>
+                    {{ if .nextEntry }}
+                    <a href="{{ .nextEntryRoute }}{{ queryString (dict "q" .searchQuery "unread" .searchUnreadOnly) }}" title="{{ .nextEntry.Title }}" class="page-button" data-page="next" rel="next">{{ icon "chevron-right" }}<span class="icon-label">{{ t "pagination.next" }}</span></a>
+                    {{ else }}
+                    <a class="page-button" aria-disabled="true" tabindex="-1">{{ icon "chevron-right" }}<span class="icon-label">{{ t "pagination.next" }}</span></a>
+                    {{ end }}
+                </li>
             </ul>
         </div>
         {{ end }}
@@ -229,13 +243,6 @@
 
 
 {{ define "content"}}
-{{ if gt (len .entry.Content) 120 }}
-{{ if .user }}
-<div class="pagination-entry-top">
-    {{ template "entry_pagination" . }}
-</div>
-{{ end }}
-{{ end }}
 <article class="entry-content {{ if ne $.user.GestureNav "none" }}gesture-nav-{{ $.user.GestureNav }}{{ end }}" dir="auto">
     {{ if not .entry.Feed.NoMediaPlayer }}
         {{ $mediaPlayerEnclosure := .entry.Enclosures.FindMediaPlayerEnclosure }}

--- a/internal/template/templates/views/feed_entries.html
+++ b/internal/template/templates/views/feed_entries.html
@@ -72,6 +72,9 @@
                     data-url="{{ routePath "/feed/%d/remove" .feed.ID }}"
                     data-redirect-url="{{ routePath "/feeds" }}">{{ icon "delete" }}{{ t "action.remove_feed" }}</button>
             </li>
+            {{ if .entries }}
+            {{ template "pagination_header" .pagination }}
+            {{ end }}
         </ul>
     </nav>
 </section>
@@ -92,9 +95,6 @@
         <p role="alert" class="alert">{{ t "alert.no_feed_entry" }}</p>
     {{ end }}
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination }}
-    </div>
     <div class="items">
         {{ range .entries }}
         <article

--- a/internal/template/templates/views/history_entries.html
+++ b/internal/template/templates/views/history_entries.html
@@ -24,6 +24,9 @@
             <li>
                 <a class="page-link" href="{{ routePath "/shares" }}">{{ icon "share" }}{{ t "menu.shared_entries" }}</a>
             </li>
+            {{ if .entries }}
+            {{ template "pagination_header" .pagination }}
+            {{ end }}
         </ul>
     </nav>
 </section>
@@ -33,9 +36,6 @@
 {{ if not .entries }}
     <p role="alert" class="alert alert-info">{{ t "alert.no_history" }}</p>
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination }}
-    </div>
     <div class="items">
         {{ range .entries }}
         <article

--- a/internal/template/templates/views/search.html
+++ b/internal/template/templates/views/search.html
@@ -3,6 +3,13 @@
 {{ define "page_header"}}
 <section class="page-header" aria-labelledby="page-header-title">
     <h1 id="page-header-title">{{ t "page.search.title" }} ({{ .total }})</h1>
+    {{ if and $.searchQuery .entries }}
+    <nav aria-label="{{ t "page.search.title" }} {{ t "menu.title" }}">
+        <ul>
+            {{ template "pagination_header" .pagination }}
+        </ul>
+    </nav>
+    {{ end }}
 </section>
 {{ end }}
 
@@ -21,9 +28,6 @@
     {{ if not .entries }}
         <p role="alert" class="alert alert-info">{{ t "alert.no_search_result" }}</p>
     {{ else }}
-        <div class="pagination-top">
-            {{ template "pagination" .pagination }}
-        </div>
         <div class="items">
             {{ range .entries }}
             <article

--- a/internal/template/templates/views/shared_entries.html
+++ b/internal/template/templates/views/shared_entries.html
@@ -23,6 +23,7 @@
             <li>
                 <a class="page-link" href="{{ routePath "/shares" }}">{{ icon "share" }}{{ t "menu.shared_entries" }}</a>
             </li>
+            {{ template "pagination_header" .pagination }}
         </ul>
     </nav>
     {{ end }}
@@ -33,9 +34,6 @@
 {{ if not .entries }}
     <p role="alert" class="alert alert-info">{{ t "alert.no_shared_entry" }}</p>
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination }}
-    </div>
     <div class="items">
         {{ range .entries }}
         <article

--- a/internal/template/templates/views/starred_entries.html
+++ b/internal/template/templates/views/starred_entries.html
@@ -7,6 +7,13 @@
         <span aria-hidden="true"> ({{ .total }})</span>
     </h1>
     <span id="page-header-title-count" class="sr-only">{{ plural "page.starred_entry_count" .total .total }}</span>
+    {{ if .entries }}
+    <nav aria-label="{{ t "page.starred.title" }} {{ t "menu.title" }}">
+        <ul>
+            {{ template "pagination_header" .pagination }}
+        </ul>
+    </nav>
+    {{ end }}
 </section>
 {{ end }}
 
@@ -14,9 +21,6 @@
 {{ if not .entries }}
     <p role="alert" class="alert alert-info">{{ t "alert.no_starred" }}</p>
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination }}
-    </div>
     <div class="items">
         {{ range .entries }}
         <article

--- a/internal/template/templates/views/tag_entries.html
+++ b/internal/template/templates/views/tag_entries.html
@@ -7,6 +7,13 @@
         <span aria-hidden="true"> ({{ .total }})</span>
     </h1>
     <span id="page-header-title-count" class="sr-only">{{ plural "page.tag_entry_count" .total .total }}</span>
+    {{ if .entries }}
+    <nav aria-label="{{ .tagName }} {{ t "menu.title" }}">
+        <ul>
+            {{ template "pagination_header" .pagination }}
+        </ul>
+    </nav>
+    {{ end }}
 </section>
 {{ end }}
 
@@ -14,9 +21,6 @@
 {{ if not .entries }}
     <p role="alert" class="alert alert-info">{{ t "alert.no_tag_entry" }}</p>
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination }}
-    </div>
     <div class="items">
         {{ range .entries }}
         <article

--- a/internal/template/templates/views/unread_entries.html
+++ b/internal/template/templates/views/unread_entries.html
@@ -31,6 +31,7 @@
                     data-label-no="{{ t "confirm.no" }}"
                     data-label-loading="{{ t "confirm.loading" }}">{{ icon "mark-all-as-read" }}{{ t "menu.mark_all_as_read" }}</button>
             </li>
+            {{ template "pagination_header" .pagination }}
         </ul>
     </nav>
     {{ end }}
@@ -41,9 +42,6 @@
 {{ if not .entries }}
     <p role="alert" class="alert">{{ t "alert.no_unread_entry" }}</p>
 {{ else }}
-    <div class="pagination-top">
-        {{ template "pagination" .pagination -}}
-    </div>
     <div class="items hide-read-items">
         {{ range .entries -}}
         <article

--- a/internal/ui/static/bin/sprite.svg
+++ b/internal/ui/static/bin/sprite.svg
@@ -12,9 +12,19 @@ Source: https://github.com/tabler/tabler-icons
         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
         <path d="M15 6l-6 6l6 6"/>
     </symbol>
+    <symbol id="icon-chevrons-left" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M11 7l-5 5l5 5"/>
+        <path d="M17 7l-5 5l5 5"/>
+    </symbol>
     <symbol id="icon-chevron-right" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
         <path d="M9 6l6 6l-6 6"/>
+    </symbol>
+    <symbol id="icon-chevrons-right" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M7 7l5 5l-5 5"/>
+        <path d="M13 7l5 5l-5 5"/>
     </symbol>
     <symbol id="icon-read" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z"/>

--- a/internal/ui/static/bin/sprite.svg
+++ b/internal/ui/static/bin/sprite.svg
@@ -8,6 +8,14 @@ Source: https://github.com/tabler/tabler-icons
         <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
         <path d="M6 9l6 6l6 -6"/>
     </symbol>
+    <symbol id="icon-chevron-left" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M15 6l-6 6l6 6"/>
+    </symbol>
+    <symbol id="icon-chevron-right" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M9 6l6 6l-6 6"/>
+    </symbol>
     <symbol id="icon-read" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z"/>
         <circle cx="12" cy="12" r="9"/>

--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -212,6 +212,13 @@ a:hover {
     translate: 1px 1px;
 }
 
+.page-button[aria-disabled="true"] {
+    color: var(--text-color-muted, #ccc);
+    cursor: default;
+    opacity: 0.4;
+    pointer-events: none;
+}
+
 /* Logo */
 .logo {
     text-align: center;

--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -187,9 +187,14 @@ a:hover {
     white-space: nowrap;
 }
 
-#header-menu .icon,
-.page-header ul a .icon {
+#header-menu .icon {
     margin-bottom: 2px;
+}
+
+.page-header ul .icon,
+.page-header ul .icon-label {
+    vertical-align: middle;
+    margin-bottom: 0;
 }
 
 .page-header-action-form {
@@ -1019,6 +1024,7 @@ article.category-has-unread {
     line-height: 1.7em;
 }
 
+.entry-actions .icon,
 .entry-actions .icon-label {
     vertical-align: middle;
 }


### PR DESCRIPTION
Move the previous/next entry navigation controls from the separate pagination block into the entry actions toolbar.

Use chevron-left and chevron-right SVG icons (added to the sprite) for horizontal navigation, matching the visual style of existing toolbar buttons. Inactive controls (no previous/next entry) render as disabled buttons with reduced opacity.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
