### PR TITLE
perf(subscription): use a slice instead of a map for well-known feed …

### DIFF
--- a/internal/reader/subscription/finder.go
+++ b/internal/reader/subscription/finder.go
@@ -171,16 +171,18 @@ func (f *subscriptionFinder) findSubscriptionsFromWebPage(websiteURL string, doc
 }
 
 func (f *subscriptionFinder) findSubscriptionsFromWellKnownURLs(websiteURL string) (Subscriptions, *locale.LocalizedErrorWrapper) {
-	knownURLs := map[string]string{
-		"atom.xml":     parser.FormatAtom,
-		"feed.atom":    parser.FormatAtom,
-		"feed.xml":     parser.FormatAtom,
-		"feed/":        parser.FormatAtom,
-		"index.rss":    parser.FormatRSS,
-		"index.xml":    parser.FormatRSS,
-		"rss.xml":      parser.FormatRSS,
-		"rss/":         parser.FormatRSS,
-		"rss/feed.xml": parser.FormatRSS,
+	knownURLs := [...]struct {
+		path, format string
+	}{
+		{"atom.xml", parser.FormatAtom},
+		{"feed.atom", parser.FormatAtom},
+		{"feed.xml", parser.FormatAtom},
+		{"feed/", parser.FormatAtom},
+		{"index.rss", parser.FormatRSS},
+		{"index.xml", parser.FormatRSS},
+		{"rss.xml", parser.FormatRSS},
+		{"rss/", parser.FormatRSS},
+		{"rss/feed.xml", parser.FormatRSS},
 	}
 
 	websiteURLRoot := urllib.RootURL(websiteURL)
@@ -197,8 +199,8 @@ func (f *subscriptionFinder) findSubscriptionsFromWellKnownURLs(websiteURL strin
 
 	var subscriptions Subscriptions
 	for _, baseURL := range baseURLs {
-		for knownURL, kind := range knownURLs {
-			fullURL, err := urllib.ResolveToAbsoluteURL(baseURL, knownURL)
+		for _, known := range knownURLs {
+			fullURL, err := urllib.ResolveToAbsoluteURL(baseURL, known.path)
 			if err != nil {
 				continue
 			}
@@ -227,7 +229,7 @@ func (f *subscriptionFinder) findSubscriptionsFromWellKnownURLs(websiteURL strin
 			}
 
 			subscriptions = append(subscriptions, &subscription{
-				Type:  kind,
+				Type:  known.format,
 				Title: fullURL,
 				URL:   fullURL,
 			})


### PR DESCRIPTION
…paths

findSubscriptionsFromWellKnownURLs iterates a fixed table of 9 well-known feed paths against the discovered base URLs. The table was declared as a map[string]string, which paid per-iteration hash overhead and gave non-deterministic probe order across runs.

This commit replaces it with a fixed-size [...]struct{path, format string}. Probes now run in declared order (more predictable behavior for users when multiple well-known URLs respond, and easier to reason about in tests), and the inner loop avoids the map iterator entirely.

Micro-benchmark replaying the double loop body against 2 base URLs × 9 paths, sans HTTP I/O (medians of 5 runs):

    name           old ns/op    new ns/op    delta
    KnownURLs      24,194       18,150       -25%

    name           old B/op     new B/op     delta
    KnownURLs      9,688        9,072        -6.4%

    name           old allocs/op  new allocs/op  delta
    KnownURLs      110            107            -3