### PR TITLE
feat(rewrite): add OpenGraph and Twitter Card preview rules

### DIFF
--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -91,6 +91,7 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 		}
 
 		webpageBaseURL := ""
+		var scrapedMetadata map[string]string
 		entry.URL = rewrite.RewriteEntryURL(feed, entry)
 		entryIsNew := store.IsNewEntry(feed.ID, entry.Hash)
 		contentExtractedSuccessfully := false
@@ -108,15 +109,16 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 
 			startTime := time.Now()
 
-			scrapedPageBaseURL, extractedContent, scraperErr := scraper.ScrapeWebsite(
+			scrapeResult, scraperErr := scraper.ScrapeWebsite(
 				requestBuilder,
 				entry.URL,
 				feed.ScraperRules,
 			)
 
-			if scrapedPageBaseURL != "" {
-				webpageBaseURL = scrapedPageBaseURL
+			if scrapeResult.BaseURL != "" {
+				webpageBaseURL = scrapeResult.BaseURL
 			}
+			scrapedMetadata = scrapeResult.Metadata
 
 			if config.Opts.HasMetricsCollector() {
 				status := metric.StatusSuccess
@@ -134,14 +136,14 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 					slog.String("feed_url", feed.FeedURL),
 					slog.Any("error", scraperErr),
 				)
-			} else if extractedContent != "" {
+			} else if scrapeResult.ExtractedContent != "" {
 				// We replace the entry content only if the scraper doesn't return any error.
-				entry.Content = minifyContent(extractedContent)
+				entry.Content = minifyContent(scrapeResult.ExtractedContent)
 				contentExtractedSuccessfully = true
 			}
 		}
 
