### PR TITLE
feat(sanitizer): speed up TruncateHTML by a lot

### DIFF
--- a/internal/reader/sanitizer/strip_tags.go
+++ b/internal/reader/sanitizer/strip_tags.go
@@ -14,22 +14,39 @@ import (
 // StripTags removes all HTML/XML tags from the input string.
 // This function must *only* be used for cosmetic purposes, not to prevent code injections like XSS.
 func StripTags(input string) string {
-	tokenizer := html.NewTokenizer(strings.NewReader(input))
-	var buffer strings.Builder
+	dst := &strings.Builder{}
+	src := strings.NewReader(input)
 
-	for {
-		if tokenizer.Next() == html.ErrorToken {
-			err := tokenizer.Err()
-			if errors.Is(err, io.EOF) {
-				return buffer.String()
-			}
+	err := stripIter(src, func(text string) bool {
+		dst.WriteString(text)
+		return true
+	})
+	if err != nil {
+		return ""
+	}
 
-			return ""
+	return dst.String()
+}
+
+// stripIter iterates over the input [io.Reader] and calls the yield function for each [html.TextToken].
+// Other kinds of [html.TokenType] are skipped.
+func stripIter(src io.Reader, yield func(string) bool) error {
+	tokenizer := html.NewTokenizer(src)
+
+	for tokenizer.Next() != html.ErrorToken {
+		token := tokenizer.Token()
+		if token.Type != html.TextToken {
+			continue
 		}
 
-		token := tokenizer.Token()
-		if token.Type == html.TextToken {
-			buffer.WriteString(token.Data)
+		if !yield(token.Data) {
+			break
 		}
 	}
+
+	if err := tokenizer.Err(); !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
 }

--- a/internal/reader/sanitizer/truncate.go
+++ b/internal/reader/sanitizer/truncate.go
@@ -3,19 +3,86 @@
 
 package sanitizer
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
 
-func TruncateHTML(input string, max int) string {
-	text := StripTags(input)
+// TruncateHTML returns cleaned up and shortened version of input.
+//   - HTML tags are removed
+//   - Consecutive whitespace characters replaced with single SPACE (0x20) character
+//   - If input has more runes than limit, it's truncated
+func TruncateHTML(input string, limit int) string {
+	dst := &strings.Builder{}
+	src := strings.NewReader(input)
 
-	// Collapse multiple spaces into a single space
-	text = strings.Join(strings.Fields(text), " ")
+	words := 0
+	count := 0
+	needspace := false
 
-	// Convert to runes to be safe with unicode
-	runes := []rune(text)
-	if len(runes) > max {
-		return strings.TrimSpace(string(runes[:max])) + "…"
+	err := stripIter(src, func(token string) bool {
+		// Skip leading space.
+		if words > 0 {
+			// Add a space between tokens if there's one before HTML tag.
+			r, _ := utf8.DecodeRuneInString(token)
+			needspace = needspace || unicode.IsSpace(r)
+		}
+
+		for word := range strings.FieldsSeq(token) {
+			if needspace {
+				if count += 1; count > limit {
+					return false
+				}
+			}
+
+			// Compute how much of the word we can use later.
+			wordlen := 0
+			for wordlen < len(word) {
+				if count += 1; count > limit {
+					break
+				}
+
+				r, w := utf8.DecodeRuneInString(word[wordlen:])
+				if r == utf8.RuneError {
+					wordlen += 1
+					continue
+				}
+
+				wordlen += w
+			}
+
+			// This is the only place where space being placed.
+			// That way any sequence of space characters ends up as a singular SPACE (0x20) character.
+			//
+			// wordlen > 0 skips spaces if no printable characters left.
+			if needspace && wordlen > 0 {
+				dst.WriteByte(' ')
+			}
+
+			dst.WriteString(word[:wordlen])
+
+			if count > limit {
+				return false
+			}
+
+			needspace = true // To insert spaces in-between words in a token.
+			words++
+		}
+
+		// Add a space between tokens if there's one after HTML tag.
+		r, _ := utf8.DecodeLastRuneInString(token)
+		needspace = unicode.IsSpace(r) && words > 0
+
+		return true
+	})
+	if err != nil {
+		return ""
 	}
 
-	return text
+	if count > limit {
+		dst.WriteRune('…')
+	}
+
+	return dst.String()
 }

--- a/internal/reader/sanitizer/truncate_test.go
+++ b/internal/reader/sanitizer/truncate_test.go
@@ -5,71 +5,43 @@ package sanitizer
 
 import "testing"
 
-func TestTruncateHTMWithTextLowerThanLimitL(t *testing.T) {
-	input := `This is a <strong>bug 🐛</strong>.`
-	expected := `This is a bug 🐛.`
-	output := TruncateHTML(input, 50)
-
-	if expected != output {
-		t.Errorf(`Wrong output: %q != %q`, expected, output)
-	}
-}
-
-func TestTruncateHTMLWithTextAboveLimit(t *testing.T) {
-	input := `This is <strong>HTML</strong>.`
-	expected := `This…`
-	output := TruncateHTML(input, 4)
-
-	if expected != output {
-		t.Errorf(`Wrong output: %q != %q`, expected, output)
-	}
-}
-
-func TestTruncateHTMLWithUnicodeTextAboveLimit(t *testing.T) {
-	input := `This is a <strong>bike 🚲</strong>.`
-	expected := `This…`
-	output := TruncateHTML(input, 4)
-
-	if expected != output {
-		t.Errorf(`Wrong output: %q != %q`, expected, output)
-	}
-}
-
-func TestTruncateHTMLWithMultilineTextAboveLimit(t *testing.T) {
-	input := `
-		This is a <strong>bike
-		🚲</strong>.
-
-	`
-	expected := `This is a bike…`
-	output := TruncateHTML(input, 15)
-
-	if expected != output {
-		t.Errorf(`Wrong output: %q != %q`, expected, output)
-	}
-}
-
-func TestTruncateHTMLWithMultilineTextLowerThanLimit(t *testing.T) {
-	input := `
-		This is a <strong>bike
- 🚲</strong>.
-
-	`
-	expected := `This is a bike 🚲.`
-	output := TruncateHTML(input, 20)
-
-	if expected != output {
-		t.Errorf(`Wrong output: %q != %q`, expected, output)
-	}
-}
-
-func TestTruncateHTMLWithMultipleSpaces(t *testing.T) {
+func TestTruncateHTML(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
 		maxLen   int
 		expected string
 	}{
+		{
+			name:     "text lower than limit",
+			input:    "This is a <strong>bug 🐛</strong>.",
+			maxLen:   50,
+			expected: "This is a bug 🐛.",
+		},
+		{
+			name:     "text above limit",
+			input:    "This is <strong>HTML</strong>.",
+			maxLen:   4,
+			expected: "This…",
+		},
+		{
+			name:     "unicode text above limit",
+			input:    "This is a <strong>bike 🚲</strong>.",
+			maxLen:   4,
+			expected: "This…",
+		},
+		{
+			name:     "multiline text above limit",
+			input:    "\n\t\tThis is a <strong>bike\n\t\t🚲</strong>.\n\n\t",
+			maxLen:   15,
+			expected: "This is a bike…",
+		},
+		{
+			name:     "multiline text lower than limit",
+			input:    "\n\t\tThis is a <strong>bike\n 🚲</strong>.\n\n\t",
+			maxLen:   20,
+			expected: "This is a bike 🚲.",
+		},
 		{
 			name:     "multiple spaces",
 			input:    "hello    world   test",

--- a/internal/reader/sanitizer/truncate_test.go
+++ b/internal/reader/sanitizer/truncate_test.go
@@ -76,6 +76,72 @@ func TestTruncateHTML(t *testing.T) {
 			maxLen:   20,
 			expected: "hello world",
 		},
+		{
+			name:     "just enough characters",
+			input:    "Hello",
+			maxLen:   5,
+			expected: "Hello",
+		},
+		{
+			name:     "just enough unicode characters",
+			input:    "Привет",
+			maxLen:   6,
+			expected: "Привет",
+		},
+		{
+			name:     "spaces around tag",
+			input:    "hello <br/> world",
+			maxLen:   20,
+			expected: "hello world",
+		},
+		{
+			name:     "leading spaces",
+			input:    "  hello world",
+			maxLen:   5,
+			expected: "hello…",
+		},
+		{
+			name:     "text above limit with space at the end",
+			input:    "hello world",
+			maxLen:   6,
+			expected: "hello…",
+		},
+		{
+			name:     "leading space before tag",
+			input:    " <a>hello</a>",
+			maxLen:   15,
+			expected: "hello",
+		},
+		{
+			name:     "space-only tokens in between tags",
+			input:    "hello <br/>\t<a> </a>world",
+			maxLen:   15,
+			expected: "hello world",
+		},
+		{
+			name:     "truncate mid-word",
+			input:    "hello world",
+			maxLen:   8,
+			expected: "hello wo…",
+		},
+		{
+			name:     "truncate mid-word with unicode",
+			input:    "Съешь ещё этих мягких французских булок, да выпей же чаю",
+			maxLen:   25,
+			expected: "Съешь ещё этих мягких фра…",
+		},
+		{
+			name:     "negative limit",
+			input:    "whatever",
+			maxLen:   -10,
+			expected: "…",
+		},
+		{
+			name:     "zero limit",
+			input:    "whatever",
+			maxLen:   0,
+			expected: "…",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/reader/sanitizer/truncate_test.go
+++ b/internal/reader/sanitizer/truncate_test.go
@@ -3,7 +3,11 @@
 
 package sanitizer
 
-import "testing"
+import (
+	"os"
+	"strconv"
+	"testing"
+)
 
 func TestTruncateHTML(t *testing.T) {
 	tests := []struct {
@@ -81,6 +85,48 @@ func TestTruncateHTML(t *testing.T) {
 				t.Errorf("TruncateHTML(%q, %d) = %q, want %q",
 					tt.input, tt.maxLen, result, tt.expected)
 			}
+		})
+	}
+}
+
+func BenchmarkTruncateHTML(b *testing.B) {
+	benches := []struct {
+		filename string
+		limit    int
+	}{
+		{
+			filename: "miniflux_github.html",
+			limit:    100,
+		},
+		{
+			filename: "miniflux_github.html",
+			limit:    10_000,
+		},
+		{
+			filename: "miniflux_wikipedia.html",
+			limit:    100,
+		},
+		{
+			filename: "miniflux_wikipedia.html",
+			limit:    100_000,
+		},
+	}
+
+	for _, f := range benches {
+		data, err := os.ReadFile("testdata/" + f.filename)
+		if err != nil {
+			b.Fatalf(`Unable to read file %q: %v`, f.filename, err)
+		}
+
+		b.Run(f.filename+"_"+strconv.Itoa(f.limit), func(b *testing.B) {
+			var junk string
+
+			str := string(data)
+			for b.Loop() {
+				junk = TruncateHTML(str, 100)
+			}
+
+			_ = junk
 		})
 	}
 }


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

---

`TruncateHTML` now reads *all* content, handles HTML semantics and just throws everything after first 100 bytes.

Not to mention `string` > `[]rune` > `string` conversion.

With a bit more sane approach only beginning is parsed and no allocation for `string <> []rune` conversion is being made. Not allocating `[]string` for join either as you can just write content as is.

From my micro-benchmark using existing github/wikipedia HTML files you can see some significant improvements:
```
name                                           old time/op    new time/op    delta
TruncateHTML/miniflux_github.html_100-8          3.02ms ± 2%    0.03ms ± 2%  -98.91%  (p=0.000 n=9+9)
TruncateHTML/miniflux_github.html_10000-8        3.07ms ± 4%    0.03ms ± 4%  -98.92%  (p=0.000 n=10+10)
TruncateHTML/miniflux_wikipedia.html_100-8        779µs ± 3%      20µs ± 2%  -97.42%  (p=0.000 n=10+10)
TruncateHTML/miniflux_wikipedia.html_100000-8     773µs ± 3%      20µs ± 6%  -97.38%  (p=0.000 n=10+9)

name                                           old alloc/op   new alloc/op   delta
TruncateHTML/miniflux_github.html_100-8          1.68MB ± 0%    0.02MB ± 0%  -98.94%  (p=0.000 n=9+10)
TruncateHTML/miniflux_github.html_10000-8        1.68MB ± 0%    0.02MB ± 0%  -98.94%  (p=0.000 n=10+10)
TruncateHTML/miniflux_wikipedia.html_100-8        361kB ± 0%      19kB ± 0%  -94.76%  (p=0.000 n=10+10)
TruncateHTML/miniflux_wikipedia.html_100000-8     361kB ± 0%      19kB ± 0%  -94.76%  (p=0.000 n=9+10)

name                                           old allocs/op  new allocs/op  delta
TruncateHTML/miniflux_github.html_100-8           10.9k ± 0%      0.2k ± 0%  -98.07%  (p=0.000 n=10+10)
TruncateHTML/miniflux_github.html_10000-8         10.9k ± 0%      0.2k ± 0%  -98.07%  (p=0.000 n=10+10)
TruncateHTML/miniflux_wikipedia.html_100-8        3.03k ± 0%     0.03k ± 0%  -99.17%  (p=0.000 n=10+10)
TruncateHTML/miniflux_wikipedia.html_100000-8     3.03k ± 0%     0.03k ± 0%  -99.17%  (p=0.000 n=10+10)
```

It's not ready yet as some tests still fail but I'm not sure if that's a bug of this implementation. So some feedback is needed to proceed further.