### PR TITLE
googlereader: avoid inlining validateApiKey at every call site

### DIFF
--- a/internal/googlereader/middleware.go
+++ b/internal/googlereader/middleware.go
@@ -28,151 +28,155 @@ func newAuthMiddleware(s *storage.Storage) *authMiddleware {
 
 func (m *authMiddleware) validateApiKey(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		clientIP := request.ClientIP(r)
-
-		var token string
-		if r.Method == http.MethodPost {
-			if err := r.ParseForm(); err != nil {
-				slog.Warn("[GoogleReader] Could not parse request form data",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-					slog.Any("error", err),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-
-			token = r.Form.Get("T")
-			if token == "" {
-				slog.Warn("[GoogleReader] Post-Form T field is empty",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-		} else {
-			authorization := r.Header.Get("Authorization")
-
-			if authorization == "" {
-				slog.Warn("[GoogleReader] No token provided",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-			fields := strings.Fields(authorization)
-			if len(fields) != 2 {
-				slog.Warn("[GoogleReader] Authorization header does not have the expected GoogleLogin format auth=xxxxxx",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-			if fields[0] != "GoogleLogin" {
-				slog.Warn("[GoogleReader] Authorization header does not begin with GoogleLogin",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-			auths := strings.Split(fields[1], "=")
-			if len(auths) != 2 {
-				slog.Warn("[GoogleReader] Authorization header does not have the expected GoogleLogin format auth=xxxxxx",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-			if auths[0] != "auth" {
-				slog.Warn("[GoogleReader] Authorization header does not have the expected GoogleLogin format auth=xxxxxx",
-					slog.Bool("authentication_failed", true),
-					slog.String("client_ip", clientIP),
-					slog.String("user_agent", r.UserAgent()),
-				)
-				sendUnauthorizedResponse(w, r)
-				return
-			}
-			token = auths[1]
-		}
-
-		parts := strings.Split(token, "/")
-		if len(parts) != 2 {
-			slog.Warn("[GoogleReader] Auth token does not have the expected structure username/hash",
-				slog.Bool("authentication_failed", true),
-				slog.String("client_ip", clientIP),
-				slog.String("user_agent", r.UserAgent()),
-				slog.String("token", token),
-			)
-			sendUnauthorizedResponse(w, r)
-			return
-		}
-		var integration *model.Integration
-		var user *model.User
-		var err error
-		if integration, err = m.store.GoogleReaderUserGetIntegration(parts[0]); err != nil {
-			slog.Warn("[GoogleReader] No user found with the given Google Reader username",
-				slog.Bool("authentication_failed", true),
-				slog.String("client_ip", clientIP),
-				slog.String("user_agent", r.UserAgent()),
-				slog.Any("error", err),
-			)
-			sendUnauthorizedResponse(w, r)
-			return
-		}
-		expectedToken := getAuthToken(integration.GoogleReaderUsername, integration.GoogleReaderPassword)
-		if !crypto.ConstantTimeCmp(expectedToken, token) {
-			slog.Warn("[GoogleReader] Token does not match",
-				slog.Bool("authentication_failed", true),
-				slog.String("client_ip", clientIP),
-				slog.String("user_agent", r.UserAgent()),
-			)
-			sendUnauthorizedResponse(w, r)
-			return
-		}
-		if user, err = m.store.UserByID(integration.UserID); err != nil {
-			slog.Error("[GoogleReader] Unable to fetch user from database",
-				slog.Bool("authentication_failed", true),
-				slog.String("client_ip", clientIP),
-				slog.String("user_agent", r.UserAgent()),
-				slog.Any("error", err),
-			)
-			sendUnauthorizedResponse(w, r)
-			return
-		}
-
-		if user == nil {
-			slog.Warn("[GoogleReader] No user found with the given Google Reader credentials",
-				slog.Bool("authentication_failed", true),
-				slog.String("client_ip", clientIP),
-				slog.String("user_agent", r.UserAgent()),
-			)
-			sendUnauthorizedResponse(w, r)
-			return
-		}
-
-		m.store.SetLastLogin(integration.UserID)
-
-		ctx := r.Context()
-		ctx = context.WithValue(ctx, request.UserIDContextKey, user.ID)
-		ctx = context.WithValue(ctx, request.UserNameContextKey, user.Username)
-		ctx = context.WithValue(ctx, request.UserTimezoneContextKey, user.Timezone)
-		ctx = context.WithValue(ctx, request.IsAdminUserContextKey, user.IsAdmin)
-		ctx = context.WithValue(ctx, request.IsAuthenticatedContextKey, true)
-		ctx = context.WithValue(ctx, request.GoogleReaderTokenKey, token)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
+		m.serveValidated(w, r, next)
 	})
+}
+
+func (m *authMiddleware) serveValidated(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	clientIP := request.ClientIP(r)
+
+	var token string
+	if r.Method == http.MethodPost {
+		if err := r.ParseForm(); err != nil {
+			slog.Warn("[GoogleReader] Could not parse request form data",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+				slog.Any("error", err),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+
+		token = r.Form.Get("T")
+		if token == "" {
+			slog.Warn("[GoogleReader] Post-Form T field is empty",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+	} else {
+		authorization := r.Header.Get("Authorization")
+
+		if authorization == "" {
+			slog.Warn("[GoogleReader] No token provided",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+		fields := strings.Fields(authorization)
+		if len(fields) != 2 {
+			slog.Warn("[GoogleReader] Authorization header does not have the expected GoogleLogin format auth=xxxxxx",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+		if fields[0] != "GoogleLogin" {
+			slog.Warn("[GoogleReader] Authorization header does not begin with GoogleLogin",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+		auths := strings.Split(fields[1], "=")
+		if len(auths) != 2 {
+			slog.Warn("[GoogleReader] Authorization header does not have the expected GoogleLogin format auth=xxxxxx",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+		if auths[0] != "auth" {
+			slog.Warn("[GoogleReader] Authorization header does not have the expected GoogleLogin format auth=xxxxxx",
+				slog.Bool("authentication_failed", true),
+				slog.String("client_ip", clientIP),
+				slog.String("user_agent", r.UserAgent()),
+			)
+			sendUnauthorizedResponse(w, r)
+			return
+		}
+		token = auths[1]
+	}
+
+	parts := strings.Split(token, "/")
+	if len(parts) != 2 {
+		slog.Warn("[GoogleReader] Auth token does not have the expected structure username/hash",
+			slog.Bool("authentication_failed", true),
+			slog.String("client_ip", clientIP),
+			slog.String("user_agent", r.UserAgent()),
+			slog.String("token", token),
+		)
+		sendUnauthorizedResponse(w, r)
+		return
+	}
+	var integration *model.Integration
+	var user *model.User
+	var err error
+	if integration, err = m.store.GoogleReaderUserGetIntegration(parts[0]); err != nil {
+		slog.Warn("[GoogleReader] No user found with the given Google Reader username",
+			slog.Bool("authentication_failed", true),
+			slog.String("client_ip", clientIP),
+			slog.String("user_agent", r.UserAgent()),
+			slog.Any("error", err),
+		)
+		sendUnauthorizedResponse(w, r)
+		return
+	}
+	expectedToken := getAuthToken(integration.GoogleReaderUsername, integration.GoogleReaderPassword)
+	if !crypto.ConstantTimeCmp(expectedToken, token) {
+		slog.Warn("[GoogleReader] Token does not match",
+			slog.Bool("authentication_failed", true),
+			slog.String("client_ip", clientIP),
+			slog.String("user_agent", r.UserAgent()),
+		)
+		sendUnauthorizedResponse(w, r)
+		return
+	}
+	if user, err = m.store.UserByID(integration.UserID); err != nil {
+		slog.Error("[GoogleReader] Unable to fetch user from database",
+			slog.Bool("authentication_failed", true),
+			slog.String("client_ip", clientIP),
+			slog.String("user_agent", r.UserAgent()),
+			slog.Any("error", err),
+		)
+		sendUnauthorizedResponse(w, r)
+		return
+	}
+
+	if user == nil {
+		slog.Warn("[GoogleReader] No user found with the given Google Reader credentials",
+			slog.Bool("authentication_failed", true),
+			slog.String("client_ip", clientIP),
+			slog.String("user_agent", r.UserAgent()),
+		)
+		sendUnauthorizedResponse(w, r)
+		return
+	}
+
+	m.store.SetLastLogin(integration.UserID)
+
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, request.UserIDContextKey, user.ID)
+	ctx = context.WithValue(ctx, request.UserNameContextKey, user.Username)
+	ctx = context.WithValue(ctx, request.UserTimezoneContextKey, user.Timezone)
+	ctx = context.WithValue(ctx, request.IsAdminUserContextKey, user.IsAdmin)
+	ctx = context.WithValue(ctx, request.IsAuthenticatedContextKey, true)
+	ctx = context.WithValue(ctx, request.GoogleReaderTokenKey, token)
+
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 func getAuthToken(username, password string) string {


### PR DESCRIPTION
The middleware (*authMiddleware).validateApiKey is registered for 14 routes in NewHandler. Its body was just `return http.HandlerFunc(func…)`, which made the compiler consider it inlinable. As a result, the entire losure body was duplicated at every call site, taking space in the .text section.

Move the request-handling logic into a separate non-inlined method serveValidated and keep validateApiKey as a thin wrapper that only allocates the http.HandlerFunc. The 14 duplicated symbols are gone and the stripped binary shrinks from 20,513,033 to 20,447,497 bytes, which isn't that much, but it's still something, especially for such a simple commit.