### PR TITLE
refactor(misc): various minor code simplifications

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -246,10 +246,10 @@ func (h *greaderHandler) editTagHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	n := 0
-	readEntryIDs := make([]int64, 0)
-	unreadEntryIDs := make([]int64, 0)
-	starredEntryIDs := make([]int64, 0)
-	unstarredEntryIDs := make([]int64, 0)
+	var readEntryIDs []int64
+	var unreadEntryIDs []int64
+	var starredEntryIDs []int64
+	var unstarredEntryIDs []int64
 	for _, entry := range entries {
 		if read, exists := tags[ReadStream]; exists {
 			if read && entry.Status == model.EntryStatusUnread {

--- a/internal/reader/sanitizer/sanitizer.go
+++ b/internal/reader/sanitizer/sanitizer.go
@@ -482,9 +482,7 @@ func sanitizeAttributes(parsedBaseUrl *url.URL, tagName string, attributes []htm
 		switch tagName {
 		case "math":
 			if attribute.Key == "xmlns" {
-				if value != "http://www.w3.org/1998/Math/MathML" {
-					value = "http://www.w3.org/1998/Math/MathML"
-				}
+				value = "http://www.w3.org/1998/Math/MathML"
 			}
 		case "img":
 			switch attribute.Key {

--- a/internal/urllib/url.go
+++ b/internal/urllib/url.go
@@ -144,11 +144,6 @@ func JoinBaseURLAndPath(baseURL, path string) (string, error) {
 		return "", errors.New("empty path")
 	}
 
-	_, err := url.Parse(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("invalid base URL: %w", err)
-	}
-
 	finalURL, err := url.JoinPath(baseURL, path)
 	if err != nil {
 		return "", fmt.Errorf("unable to join base URL %s and path %s: %w", baseURL, path, err)


### PR DESCRIPTION
- No need to use `make(…)` construct for empty slices, as is already the case in the rest of internal/googlereader/handler.go
- Unify style as well for errors handling in internal/reader/fetcher/response_handler.go, and simplify a condition
- Replace a useless condition in internal/reader/sanitizer/sanitizer.go with an unconditional assignment.
- Remove a useless call to url.Parse in JoinBaseURLAndPath, as url.JoinPath already performs the validation internally
