### PR TITLE
refactor(storage): Use INNER JOIN instead of LEFT JOIN in IconByFeedID

### DIFF
--- a/internal/storage/icon.go
+++ b/internal/storage/icon.go
@@ -78,8 +78,8 @@ func (s *Storage) IconByFeedID(userID, feedID int64) (*model.Icon, error) {
 			icons.content,
 			icons.external_id
 		FROM icons
-		LEFT JOIN feed_icons ON feed_icons.icon_id=icons.id
-		LEFT JOIN feeds ON feeds.id=feed_icons.feed_id
+		INNER JOIN feed_icons ON feed_icons.icon_id=icons.id
+		INNER JOIN feeds ON feeds.id=feed_icons.feed_id
 		WHERE
 			feeds.user_id=$1 AND feeds.id=$2
 		LIMIT 1


### PR DESCRIPTION
The WHERE clause on feeds columns already eliminates NULL-extended rows, making the LEFT JOINs logically equivalent to INNER JOINs. PostgreSQL's planner is smart enough to recognize this and produces an identical execution plan (verified with EXPLAIN ANALYZE), but using INNER JOIN makes the intent explicit for humans like me reading the query.