### PR TITLE
perf(storage): fetch enclosures in GetEntries in GetEntry

### DIFF
--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -255,6 +255,7 @@ func (e *EntryQueryBuilder) CountEntries() (count int, err error) {
 // GetEntry returns a single entry that match the condition.
 func (e *EntryQueryBuilder) GetEntry() (*model.Entry, error) {
 	e.limit = 1
+	e.fetchEnclosures = true
 	entries, err := e.GetEntries()
 	if err != nil {
 		return nil, err
@@ -262,11 +263,6 @@ func (e *EntryQueryBuilder) GetEntry() (*model.Entry, error) {
 
 	if len(entries) != 1 {
 		return nil, nil
-	}
-
-	entries[0].Enclosures, err = e.store.GetEnclosures(entries[0].ID)
-	if err != nil {
-		return nil, err
 	}
 
 	return entries[0], nil


### PR DESCRIPTION
GetEntry() was issuing a separate GetEnclosures() query for the single returned entry. The batch path already exists: fetchEntries() checks the fetchEnclosures flag and calls GetEnclosuresForEntries() in one round-trip.

Set fetchEnclosures=true so GetEntry() uses that path, removing one database round-trip per call.