### PR TITLE
fix(googlereader): fix incorrect read/starred toggling

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -254,7 +254,7 @@ func (h *greaderHandler) editTagHandler(w http.ResponseWriter, r *http.Request) 
 		if read, exists := tags[ReadStream]; exists {
 			if read && entry.Status == model.EntryStatusUnread {
 				readEntryIDs = append(readEntryIDs, entry.ID)
-			} else if entry.Status == model.EntryStatusRead {
+			} else if !read && entry.Status == model.EntryStatusRead {
 				unreadEntryIDs = append(unreadEntryIDs, entry.ID)
 			}
 		}
@@ -264,7 +264,7 @@ func (h *greaderHandler) editTagHandler(w http.ResponseWriter, r *http.Request) 
 				// filter the original array
 				entries[n] = entry
 				n++
-			} else if entry.Starred {
+			} else if !starred && entry.Starred {
 				unstarredEntryIDs = append(unstarredEntryIDs, entry.ID)
 			}
 		}


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

## Problem

When using the Google Reader API to mark an entry as read or starred, if the entry was already in the target state, the handler would incorrectly toggle it to the opposite state instead of leaving it unchanged.

For example, calling the API to mark an already-read entry as read would result in it being marked as unread.

The root cause is a missing `!read` (and `!starred`) guard in the `else if` branch:

```go
// Before (buggy)
if read && entry.Status == model.EntryStatusUnread {
    readEntryIDs = append(readEntryIDs, entry.ID)
} else if entry.Status == model.EntryStatusRead {
    unreadEntryIDs = append(unreadEntryIDs, entry.ID)
}

// After (fixed)
if read && entry.Status == model.EntryStatusUnread {
    readEntryIDs = append(readEntryIDs, entry.ID)
} else if !read && entry.Status == model.EntryStatusRead {
    unreadEntryIDs = append(unreadEntryIDs, entry.ID)
}
```

Without the `!read` check, the condition only tests the *current* state of the entry, not whether the *requested* state differs from it, causing idempotent API calls to have unintended side effects.

## Changes

- Fix `read` state toggling: add `!read` guard to the `else if` branch
  in the stream tag handler so that already-read entries are not
  re-queued as unread.
- Apply the same fix to the `starred` state handler for consistency.

## Example

- Miniflux version: commit 45e2226
- Client: [Read You](https://github.com/ReadYouApp/ReadYou) 0.16.1

When clicking "Mark all as read" in Read You to mark at least one articles as read, Read You tries to mark every article as read, including read articles. 

Experiment steps:
1. Every article is read initially
2. Mark some articles as unread
3. Mark all articles as read
4. Check if any article becomes unread again

### Before Change

Unread articles are marked as read, but read articles become unread again.

https://github.com/user-attachments/assets/01b48be3-8f36-4fb7-93af-e5200962ef70

## After Change

All articles become read.

https://github.com/user-attachments/assets/d8d49667-67a5-4417-8e37-cc16de216468
