### PR TITLE
perf(integration): don't defer in a for loop

### DIFF
--- a/internal/integration/apprise/apprise.go
+++ b/internal/integration/apprise/apprise.go
@@ -72,7 +72,7 @@ func (c *Client) SendNotification(feed *model.Feed, entries model.Entries) error
 		if err != nil {
 			return fmt.Errorf("apprise: unable to send request: %v", err)
 		}
-		defer response.Body.Close()
+		response.Body.Close()
 
 		if response.StatusCode >= 400 {
 			return fmt.Errorf("apprise: unable to send a notification: url=%s status=%d", apiEndpoint, response.StatusCode)

--- a/internal/integration/discord/discord.go
+++ b/internal/integration/discord/discord.go
@@ -84,7 +84,7 @@ func (c *Client) SendDiscordMsg(feed *model.Feed, entries model.Entries) error {
 		if err != nil {
 			return fmt.Errorf("discord: unable to send request: %v", err)
 		}
-		defer response.Body.Close()
+		response.Body.Close()
 
 		if response.StatusCode >= 400 {
 			return fmt.Errorf("discord: unable to send a notification: url=%s status=%d", c.webhookURL, response.StatusCode)

--- a/internal/integration/slack/slack.go
+++ b/internal/integration/slack/slack.go
@@ -88,7 +88,7 @@ func (c *Client) SendSlackMsg(feed *model.Feed, entries model.Entries) error {
 		if err != nil {
 			return fmt.Errorf("slack: unable to send request: %v", err)
 		}
-		defer response.Body.Close()
+		response.Body.Close()
 
 		if response.StatusCode >= 400 {
 			return fmt.Errorf("slack: unable to send a notification: url=%s status=%d", c.webhookURL, response.StatusCode)


### PR DESCRIPTION
Since the Body isn't used, it can immediately be closed, instead of deferring the operation to the end of the function.