### PR TITLE
refactor(storage): remove a useless ORDER BY in GetEnclosure

### DIFF
--- a/internal/storage/enclosure.go
+++ b/internal/storage/enclosure.go
@@ -120,7 +120,6 @@ func (s *Storage) GetEnclosure(enclosureID int64) (*model.Enclosure, error) {
 			enclosures
 		WHERE
 			id = $1
-		ORDER BY id ASC
 	`
 
 	row := s.db.QueryRow(query, enclosureID)


### PR DESCRIPTION
The query selects a single row by primary key, there is no need to sort anything.