### PR TITLE
feat(ui): replace confirm inline input with html dialog

### DIFF
--- a/internal/template/functions_test.go
+++ b/internal/template/functions_test.go
@@ -272,6 +272,26 @@ func TestQueryString(t *testing.T) {
 	}
 }
 
+func TestConfirmationModalDefaultsToCancelAction(t *testing.T) {
+	contents, err := commonTemplateFiles.ReadFile("templates/common/layout.html")
+	if err != nil {
+		t.Fatalf(`Unable to read layout template: %v`, err)
+	}
+
+	layout := string(contents)
+	if !strings.Contains(layout, `<dialog id="confirmation-modal">`) {
+		t.Fatal(`The confirmation modal should be present in the base layout`)
+	}
+
+	if !strings.Contains(layout, `<button value="no" id="confirmation-modal-no" class="button" autofocus>`) {
+		t.Fatal(`The confirmation modal should focus the cancel action by default`)
+	}
+
+	if strings.Contains(layout, `<button value="yes" id="confirmation-modal-yes" class="button button-primary" autofocus>`) {
+		t.Fatal(`The confirmation modal should not focus the confirm action by default`)
+	}
+}
+
 func TestCSPExternalFont(t *testing.T) {
 	want := []string{
 		`default-src 'none';`,

--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -185,6 +185,15 @@
             </ul>
         </div>
     </dialog>
+    <dialog id="confirmation-modal">
+        <form method="dialog">
+            <p id="confirmation-modal-question"></p>
+            <div class="confirmation-modal-actions">
+                <button value="yes" id="confirmation-modal-yes" class="button button-primary"></button>
+                <button value="no" id="confirmation-modal-no" class="button" autofocus></button>
+            </div>
+        </form>
+    </dialog>
 
     <template id="icon-read">{{ icon "read" }}</template>
     <template id="icon-unread">{{ icon "unread" }}</template>

--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -675,10 +675,18 @@ template {
 }
 
 dialog {
-    max-height: none;
-    height: 100vh;
+    box-sizing: border-box;
+    inline-size: fit-content;
+    max-inline-size: calc(100vw - 2rem);
+    max-block-size: 80vh;
     border: none;
-    padding: 1%;
+    margin: 10vh auto auto;
+    padding: 1rem;
+    overflow: auto;
+}
+
+dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 .btn-close-modal {
@@ -1291,18 +1299,16 @@ details.entry-enclosures {
     word-wrap: break-word;
 }
 
-/* Confirmation */
-.confirm {
+#confirmation-modal-question {
+    margin: 0 0 0.75rem;
     font-weight: 500;
-    color: #ed2d04;
+    text-align: center;
 }
 
-.confirm button {
-    color: #ed2d04;
-    border: none;
-    background-color: transparent;
-    cursor: pointer;
-    font-size: inherit;
+.confirmation-modal-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
 }
 
 .loading {

--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -901,68 +901,53 @@ function updateUnreadCounterValue(delta) {
 }
 
 /**
- * Handle confirmation messages for actions that require user confirmation.
+ * Handle confirmation dialogs for actions that require user confirmation.
  *
- * This function modifies the link element to show a confirmation question with "Yes" and "No" buttons.
  * If the user clicks "Yes", it calls the provided callback with the URL and redirect URL.
- * If the user clicks "No", it either redirects to a no-action URL or restores the link element.
+ * If the user clicks "No", it either redirects to a no-action URL or cancels the action.
  *
  * @param {Element} linkElement - The link or button element that triggered the confirmation.
  * @param {function} callback - The callback function to execute if the user confirms the action.
  * @returns {void}
  */
 function handleConfirmationMessage(linkElement, callback) {
-    if (linkElement.tagName !== 'A' && linkElement.tagName !== "BUTTON") {
-        linkElement = linkElement.parentNode;
-    }
-
-    linkElement.style.display = "none";
-
-    const containerElement = linkElement.parentNode;
-    const questionElement = document.createElement("span");
+    linkElement = linkElement.closest("a, button");
+    if (!linkElement) return;
 
     function createLoadingElement() {
         const loadingElement = document.createElement("span");
         loadingElement.className = "loading";
         loadingElement.appendChild(document.createTextNode(linkElement.dataset.labelLoading));
 
-        questionElement.remove();
-        containerElement.appendChild(loadingElement);
+        linkElement.style.display = "none";
+        linkElement.parentNode.appendChild(loadingElement);
     }
 
-    const yesElement = document.createElement("button");
-    yesElement.appendChild(document.createTextNode(linkElement.dataset.labelYes));
-    yesElement.onclick = (event) => {
-        event.preventDefault();
+    const dialogElement = document.getElementById("confirmation-modal");
+    const questionElement = document.getElementById("confirmation-modal-question");
+    const yesElement = document.getElementById("confirmation-modal-yes");
+    const noElement = document.getElementById("confirmation-modal-no");
 
-        createLoadingElement();
+    questionElement.textContent = linkElement.dataset.labelQuestion;
+    yesElement.textContent = linkElement.dataset.labelYes;
+    noElement.textContent = linkElement.dataset.labelNo;
+    dialogElement.returnValue = "";
 
-        callback(linkElement.dataset.url, linkElement.dataset.redirectUrl);
-    };
-
-    const noElement = document.createElement("button");
-    noElement.appendChild(document.createTextNode(linkElement.dataset.labelNo));
-    noElement.onclick = (event) => {
-        event.preventDefault();
-
-        const noActionUrl = linkElement.dataset.noActionUrl;
-        if (noActionUrl) {
+    dialogElement.onclose = () => {
+        dialogElement.onclose = null;
+        if (dialogElement.returnValue === "yes") {
             createLoadingElement();
+            callback(linkElement.dataset.url, linkElement.dataset.redirectUrl);
+            return;
+        }
 
-            callback(noActionUrl, linkElement.dataset.redirectUrl);
-        } else {
-            linkElement.style.display = "inline";
-            questionElement.remove();
+        if (dialogElement.returnValue === "no" && linkElement.dataset.noActionUrl) {
+            createLoadingElement();
+            callback(linkElement.dataset.noActionUrl, linkElement.dataset.redirectUrl);
         }
     };
 
-    questionElement.className = "confirm";
-    questionElement.appendChild(document.createTextNode(`${linkElement.dataset.labelQuestion} `));
-    questionElement.appendChild(yesElement);
-    questionElement.appendChild(document.createTextNode(", "));
-    questionElement.appendChild(noElement);
-
-    containerElement.appendChild(questionElement);
+    dialogElement.showModal();
 }
 
 /**


### PR DESCRIPTION
This PR replaces all usages of inline confirm with [native HTML dialog element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) - it is widely supported, so there shouldn't be any regression. 

|||
|-|-|
| <img width="1065" height="492" alt="Zrzut ekranu 2026-04-30 o 17 10 25" src="https://github.com/user-attachments/assets/48e94d5b-e9bb-4d76-8b2e-684f7018a791" /> | <img width="487" height="538" alt="Zrzut ekranu 2026-04-30 o 17 11 25" src="https://github.com/user-attachments/assets/7b22eff4-876b-48a9-8027-0d8b0fd18d03" /> |
| <img width="1060" height="384" alt="Zrzut ekranu 2026-04-30 o 17 11 13" src="https://github.com/user-attachments/assets/23eae0ed-ba78-4ff4-80c5-76f2bdd556f8" /> | <img width="494" height="470" alt="Zrzut ekranu 2026-04-30 o 17 11 30" src="https://github.com/user-attachments/assets/d5ed227e-8f0f-47bb-aaf9-3e50dca4e531" /> |

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
