### PR TITLE
fix(proxy): limit the data size going through the proxy

### DIFF
--- a/internal/ui/proxy.go
+++ b/internal/ui/proxy.go
@@ -159,7 +159,7 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 				b.WithHeader(responseHeaderName, resp.Header.Get(responseHeaderName))
 			}
 		}
-		b.WithBodyAsReader(resp.Body)
+		b.WithBodyAsReader(http.MaxBytesReader(nil, resp.Body, config.Opts.HTTPClientMaxBodySize()))
 		b.WithoutCompression()
 		b.Write()
 	})


### PR DESCRIPTION
The media proxy was streaming upstream response bodies to clients without any size bound, allowing a malicious origin server to exhaust server memory and bandwidth.

Reject responses immediately when Content-Length exceeds HTTPClientMaxBodySize, and wrap the body with io.LimitReader as a safety net for chunked/unknown-length responses, as is done everywhere else in miniflux.