### PR TITLE
fix(storage): safeguard for possible SQL injection

### DIFF
--- a/internal/storage/entry_pagination_builder.go
+++ b/internal/storage/entry_pagination_builder.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lib/pq"
 	"miniflux.app/v2/internal/model"
 )
 
@@ -192,7 +193,7 @@ func NewEntryPaginationBuilder(store *Storage, userID, entryID int64, order, dir
 		args:       []any{userID},
 		conditions: []string{"e.user_id = $1"},
 		entryID:    entryID,
-		order:      order,
+		order:      pq.QuoteIdentifier(order),
 		direction:  direction,
 	}
 }

--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -50,9 +50,9 @@ func (e *EntryQueryBuilder) WithSearchQuery(query string) *EntryQueryBuilder {
 		e.args = append(e.args, query)
 
 		// 0.0000001 = 0.1 / (seconds_in_a_day)
-		e.WithSorting(
-			fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d)) - extract (epoch from now() - published_at)::float * 0.0000001", nArgs),
-			"DESC",
+
+		e.sortExpressions = append(e.sortExpressions,
+			fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d)) - extract (epoch from now() - published_at)::float * 0.0000001 DESC", nArgs),
 		)
 	}
 	return e
@@ -209,7 +209,13 @@ func (e *EntryQueryBuilder) WithShareCodeNotEmpty() *EntryQueryBuilder {
 
 // WithSorting add a sort expression.
 func (e *EntryQueryBuilder) WithSorting(column, direction string) *EntryQueryBuilder {
-	e.sortExpressions = append(e.sortExpressions, column+" "+direction)
+	switch {
+	case strings.EqualFold(direction, "ASC"):
+		e.sortExpressions = append(e.sortExpressions, pq.QuoteIdentifier(column)+" ASC")
+	case strings.EqualFold(direction, "DESC"):
+		e.sortExpressions = append(e.sortExpressions, pq.QuoteIdentifier(column)+" DESC")
+	}
+
 	return e
 }
 
@@ -410,7 +416,6 @@ func (e *EntryQueryBuilder) fetchEntries(withCount bool) (model.Entries, int, er
 		}
 
 		err := rows.Scan(dest...)
-
 		if err != nil {
 			return nil, 0, fmt.Errorf("store: unable to fetch entry row: %v", err)
 		}

--- a/internal/storage/feed_query_builder.go
+++ b/internal/storage/feed_query_builder.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lib/pq"
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/timezone"
 )
@@ -67,7 +68,13 @@ func (f *feedQueryBuilder) WithCounters() *feedQueryBuilder {
 
 // WithSorting add a sort expression.
 func (f *feedQueryBuilder) WithSorting(column, direction string) *feedQueryBuilder {
-	f.sortExpressions = append(f.sortExpressions, column+" "+direction)
+	switch {
+	case strings.EqualFold(direction, "ASC"):
+		f.sortExpressions = append(f.sortExpressions, pq.QuoteIdentifier(column)+" ASC")
+	case strings.EqualFold(direction, "DESC"):
+		f.sortExpressions = append(f.sortExpressions, pq.QuoteIdentifier(column)+" DESC")
+	}
+
 	return f
 }
 


### PR DESCRIPTION
As `ORDER BY` strings can't be included in parametrized queries, queries containing them are vulnerable to SQL injections.

It is very unlikely that anyone could exploit this though. In all cases sorting column and direction is taken from `User` object. And before calling `UpdateUser` input from API is validated.

But I guess better safe than sorry. This way you will just get an error even if there's a loop hole in validation process.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
