### PR TITLE
perf(database): drop two redundant indexes

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1510,4 +1510,19 @@ var migrations = [...]func(tx *sql.Tx) error{
 		`)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		// entries_feed_idx is redundant: the unique constraint
+		// entries_feed_id_hash_key(feed_id, hash) and the explicit
+		// entries_feed_id_status_hash_idx(feed_id, status, hash) both
+		// cover feed_id-leading lookups, including FK cascade deletes.
+		//
+		// entries_user_status_idx is redundant: five three-column indexes
+		// share the same (user_id, status) prefix and serve every query
+		// that the two-column index could.
+		_, err = tx.Exec(`
+			DROP INDEX IF EXISTS entries_feed_idx;
+			DROP INDEX IF EXISTS entries_user_status_idx;
+		`)
+		return err
+	},
 }


### PR DESCRIPTION
entries_feed_idx(feed_id) is covered by both the unique constraint entries_feed_id_hash_key(feed_id, hash) and the explicit index entries_feed_id_status_hash_idx(feed_id, status, hash), which handle all feed_id-leading lookups including FK cascade deletes.

entries_user_status_idx(user_id, status) is a prefix of five existing three-column indexes (entries_user_status_feed_idx, entries_user_status_changed_idx, entries_user_status_published_idx, entries_user_status_created_idx, entries_user_status_changed_published_idx), all of which serve every query the two-column index could.