### PR TITLE
fix: typo in wallabag integration error message

### DIFF
--- a/internal/integration/wallabag/wallabag.go
+++ b/internal/integration/wallabag/wallabag.go
@@ -94,7 +94,7 @@ func (c *Client) createEntry(accessToken, entryURL, entryTitle, entryContent, ta
 	defer response.Body.Close()
 
 	if response.StatusCode >= 400 {
-		return fmt.Errorf("wallabag: unable to get save entry: url=%s status=%d", apiEndpoint, response.StatusCode)
+		return fmt.Errorf("wallabag: unable to save entry: url=%s status=%d", apiEndpoint, response.StatusCode)
 	}
 
 	return nil

--- a/internal/integration/wallabag/wallabag_test.go
+++ b/internal/integration/wallabag/wallabag_test.go
@@ -201,7 +201,7 @@ func TestCreateEntry(t *testing.T) {
 				}
 				w.WriteHeader(http.StatusUnauthorized)
 			},
-			errContains: "unable to get save entry",
+			errContains: "unable to save entry",
 		},
 		{
 			name:         "failure due to no accessToken",


### PR DESCRIPTION
## Description

Fix a grammatical typo in the wallabag integration error message.

**Before:** `"wallabag: unable to get save entry: url=%s status=%d"`
**After:** `"wallabag: unable to save entry: url=%s status=%d"`

The phrase "unable to get save entry" is grammatically incorrect. The word "get" is extraneous and the error message should read "unable to save entry".

### Changes
- `internal/integration/wallabag/wallabag.go`: Fix typo in error message on line 97
- `internal/integration/wallabag/wallabag_test.go`: Update corresponding test assertion on line 204