### PR TITLE
refactor(storage): collapse WithTags into a single array-containment predicate

### DIFF
--- a/internal/storage/entry_pagination_builder.go
+++ b/internal/storage/entry_pagination_builder.go
@@ -92,10 +92,8 @@ func (e *entryPaginationBuilder) WithStatusOrEntryID(status string, entryID int6
 
 func (e *entryPaginationBuilder) WithTags(tags []string) *entryPaginationBuilder {
 	if len(tags) > 0 {
-		for _, tag := range tags {
-			e.conditions = append(e.conditions, fmt.Sprintf("LOWER($%d) = ANY(LOWER(e.tags::text)::text[])", len(e.args)+1))
-			e.args = append(e.args, tag)
-		}
+		e.conditions = append(e.conditions, fmt.Sprintf("LOWER(e.tags::text)::text[] @> LOWER($%d::text)::text[]", len(e.args)+1))
+		e.args = append(e.args, pq.Array(tags))
 	}
 
 	return e

--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -177,10 +177,8 @@ func (e *EntryQueryBuilder) WithStatuses(statuses []string) *EntryQueryBuilder {
 // WithTags filter by a list of entry tags.
 func (e *EntryQueryBuilder) WithTags(tags []string) *EntryQueryBuilder {
 	if len(tags) > 0 {
-		for _, cat := range tags {
-			e.conditions = append(e.conditions, fmt.Sprintf("LOWER($%d) = ANY(LOWER(e.tags::text)::text[])", len(e.args)+1))
-			e.args = append(e.args, cat)
-		}
+		e.conditions = append(e.conditions, fmt.Sprintf("LOWER(e.tags::text)::text[] @> LOWER($%d::text)::text[]", len(e.args)+1))
+		e.args = append(e.args, pq.Array(tags))
 	}
 	return e
 }


### PR DESCRIPTION
WithTags previously emitted one "LOWER($i) = ANY(LOWER(e.tags::text)::text[])" condition and one parameter per filter tag. With K tags this means K predicates, K parameters, and K evaluations of the LOWER(e.tags::text)::text[] sub-expression per candidate row.

This commit replaces the loop with a single predicate using the array containment operator:

    LOWER(e.tags::text)::text[] @> LOWER($N::text)::text[]

Same case-insensitive "row must contain all listed tags" semantics, fewer predicates for the planner, and the row-side expression is referenced once instead of K times.