### PR TITLE
refactor(storage): use INNER JOIN where LEFT JOIN is redundant

### DIFF
--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -335,15 +335,15 @@ func (e *EntryQueryBuilder) fetchEntries(withCount bool) (model.Entries, int, er
 			u.timezone
 		FROM
 			entries e
-		LEFT JOIN
+		INNER JOIN
 			feeds f ON f.id=e.feed_id
-		LEFT JOIN
+		INNER JOIN
 			categories c ON c.id=f.category_id
 		LEFT JOIN
 			feed_icons fi ON fi.feed_id=f.id
 		LEFT JOIN
 			icons i ON i.id=fi.icon_id
-		LEFT JOIN
+		INNER JOIN
 			users u ON u.id=e.user_id
 		WHERE ` + e.buildCondition() + " " + e.buildSorting()
 

--- a/internal/storage/feed_query_builder.go
+++ b/internal/storage/feed_query_builder.go
@@ -312,7 +312,7 @@ func (f *feedQueryBuilder) fetchFeedCounter() (unreadCounters map[int64]int, rea
 	`
 	join := ""
 	if f.counterJoinFeeds {
-		join = "LEFT JOIN feeds f ON f.id=e.feed_id"
+		join = "INNER JOIN feeds f ON f.id=e.feed_id"
 	}
 	query = fmt.Sprintf(query, join, f.buildCounterCondition())
 

--- a/internal/storage/icon.go
+++ b/internal/storage/icon.go
@@ -175,8 +175,8 @@ func (s *Storage) Icons(userID int64) (model.Icons, error) {
 			icons.content,
 			icons.external_id
 		FROM icons
-		LEFT JOIN feed_icons ON feed_icons.icon_id=icons.id
-		LEFT JOIN feeds ON feeds.id=feed_icons.feed_id
+		INNER JOIN feed_icons ON feed_icons.icon_id=icons.id
+		INNER JOIN feeds ON feeds.id=feed_icons.feed_id
 		WHERE
 			feeds.user_id=$1
 	`

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -513,7 +513,7 @@ func (s *Storage) UserByAPIKey(token string) (*model.User, error) {
 			u.open_external_links_in_new_tab
 		FROM
 			users u
-		LEFT JOIN
+		INNER JOIN
 			api_keys ON api_keys.user_id=u.id
 		WHERE
 			api_keys.token = $1


### PR DESCRIPTION
Replace LEFT JOIN with INNER JOIN in queries where the WHERE clause or foreign key constraints already guarantee matching rows exist:

- Icons(): filters on feeds.user_id
- UserByAPIKey(): filters on api_keys.token
- fetchFeedCounter(): filters on feeds columns when counterJoinFeeds is set
- fetchEntries(): entries have FK constraints to feeds, categories, and users (feed_icons/icons kept as LEFT JOIN since icons are optional)

PostgreSQL already optimizes these identically, but INNER JOIN makes the intent explicit.