-		rewrite.ApplyContentRewriteRules(entry, feed.RewriteRules)
+		rewrite.ApplyContentRewriteRules(entry, feed.RewriteRules, &rewrite.RewriteContext{Metadata: scrapedMetadata})
 
 		// Re-run filters only when extracted content replaced entry.Content.
 		if contentExtractedSuccessfully && filter.IsBlockedEntry(blockRules, allowRules, feed, entry) {
@@ -192,7 +194,7 @@ func ProcessEntryWebPage(feed *model.Feed, entry *model.Entry, user *model.User)
 	requestBuilder.IgnoreTLSErrors(feed.AllowSelfSignedCertificates)
 	requestBuilder.DisableHTTP2(feed.DisableHTTP2)
 
-	webpageBaseURL, extractedContent, scraperErr := scraper.ScrapeWebsite(
+	scrapeResult, scraperErr := scraper.ScrapeWebsite(
 		requestBuilder,
 		entry.URL,
 		feed.ScraperRules,
@@ -210,15 +212,15 @@ func ProcessEntryWebPage(feed *model.Feed, entry *model.Entry, user *model.User)
 		return scraperErr
 	}
 
-	if extractedContent != "" {
-		entry.Content = minifyContent(extractedContent)
+	if scrapeResult.ExtractedContent != "" {
+		entry.Content = minifyContent(scrapeResult.ExtractedContent)
 		if user.ShowReadingTime {
 			entry.ReadingTime = readingtime.EstimateReadingTime(entry.Content, user.DefaultReadingSpeed, user.CJKReadingSpeed)
 		}
 	}
 
-	rewrite.ApplyContentRewriteRules(entry, entry.Feed.RewriteRules)
-	entry.Content = sanitizer.SanitizeHTML(webpageBaseURL, entry.Content, &sanitizer.SanitizerOptions{OpenLinksInNewTab: user.OpenExternalLinksInNewTab})
+	rewrite.ApplyContentRewriteRules(entry, entry.Feed.RewriteRules, &rewrite.RewriteContext{Metadata: scrapeResult.Metadata})
+	entry.Content = sanitizer.SanitizeHTML(scrapeResult.BaseURL, entry.Content, &sanitizer.SanitizerOptions{OpenLinksInNewTab: user.OpenExternalLinksInNewTab})
 
 	return nil
 }

--- a/internal/reader/rewrite/content_rewrite.go
+++ b/internal/reader/rewrite/content_rewrite.go
@@ -13,12 +13,27 @@ import (
 	"miniflux.app/v2/internal/urllib"
 )
 
+// RewriteContext carries optional inputs collected by earlier stages of the
+// reader pipeline. It is passed to rewrite rules that need more than the
+// entry content alone (for example, OpenGraph values extracted from the
+// page's <head>).
+//
+// All fields are optional; rules that depend on them must degrade gracefully
+// when the value is missing.
+type RewriteContext struct {
+	// Metadata holds key/value pairs collected from <meta> tags in the
+	// scraped page. Keys keep their original prefix ("og:", "twitter:") and
+	// are normalized to lowercase. The map can be nil when no scraping took
+	// place (for example, when the feed crawler is disabled).
+	Metadata map[string]string
+}
+
 type rule struct {
 	name string
 	args []string
 }
 
-func (rule rule) applyRule(entryURL string, entry *model.Entry) {
+func (rule rule) applyRule(entryURL string, entry *model.Entry, ctx *RewriteContext) {
 	switch rule.name {
 	case "add_image_title":
 		entry.Content = addImageTitle(entry.Content)
@@ -96,10 +111,35 @@ func (rule rule) applyRule(entryURL string, entry *model.Entry) {
 		entry.Content = fixGhostCards(entry.Content)
 	case "remove_img_blur_params":
 		entry.Content = removeImgBlurParams(entry.Content)
+	case "add_open_graph":
+		// Format: add_open_graph("description","image",...)
+		// Without arguments, falls back to the most useful defaults.
+		properties := rule.args
+		if len(properties) == 0 {
+			properties = defaultOpenGraphProperties
+		}
+		entry.Content = addMetaPreview(entry.Content, ctx.metadataLookup(), "og:", properties)
+	case "add_twitter_card":
+		// Format: add_twitter_card("description","image",...)
+		properties := rule.args
+		if len(properties) == 0 {
+			properties = defaultTwitterCardProperties
+		}
+		entry.Content = addMetaPreview(entry.Content, ctx.metadataLookup(), "twitter:", properties)
 	}
 }
 
-func ApplyContentRewriteRules(entry *model.Entry, customRewriteRules string) {
+// metadataLookup returns the metadata map for the current rewrite context,
+// returning an empty (but non-nil) map when the context or its Metadata field
+// is nil. This keeps rule implementations free of nil checks.
+func (ctx *RewriteContext) metadataLookup() map[string]string {
+	if ctx == nil || ctx.Metadata == nil {
+		return map[string]string{}
+	}
+	return ctx.Metadata
+}
+
+func ApplyContentRewriteRules(entry *model.Entry, customRewriteRules string, ctx *RewriteContext) {
 	rulesList := getPredefinedRewriteRules(entry.URL)
 	if customRewriteRules != "" {
 		rulesList = customRewriteRules
@@ -114,7 +154,7 @@ func ApplyContentRewriteRules(entry *model.Entry, customRewriteRules string) {
 	)
 
 	for _, rule := range rules {
-		rule.applyRule(entry.URL, entry)
+		rule.applyRule(entry.URL, entry, ctx)
 	}
 }
 

--- a/internal/reader/rewrite/content_rewrite_functions.go
+++ b/internal/reader/rewrite/content_rewrite_functions.go
@@ -26,6 +26,14 @@ var (
 	textLinkRegex  = regexp.MustCompile(`(?mi)(\bhttps?:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])`)
 )
 
+// defaultOpenGraphProperties is the suffix list applied when add_open_graph
+// is invoked without explicit arguments.
+var defaultOpenGraphProperties = []string{"description", "image"}
+
+// defaultTwitterCardProperties is the suffix list applied when add_twitter_card
+// is invoked without explicit arguments.
+var defaultTwitterCardProperties = []string{"description", "image"}
+
 // titlelize returns a copy of the string s with all Unicode letters that begin words
 // mapped to their Unicode title case.
 func titlelize(s string) string {
@@ -548,6 +556,114 @@ func fixGhostCards(entryContent string) string {
 
 	output, _ := doc.FindMatcher(goquery.Single("body")).Html()
 	return strings.TrimSpace(output)
+}
+
+// addMetaPreview prepends a small block of preview content built from the
+// supplied metadata map. The keyPrefix selects which family of values to read
+// ("og:" for OpenGraph, "twitter:" for Twitter Cards) and properties is the
+// list of suffixes to render ("description", "image", "title", ...).
+//
+// The block is rendered as a <figure> when an image suffix is requested and
+// the metadata contains a value for it; otherwise a single <p> tag is
+// emitted. When no requested property has a value the original content is
+// returned unchanged so the rule is a no-op.
+func addMetaPreview(entryContent string, metadata map[string]string, keyPrefix string, properties []string) string {
+	if len(metadata) == 0 || len(properties) == 0 {
+		return entryContent
+	}
+
+	var (
+		imageURL    string
+		imageAlt    string
+		title       string
+		description string
+		extraLines  []string
+	)
+
+	for _, prop := range properties {
+		prop = strings.TrimSpace(strings.ToLower(prop))
+		if prop == "" {
+			continue
+		}
+		// Allow callers to pass either the bare suffix ("description") or
+		// the fully-qualified key ("og:description"). When a fully-qualified
+		// key is given, only honor it if the prefix matches the rule family.
+		key := prop
+		if strings.HasPrefix(prop, "og:") || strings.HasPrefix(prop, "twitter:") {
+			if !strings.HasPrefix(prop, keyPrefix) {
+				continue
+			}
+		} else {
+			key = keyPrefix + prop
+		}
+
+		value, ok := metadata[key]
+		if !ok || value == "" {
+			continue
+		}
+
+		shortKey := strings.TrimPrefix(key, keyPrefix)
+		switch shortKey {
+		case "image", "image:url", "image:secure_url":
+			if imageURL == "" {
+				imageURL = value
+			}
+		case "image:alt":
+			if imageAlt == "" {
+				imageAlt = value
+			}
+		case "title":
+			if title == "" {
+				title = value
+			}
+		case "description":
+			if description == "" {
+				description = value
+			}
+		default:
+			extraLines = append(extraLines, fmt.Sprintf(
+				`<p><strong>%s:</strong> %s</p>`,
+				html.EscapeString(shortKey),
+				html.EscapeString(value),
+			))
+		}
+	}
+
+	var preview strings.Builder
+
+	if title != "" {
+		preview.WriteString("<p><strong>")
+		preview.WriteString(html.EscapeString(title))
+		preview.WriteString("</strong></p>")
+	}
+
+	if imageURL != "" {
+		preview.WriteString(`<figure><img src="`)
+		preview.WriteString(html.EscapeString(imageURL))
+		preview.WriteString(`" alt="`)
+		preview.WriteString(html.EscapeString(imageAlt))
+		preview.WriteString(`"/>`)
+		if description != "" {
+			preview.WriteString("<figcaption><p>")
+			preview.WriteString(html.EscapeString(description))
+			preview.WriteString("</p></figcaption>")
+		}
+		preview.WriteString("</figure>")
+	} else if description != "" {
+		preview.WriteString("<p>")
+		preview.WriteString(html.EscapeString(description))
+		preview.WriteString("</p>")
+	}
+
+	for _, line := range extraLines {
+		preview.WriteString(line)
+	}
+
+	if preview.Len() == 0 {
+		return entryContent
+	}
+
+	return preview.String() + entryContent
 }
 
 func removeImgBlurParams(entryContent string) string {

--- a/internal/reader/rewrite/content_rewrite_test.go
+++ b/internal/reader/rewrite/content_rewrite_test.go
@@ -59,7 +59,7 @@ func TestRewriteWithNoMatchingRule(t *testing.T) {
 		Title:   `A title`,
 		Content: `Some text.`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -79,7 +79,7 @@ func TestRewriteYoutubeVideoLink(t *testing.T) {
 		Title:   `A title`,
 		Content: `Video Description`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -99,7 +99,7 @@ func TestRewriteYoutubeShortLink(t *testing.T) {
 		Title:   `A title`,
 		Content: `Video Description`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -119,7 +119,7 @@ func TestRewriteIncorrectYoutubeLink(t *testing.T) {
 		Title:   `A title`,
 		Content: `Video Description`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -147,7 +147,7 @@ func TestRewriteYoutubeLinkAndCustomEmbedURL(t *testing.T) {
 		Title:   `A title`,
 		Content: `Video Description`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -167,7 +167,7 @@ func TestRewriteYoutubeVideoLinkUsingInvidious(t *testing.T) {
 		Content: `Video Description`,
 	}
 
-	ApplyContentRewriteRules(testEntry, `add_youtube_video_using_invidious_player`)
+	ApplyContentRewriteRules(testEntry, `add_youtube_video_using_invidious_player`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -187,7 +187,7 @@ func TestRewriteYoutubeShortLinkUsingInvidious(t *testing.T) {
 		Content: `Video Description`,
 	}
 
-	ApplyContentRewriteRules(testEntry, `add_youtube_video_using_invidious_player`)
+	ApplyContentRewriteRules(testEntry, `add_youtube_video_using_invidious_player`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -336,7 +336,7 @@ func TestRewriteWithInexistingCustomRule(t *testing.T) {
 		Title:   `A title`,
 		Content: `Video Description`,
 	}
-	ApplyContentRewriteRules(testEntry, `some rule`)
+	ApplyContentRewriteRules(testEntry, `some rule`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -354,7 +354,7 @@ func TestRewriteWithXkcdLink(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="https://imgs.xkcd.com/comics/thermostat.png" title="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." />`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -372,7 +372,7 @@ func TestRewriteWithXkcdLinkHtmlInjection(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="https://imgs.xkcd.com/comics/thermostat.png" title="<foo>" alt="<foo>" />`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -390,7 +390,7 @@ func TestRewriteWithXkcdLinkAndImageNoTitle(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="https://imgs.xkcd.com/comics/thermostat.png" alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." />`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -408,7 +408,7 @@ func TestRewriteWithXkcdLinkAndNoImage(t *testing.T) {
 		Title:   `A title`,
 		Content: `test`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -426,7 +426,7 @@ func TestRewriteWithXkcdAndNoImage(t *testing.T) {
 		Title:   `A title`,
 		Content: `test`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -444,7 +444,7 @@ func TestRewriteMailtoLink(t *testing.T) {
 		Title:   `A title`,
 		Content: `<a href="mailto:ryan@qwantz.com?subject=blah%20blah">contact</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -462,7 +462,7 @@ func TestRewriteWithPDFLink(t *testing.T) {
 		Title:   `A title`,
 		Content: `test`,
 	}
-	ApplyContentRewriteRules(testEntry, ``)
+	ApplyContentRewriteRules(testEntry, ``, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -480,7 +480,7 @@ func TestRewriteWithNoLazyImage(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="https://example.org/image.jpg" alt="Image"><noscript><p>Some text</p></noscript>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_image")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_image", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -498,7 +498,7 @@ func TestRewriteWithLazyImage(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="" data-url="https://example.org/image.jpg" alt="Image"><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_image")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_image", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -516,7 +516,7 @@ func TestRewriteWithLazyDivImage(t *testing.T) {
 		Title:   `A title`,
 		Content: `<div data-url="https://example.org/image.jpg" alt="Image"></div><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_image")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_image", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -534,7 +534,7 @@ func TestRewriteWithUnknownLazyNoScriptImage(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="" data-non-candidate="https://example.org/image.jpg" alt="Image"><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_image")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_image", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -552,7 +552,7 @@ func TestRewriteWithLazySrcset(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img srcset="" data-srcset="https://example.org/image.jpg" alt="Image">`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_image")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_image", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -570,7 +570,7 @@ func TestRewriteWithImageAndLazySrcset(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="meow" srcset="" data-srcset="https://example.org/image.jpg" alt="Image">`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_image")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_image", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -588,7 +588,7 @@ func TestRewriteWithNoLazyIframe(t *testing.T) {
 		Title:   `A title`,
 		Content: `<iframe src="https://example.org/embed" allowfullscreen></iframe>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_iframe")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_iframe", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -606,7 +606,7 @@ func TestRewriteWithLazyIframe(t *testing.T) {
 		Title:   `A title`,
 		Content: `<iframe data-src="https://example.org/embed" allowfullscreen></iframe>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_iframe")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_iframe", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -624,7 +624,7 @@ func TestRewriteWithLazyIframeAndSrc(t *testing.T) {
 		Title:   `A title`,
 		Content: `<iframe src="about:blank" data-src="https://example.org/embed" allowfullscreen></iframe>`,
 	}
-	ApplyContentRewriteRules(testEntry, "add_dynamic_iframe")
+	ApplyContentRewriteRules(testEntry, "add_dynamic_iframe", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -642,7 +642,7 @@ func TestNewLineRewriteRule(t *testing.T) {
 		Title:   `A title`,
 		Content: "A\nB\nC",
 	}
-	ApplyContentRewriteRules(testEntry, "nl2br")
+	ApplyContentRewriteRules(testEntry, "nl2br", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -660,7 +660,7 @@ func TestConvertTextLinkRewriteRule(t *testing.T) {
 		Title:   `A title`,
 		Content: `Test: http://example.org/a/b`,
 	}
-	ApplyContentRewriteRules(testEntry, "convert_text_link")
+	ApplyContentRewriteRules(testEntry, "convert_text_link", nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -696,7 +696,7 @@ func TestMediumImage(t *testing.T) {
 		</figure>
 		`,
 	}
-	ApplyContentRewriteRules(testEntry, "fix_medium_images")
+	ApplyContentRewriteRules(testEntry, "fix_medium_images", nil)
 	testEntry.Content = strings.TrimSpace(testEntry.Content)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
@@ -715,7 +715,7 @@ func TestRewriteNoScriptImageWithoutNoScriptTag(t *testing.T) {
 		Title:   `A title`,
 		Content: `<figure><img src="https://developer.mozilla.org/static/img/favicon144.png" alt="The beautiful MDN logo."><figcaption>MDN Logo</figcaption></figure>`,
 	}
-	ApplyContentRewriteRules(testEntry, "use_noscript_figure_images")
+	ApplyContentRewriteRules(testEntry, "use_noscript_figure_images", nil)
 	testEntry.Content = strings.TrimSpace(testEntry.Content)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
@@ -734,7 +734,7 @@ func TestRewriteNoScriptImageWithNoScriptTag(t *testing.T) {
 		Title:   `A title`,
 		Content: `<figure><img src="https://developer.mozilla.org/static/img/favicon144.png" alt="The beautiful MDN logo."><noscript><img src="http://example.org/logo.svg"></noscript><figcaption>MDN Logo</figcaption></figure>`,
 	}
-	ApplyContentRewriteRules(testEntry, "use_noscript_figure_images")
+	ApplyContentRewriteRules(testEntry, "use_noscript_figure_images", nil)
 	testEntry.Content = strings.TrimSpace(testEntry.Content)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
@@ -753,7 +753,7 @@ func TestRewriteReplaceCustom(t *testing.T) {
 		Title:   `A title`,
 		Content: `<img src="http://example.org/logo.svg"><img src="https://example.org/article/picture.svg">`,
 	}
-	ApplyContentRewriteRules(testEntry, `replace("article/(.*).svg"|"article/$1.png")`)
+	ApplyContentRewriteRules(testEntry, `replace("article/(.*).svg"|"article/$1.png")`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -771,7 +771,7 @@ func TestRewriteReplaceTitleCustom(t *testing.T) {
 		Title:   `A title`,
 		Content: `The replace_title rewrite rule should not modify the content.`,
 	}
-	ApplyContentRewriteRules(testEntry, `replace_title("(?i)^a\\s*ti"|"Ouch, a this")`)
+	ApplyContentRewriteRules(testEntry, `replace_title("(?i)^a\\s*ti"|"Ouch, a this")`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -789,7 +789,7 @@ func TestRewriteRemoveCustom(t *testing.T) {
 		Title:   `A title`,
 		Content: `<div>Lorem Ipsum <span class="spam">I dont want to see this</span><span class="ads keep">Super important info</span></div>`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove(".spam, .ads:not(.keep)")`)
+	ApplyContentRewriteRules(testEntry, `remove(".spam, .ads:not(.keep)")`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -807,7 +807,7 @@ func TestRewriteRemoveQuotedSelector(t *testing.T) {
 		Title:   `A title`,
 		Content: `<div>Lorem Ipsum<img alt="LINUX KERNEL" src="/assets/categories/linuxkernel.webp" width="100" height="100"></div>`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove("img[src^='/assets/categories/']")`)
+	ApplyContentRewriteRules(testEntry, `remove("img[src^='/assets/categories/']")`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -825,7 +825,7 @@ func TestRewriteAddCastopodEpisode(t *testing.T) {
 		Title:   `A title`,
 		Content: `Episode Description`,
 	}
-	ApplyContentRewriteRules(testEntry, `add_castopod_episode`)
+	ApplyContentRewriteRules(testEntry, `add_castopod_episode`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -843,7 +843,7 @@ func TestRewriteBase64Decode(t *testing.T) {
 		Title:   `A title`,
 		Content: `VGhpcyBpcyBzb21lIGJhc2U2NCBlbmNvZGVkIGNvbnRlbnQ=`,
 	}
-	ApplyContentRewriteRules(testEntry, `base64_decode`)
+	ApplyContentRewriteRules(testEntry, `base64_decode`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -861,7 +861,7 @@ func TestRewriteBase64DecodeInHTML(t *testing.T) {
 		Title:   `A title`,
 		Content: `<div>Lorem Ipsum not valid base64<span class="base64">VGhpcyBpcyBzb21lIGJhc2U2NCBlbmNvZGVkIGNvbnRlbnQ=</span></div>`,
 	}
-	ApplyContentRewriteRules(testEntry, `base64_decode`)
+	ApplyContentRewriteRules(testEntry, `base64_decode`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -879,7 +879,7 @@ func TestRewriteBase64DecodeArgs(t *testing.T) {
 		Title:   `A title`,
 		Content: `<div>Lorem Ipsum<span class="base64">VGhpcyBpcyBzb21lIGJhc2U2NCBlbmNvZGVkIGNvbnRlbnQ=</span></div>`,
 	}
-	ApplyContentRewriteRules(testEntry, `base64_decode(".base64")`)
+	ApplyContentRewriteRules(testEntry, `base64_decode(".base64")`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -897,7 +897,7 @@ func TestRewriteRemoveTables(t *testing.T) {
 		Title:   `A title`,
 		Content: `<table class="container"><tbody><tr><td><p>Test</p><table class="row"><tbody><tr><td><p>Hello World!</p></td><td><p>Test</p></td></tr></tbody></table></td></tr></tbody></table>`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove_tables`)
+	ApplyContentRewriteRules(testEntry, `remove_tables`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -915,7 +915,7 @@ func TestRemoveClickbait(t *testing.T) {
 		Title:   `THIS IS AMAZING`,
 		Content: `Some description`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove_clickbait`)
+	ApplyContentRewriteRules(testEntry, `remove_clickbait`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -940,7 +940,7 @@ func TestAddHackerNewsLinksUsingHack(t *testing.T) {
 		<p>Points: 23</p>
 		<p># Comments: 38</p>`,
 	}
-	ApplyContentRewriteRules(testEntry, `add_hn_links_using_hack`)
+	ApplyContentRewriteRules(testEntry, `add_hn_links_using_hack`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -965,7 +965,7 @@ func TestAddHackerNewsLinksUsingOpener(t *testing.T) {
 		<p>Points: 23</p>
 		<p># Comments: 38</p>`,
 	}
-	ApplyContentRewriteRules(testEntry, `add_hn_links_using_opener`)
+	ApplyContentRewriteRules(testEntry, `add_hn_links_using_opener`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -999,7 +999,7 @@ func TestAddImageTitle(t *testing.T) {
 		<figure><img src="pif" alt="pouf"/><figcaption><p>;&amp;quot;onerror=alert(1) a=;&amp;quot;</p></figcaption></figure>
 		`,
 	}
-	ApplyContentRewriteRules(testEntry, `add_image_title`)
+	ApplyContentRewriteRules(testEntry, `add_image_title`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1033,7 +1033,7 @@ func TestFixGhostCard(t *testing.T) {
 		Title:   `A title`,
 		Content: `<a href="https://example.org/article">Example Article - Example</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1052,7 +1052,7 @@ func TestFixGhostCardNoCard(t *testing.T) {
 		Title:   `A title`,
 		Content: `<a href="https://example.org/article">Example Article - Example</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1075,7 +1075,7 @@ func TestFixGhostCardInvalidCard(t *testing.T) {
 			<a href="https://example.org/article">This card does not have the required fields</a>
 		</figure>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1104,7 +1104,7 @@ func TestFixGhostCardMissingAuthor(t *testing.T) {
 		Title:   `A title`,
 		Content: `<a href="https://example.org/article">Example Article</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1138,7 +1138,7 @@ func TestFixGhostCardDuplicatedAuthor(t *testing.T) {
 		Title:   `A title`,
 		Content: `<a href="https://example.org/article">Example Article - Example</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1188,7 +1188,7 @@ func TestFixGhostCardMultiple(t *testing.T) {
 		Title:   `A title`,
 		Content: `<ul><li><a href="https://example.org/article1">Example Article 1 - Example</a></li><li><a href="https://example.org/article2">Example Article 2 - Example</a></li></ul>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1241,7 +1241,7 @@ func TestFixGhostCardMultipleSplit(t *testing.T) {
 		<p>This separates the two cards</p>
 		<a href="https://example.org/article2">Example Article 2 - Example</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`)
+	ApplyContentRewriteRules(testEntry, `fix_ghost_cards`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1291,7 +1291,7 @@ func TestStripImageQueryParams(t *testing.T) {
 			<img src="https://example.org/normal1.jpg?width=600&amp;quality=high" alt="Normal 2"/>
 		</article>`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`)
+	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1314,7 +1314,7 @@ func TestStripImageQueryParamsNoChanges(t *testing.T) {
 		<div>Just some text content</div>
 		<a href="https://example.org">A link</a>`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`)
+	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1362,7 +1362,7 @@ func TestStripImageQueryParamsEdgeCases(t *testing.T) {
 		<img src="https://example.org/clean.jpg" alt="Clean image"/>
 		`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`)
+	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
@@ -1396,7 +1396,7 @@ func TestStripImageQueryParamsSimple(t *testing.T) {
 		<img src="https://example.org/test4.jpg" alt="No params at all"/>
 		`,
 	}
-	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`)
+	ApplyContentRewriteRules(testEntry, `remove_img_blur_params`, nil)
 
 	if !reflect.DeepEqual(testEntry, controlEntry) {
 		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)

--- a/internal/reader/rewrite/preview_meta_test.go
+++ b/internal/reader/rewrite/preview_meta_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package rewrite // import "miniflux.app/v2/internal/reader/rewrite"
+
+import (
+	"strings"
+	"testing"
+
+	"miniflux.app/v2/internal/model"
+)
+
+func TestAddOpenGraphPrependsImageAndDescription(t *testing.T) {
+	entry := &model.Entry{
+		URL:     "https://example.org/post/1",
+		Title:   "Bluesky post",
+		Content: "Original body.",
+	}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"og:description": "I took this picture of a cat today.",
+		"og:image":       "https://cdn.example.org/cat.jpg",
+	}}
+
+	ApplyContentRewriteRules(entry, `add_open_graph("description","image")`, ctx)
+
+	if !strings.Contains(entry.Content, `src="https://cdn.example.org/cat.jpg"`) {
+		t.Errorf("expected og:image to be embedded, got: %s", entry.Content)
+	}
+	if !strings.Contains(entry.Content, "I took this picture of a cat today.") {
+		t.Errorf("expected og:description to be embedded, got: %s", entry.Content)
+	}
+	if !strings.HasSuffix(entry.Content, "Original body.") {
+		t.Errorf("expected original body to remain at the end, got: %s", entry.Content)
+	}
+}
+
+func TestAddTwitterCardPrependsImageAndDescription(t *testing.T) {
+	entry := &model.Entry{
+		URL:     "https://example.org/post/1",
+		Content: "Original body.",
+	}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"twitter:description": "Card description",
+		"twitter:image":       "https://cdn.example.org/img.png",
+	}}
+
+	ApplyContentRewriteRules(entry, `add_twitter_card("description","image")`, ctx)
+
+	if !strings.Contains(entry.Content, `src="https://cdn.example.org/img.png"`) {
+		t.Errorf("expected twitter:image to be embedded, got: %s", entry.Content)
+	}
+	if !strings.Contains(entry.Content, "Card description") {
+		t.Errorf("expected twitter:description to be embedded, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphFallbackToDefaults(t *testing.T) {
+	entry := &model.Entry{
+		URL:     "https://example.org/post/1",
+		Content: "body",
+	}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"og:description": "default description",
+		"og:image":       "https://cdn.example.org/default.jpg",
+		"og:title":       "ignored without explicit arg",
+	}}
+
+	ApplyContentRewriteRules(entry, `add_open_graph`, ctx)
+
+	if !strings.Contains(entry.Content, "default description") {
+		t.Errorf("expected default og:description, got: %s", entry.Content)
+	}
+	if !strings.Contains(entry.Content, "https://cdn.example.org/default.jpg") {
+		t.Errorf("expected default og:image, got: %s", entry.Content)
+	}
+	if strings.Contains(entry.Content, "ignored without explicit arg") {
+		t.Errorf("default arg list should not include title, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphAcceptsFullyQualifiedKey(t *testing.T) {
+	entry := &model.Entry{URL: "https://example.org/", Content: "body"}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"og:description": "qualified key works too",
+	}}
+
+	ApplyContentRewriteRules(entry, `add_open_graph("og:description")`, ctx)
+
+	if !strings.Contains(entry.Content, "qualified key works too") {
+		t.Errorf("expected fully qualified og:description to work, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphIgnoresMismatchedFamilyKey(t *testing.T) {
+	entry := &model.Entry{URL: "https://example.org/", Content: "body"}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"twitter:description": "from twitter",
+	}}
+
+	// Asking add_open_graph for a "twitter:" key should be ignored, not
+	// silently fetched from the twitter family.
+	ApplyContentRewriteRules(entry, `add_open_graph("twitter:description")`, ctx)
+
+	if strings.Contains(entry.Content, "from twitter") {
+		t.Errorf("add_open_graph should not pick twitter:* values, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphNoMetadataIsNoop(t *testing.T) {
+	entry := &model.Entry{URL: "https://example.org/", Content: "untouched"}
+
+	// No context at all, simulating crawler-disabled feeds.
+	ApplyContentRewriteRules(entry, `add_open_graph("description","image")`, nil)
+
+	if entry.Content != "untouched" {
+		t.Errorf("expected no-op when no metadata is available, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphMissingPropertyIsNoop(t *testing.T) {
+	entry := &model.Entry{URL: "https://example.org/", Content: "untouched"}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"og:url": "https://example.org/canonical",
+	}}
+
+	ApplyContentRewriteRules(entry, `add_open_graph("description","image")`, ctx)
+
+	if entry.Content != "untouched" {
+		t.Errorf("expected no-op when requested properties are missing, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphRendersExtraPropertyAsParagraph(t *testing.T) {
+	entry := &model.Entry{URL: "https://example.org/", Content: "body"}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"og:site_name": "Example",
+	}}
+
+	ApplyContentRewriteRules(entry, `add_open_graph("site_name")`, ctx)
+
+	if !strings.Contains(entry.Content, "site_name") {
+		t.Errorf("expected site_name label, got: %s", entry.Content)
+	}
+	if !strings.Contains(entry.Content, "Example") {
+		t.Errorf("expected site_name value, got: %s", entry.Content)
+	}
+}
+
+func TestAddOpenGraphEscapesValues(t *testing.T) {
+	entry := &model.Entry{URL: "https://example.org/", Content: "body"}
+	ctx := &RewriteContext{Metadata: map[string]string{
+		"og:description": `<script>alert(1)</script>`,
+		"og:image":       `https://cdn.example.org/x.jpg"><script>x</script>`,
+	}}
+
+	ApplyContentRewriteRules(entry, `add_open_graph("description","image")`, ctx)
+
+	if strings.Contains(entry.Content, "<script>") {
+		t.Errorf("expected script tag in metadata to be escaped, got: %s", entry.Content)
+	}
+	if !strings.Contains(entry.Content, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Errorf("expected escaped description, got: %s", entry.Content)
+	}
+}

--- a/internal/reader/scraper/metadata.go
+++ b/internal/reader/scraper/metadata.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scraper // import "miniflux.app/v2/internal/reader/scraper"
+
+import (
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// ExtractHeadMetadata walks the <head> section of the document and collects
+// values from <meta> tags that are commonly used for previews (OpenGraph and
+// Twitter Cards).
+//
+// The returned map keys are normalized to lowercase. OpenGraph properties are
+// prefixed with "og:" and Twitter Card names with "twitter:", matching the
+// attribute values used in the markup.
+func ExtractHeadMetadata(document *goquery.Document) map[string]string {
+	metadata := make(map[string]string)
+
+	document.Find("head meta").Each(func(_ int, s *goquery.Selection) {
+		content, hasContent := s.Attr("content")
+		if !hasContent {
+			return
+		}
+		content = strings.TrimSpace(content)
+		if content == "" {
+			return
+		}
+
+		// OpenGraph uses the "property" attribute; Twitter Cards historically
+		// use the "name" attribute, but a number of sites use "property" for
+		// Twitter tags too.
+		for _, attr := range []string{"property", "name"} {
+			key, hasKey := s.Attr(attr)
+			if !hasKey {
+				continue
+			}
+			key = strings.ToLower(strings.TrimSpace(key))
+			if key == "" {
+				continue
+			}
+			if !strings.HasPrefix(key, "og:") && !strings.HasPrefix(key, "twitter:") {
+				continue
+			}
+			// First value wins so feed authors can rely on document order.
+			if _, alreadySet := metadata[key]; !alreadySet {
+				metadata[key] = content
+			}
+		}
+	})
+
+	return metadata
+}

--- a/internal/reader/scraper/metadata_test.go
+++ b/internal/reader/scraper/metadata_test.go
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package scraper // import "miniflux.app/v2/internal/reader/scraper"
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestExtractHeadMetadataOpenGraph(t *testing.T) {
+	htmlInput := `<!doctype html>
+<html><head>
+<meta property="og:title" content="A picture of a cat">
+<meta property="og:description" content="I took this picture of a cat today.">
+<meta property="og:image" content="https://cdn.example.org/cat.jpg">
+<meta property="og:url" content="https://example.org/posts/1">
+</head><body>ignored</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlInput))
+	if err != nil {
+		t.Fatalf("unable to parse fixture: %v", err)
+	}
+
+	metadata := ExtractHeadMetadata(doc)
+
+	expected := map[string]string{
+		"og:title":       "A picture of a cat",
+		"og:description": "I took this picture of a cat today.",
+		"og:image":       "https://cdn.example.org/cat.jpg",
+		"og:url":         "https://example.org/posts/1",
+	}
+
+	if len(metadata) != len(expected) {
+		t.Fatalf("expected %d entries, got %d (%v)", len(expected), len(metadata), metadata)
+	}
+
+	for k, v := range expected {
+		if metadata[k] != v {
+			t.Errorf("metadata[%q] = %q, want %q", k, metadata[k], v)
+		}
+	}
+}
+
+func TestExtractHeadMetadataTwitterCard(t *testing.T) {
+	// Twitter Card meta tags occur with both "name" and "property" attributes
+	// in the wild. Both should be picked up.
+	htmlInput := `<!doctype html>
+<html><head>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Bluesky post">
+<meta property="twitter:description" content="Some description">
+<meta name="twitter:image" content="https://cdn.example.org/img.png">
+</head><body></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlInput))
+	if err != nil {
+		t.Fatalf("unable to parse fixture: %v", err)
+	}
+
+	metadata := ExtractHeadMetadata(doc)
+
+	if metadata["twitter:card"] != "summary_large_image" {
+		t.Errorf("twitter:card not extracted, got %q", metadata["twitter:card"])
+	}
+	if metadata["twitter:description"] != "Some description" {
+		t.Errorf("twitter:description not extracted, got %q", metadata["twitter:description"])
+	}
+	if metadata["twitter:image"] != "https://cdn.example.org/img.png" {
+		t.Errorf("twitter:image not extracted, got %q", metadata["twitter:image"])
+	}
+}
+
+func TestExtractHeadMetadataIgnoresUnrelatedMeta(t *testing.T) {
+	htmlInput := `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<meta name="description" content="Plain meta description, not a card">
+<meta property="og:title" content="Only this should be kept">
+</head><body></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlInput))
+	if err != nil {
+		t.Fatalf("unable to parse fixture: %v", err)
+	}
+
+	metadata := ExtractHeadMetadata(doc)
+
+	if len(metadata) != 1 {
+		t.Fatalf("expected exactly 1 entry, got %d (%v)", len(metadata), metadata)
+	}
+	if metadata["og:title"] != "Only this should be kept" {
+		t.Errorf("og:title missing, got map = %v", metadata)
+	}
+}
+
+func TestExtractHeadMetadataKeepsFirstValue(t *testing.T) {
+	htmlInput := `<!doctype html>
+<html><head>
+<meta property="og:image" content="https://cdn.example.org/first.jpg">
+<meta property="og:image" content="https://cdn.example.org/second.jpg">
+</head><body></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlInput))
+	if err != nil {
+		t.Fatalf("unable to parse fixture: %v", err)
+	}
+
+	metadata := ExtractHeadMetadata(doc)
+
+	if metadata["og:image"] != "https://cdn.example.org/first.jpg" {
+		t.Errorf("expected first og:image to win, got %q", metadata["og:image"])
+	}
+}
+
+func TestExtractHeadMetadataIgnoresEmptyContent(t *testing.T) {
+	htmlInput := `<!doctype html>
+<html><head>
+<meta property="og:title" content="">
+<meta property="og:description" content="   ">
+<meta property="og:image" content="https://cdn.example.org/x.jpg">
+</head><body></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlInput))
+	if err != nil {
+		t.Fatalf("unable to parse fixture: %v", err)
+	}
+
+	metadata := ExtractHeadMetadata(doc)
+
+	if _, ok := metadata["og:title"]; ok {
+		t.Errorf("og:title with empty content should be ignored")
+	}
+	if _, ok := metadata["og:description"]; ok {
+		t.Errorf("og:description with whitespace-only content should be ignored")
+	}
+	if metadata["og:image"] != "https://cdn.example.org/x.jpg" {
+		t.Errorf("og:image not extracted, got %q", metadata["og:image"])
+	}
+}

--- a/internal/reader/scraper/scraper.go
+++ b/internal/reader/scraper/scraper.go
@@ -4,6 +4,7 @@
 package scraper // import "miniflux.app/v2/internal/reader/scraper"
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,17 +19,31 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string) (baseURL string, extractedContent string, err error) {
+// ScrapeResult holds the artifacts collected while scraping an entry URL.
+//
+// Metadata contains OpenGraph and Twitter Card values collected from the
+// page's <head>. It can be empty when the page does not expose any preview
+// metadata or when scraping was not performed (for example when the feed has
+// the crawler disabled).
+type ScrapeResult struct {
+	BaseURL          string
+	ExtractedContent string
+	Metadata         map[string]string
+}
+
+func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string) (ScrapeResult, error) {
+	result := ScrapeResult{Metadata: map[string]string{}}
+
 	responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(pageURL))
 	defer responseHandler.Close()
 
 	if localizedError := responseHandler.LocalizedError(); localizedError != nil {
 		slog.Warn("Unable to scrape website", slog.String("website_url", pageURL), slog.Any("error", localizedError.Error()))
-		return "", "", localizedError.Error()
+		return result, localizedError.Error()
 	}
 
 	if !isAllowedContentType(responseHandler.ContentType()) {
-		return "", "", fmt.Errorf("scraper: this resource is not a HTML document (%s)", responseHandler.ContentType())
+		return result, fmt.Errorf("scraper: this resource is not a HTML document (%s)", responseHandler.ContentType())
 	}
 
 	// The entry URL could redirect somewhere else.
@@ -45,7 +60,14 @@ func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string
 	)
 
 	if err != nil {
-		return "", "", fmt.Errorf("scraper: unable to read HTML document with charset reader: %v", err)
+		return result, fmt.Errorf("scraper: unable to read HTML document with charset reader: %v", err)
+	}
+
+	// Buffer the document so we can both run the chosen extraction strategy
+	// and parse <head> meta tags without re-fetching the page.
+	htmlBytes, err := io.ReadAll(htmlDocumentReader)
+	if err != nil {
+		return result, fmt.Errorf("scraper: unable to read HTML document body: %v", err)
 	}
 
 	if sameSite && rules != "" {
@@ -53,21 +75,32 @@ func ScrapeWebsite(requestBuilder *fetcher.RequestBuilder, pageURL, rules string
 			"url", pageURL,
 			"rules", rules,
 		)
-		baseURL, extractedContent, err = findContentUsingCustomRules(htmlDocumentReader, rules)
+		result.BaseURL, result.ExtractedContent, err = findContentUsingCustomRules(bytes.NewReader(htmlBytes), rules)
 	} else {
 		slog.Debug("Extracting content with readability",
 			"url", pageURL,
 		)
-		baseURL, extractedContent, err = readability.ExtractContent(htmlDocumentReader)
+		result.BaseURL, result.ExtractedContent, err = readability.ExtractContent(bytes.NewReader(htmlBytes))
 	}
 
-	if baseURL == "" {
-		baseURL = pageURL
+	if err != nil {
+		slog.Debug("Content extraction returned an error",
+			"url", pageURL,
+			"error", err,
+		)
+	}
+
+	if metadataDoc, metadataErr := goquery.NewDocumentFromReader(bytes.NewReader(htmlBytes)); metadataErr == nil {
+		result.Metadata = ExtractHeadMetadata(metadataDoc)
+	}
+
+	if result.BaseURL == "" {
+		result.BaseURL = pageURL
 	} else {
-		slog.Debug("Using base URL from HTML document", "base_url", baseURL)
+		slog.Debug("Using base URL from HTML document", "base_url", result.BaseURL)
 	}
 
-	return baseURL, extractedContent, nil
+	return result, nil
 }
 
 func findContentUsingCustomRules(page io.Reader, rules string) (baseURL string, extractedContent string, err error) {


### PR DESCRIPTION
Closes #4291.

## What

Adds two content rewrite rules that pull values from the scraped page's `<head>`:

- `add_open_graph(\"description\", \"image\", ...)` — reads `og:*` meta tags
- `add_twitter_card(\"description\", \"image\", ...)` — reads `twitter:*` meta tags

Both accept either bare suffixes (`description`, `image`, `title`, `site_name`, ...) or fully-qualified keys (`og:description`, `twitter:image`). Called without arguments they default to `description` + `image`.

When `description` and `image` are both available the rule renders a `<figure>` with the image and a caption; otherwise it falls back to a paragraph. Other suffixes are rendered as a labelled paragraph (`<p><strong>site_name:</strong> Example</p>`). All metadata values are HTML-escaped before being written into the entry content.

## Why

Some sites lean so heavily on JS that scraping returns very little, but their `<head>` exposes rich preview metadata. Bluesky is the example in the issue: an RSS item points at a post but only carries a short snippet, while the linked page has `og:description`, `og:image`, `twitter:description`, `twitter:image`, etc. The new rules let users opt into using those values for the entry body.

Example feed-side configuration (custom rewrite rules field):

```
add_open_graph(\"description\", \"image\")
```

or for a Twitter-Card-only site:

```
add_twitter_card(\"description\", \"image\")
```

## How

The scraper already fetches the page once when the crawler is enabled. The change buffers the fetched HTML so it can be parsed twice — once for the existing readability/custom-rules extraction, once for `<head>` meta tags — without an extra HTTP request. The collected map is exposed on a new `ScrapeResult` struct (replacing the old multi-return signature on `ScrapeWebsite`) and threaded into the rewrite layer through a new `RewriteContext`.

When the crawler is disabled or no requested key is present the rules are no-ops, so existing feeds that do not opt in are unaffected.

## Notes / open questions for reviewers

- The new directive name (`add_open_graph` / `add_twitter_card`) follows the existing `add_*` naming. Happy to rename if you prefer something more compact.
- The default property list (`description` + `image`) was chosen to match the Bluesky-style use case in the issue. Easy to extend the defaults or expose a third helper that pulls everything available.
- The `ScrapeWebsite` return type changed from three values to a `ScrapeResult` struct since metadata makes a fourth value awkward; the only callers are inside `internal/reader/processor` so no external API is affected.

## Tests

- `internal/reader/scraper/metadata_test.go` — covers OpenGraph extraction, Twitter Cards using both `name` and `property` attributes, ignoring unrelated meta, first-value-wins on duplicates, and rejection of empty/whitespace content.
- `internal/reader/rewrite/preview_meta_test.go` — covers prepending image+description, default arg fallback, fully-qualified keys, family-mismatch rejection, no-metadata no-op, missing-property no-op, the labelled-paragraph fallback, and HTML escaping of attacker-controlled meta values.
- Existing `content_rewrite_test.go` updated for the new `ApplyContentRewriteRules` signature.

`go test ./...` and `go vet ./...` pass locally.