### PR TITLE
refactor(storage): use same API for list and singular items

### DIFF
--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -57,7 +57,7 @@ func (h *handler) getFeedEntryHandler(w http.ResponseWriter, r *http.Request) {
 
 	builder := h.store.NewEntryQueryBuilder(request.UserID(r)).
 		WithFeedID(feedID).
-		WithEntryID(entryID)
+		WithEntryIDs(entryID)
 
 	h.getEntryFromBuilder(w, r, builder)
 }
@@ -77,7 +77,7 @@ func (h *handler) getCategoryEntryHandler(w http.ResponseWriter, r *http.Request
 
 	builder := h.store.NewEntryQueryBuilder(request.UserID(r)).
 		WithCategoryID(categoryID).
-		WithEntryID(entryID)
+		WithEntryIDs(entryID)
 
 	h.getEntryFromBuilder(w, r, builder)
 }
@@ -90,7 +90,7 @@ func (h *handler) getEntryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	builder := h.store.NewEntryQueryBuilder(request.UserID(r)).
-		WithEntryID(entryID)
+		WithEntryIDs(entryID)
 
 	h.getEntryFromBuilder(w, r, builder)
 }
@@ -164,11 +164,11 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 	builder := h.store.NewEntryQueryBuilder(userID).
 		WithFeedID(feedID).
 		WithCategoryID(categoryID).
-		WithStatuses(statuses).
+		WithStatuses(statuses...).
 		WithSorting(order, direction).
 		WithOffset(offset).
 		WithLimit(limit).
-		WithTags(tags).
+		WithTags(tags...).
 		WithEnclosures()
 
 	if request.HasQueryParam(r, "globally_visible") {
@@ -242,7 +242,7 @@ func (h *handler) saveEntryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entry, err := h.store.NewEntryQueryBuilder(request.UserID(r)).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.JSONServerError(w, r, err)
@@ -286,7 +286,7 @@ func (h *handler) updateEntryHandler(w http.ResponseWriter, r *http.Request) {
 	loggedUserID := request.UserID(r)
 
 	entry, err := h.store.NewEntryQueryBuilder(loggedUserID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.JSONServerError(w, r, err)
@@ -445,7 +445,7 @@ func (h *handler) fetchContentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entry, err := h.store.NewEntryQueryBuilder(loggedUserID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.JSONServerError(w, r, err)

--- a/internal/fever/handler.go
+++ b/internal/fever/handler.go
@@ -278,7 +278,7 @@ func (h *feverHandler) handleItems(w http.ResponseWriter, r *http.Request) {
 				itemIDs = append(itemIDs, itemID)
 			}
 
-			builder.WithEntryIDs(itemIDs)
+			builder.WithEntryIDs(itemIDs...)
 		}
 	default:
 		slog.Debug("[Fever] Fetching oldest items",
@@ -343,7 +343,7 @@ func (h *feverHandler) handleUnreadItems(w http.ResponseWriter, r *http.Request)
 	)
 
 	rawEntryIDs, err := h.store.NewEntryQueryBuilder(userID).
-		WithStatus(model.EntryStatusUnread).
+		WithStatuses(model.EntryStatusUnread).
 		GetEntryIDs()
 	if err != nil {
 		response.JSONServerError(w, r, err)
@@ -410,7 +410,7 @@ func (h *feverHandler) handleWriteItems(w http.ResponseWriter, r *http.Request) 
 	}
 
 	entry, err := h.store.NewEntryQueryBuilder(userID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.JSONServerError(w, r, err)

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -237,7 +237,7 @@ func (h *greaderHandler) editTagHandler(w http.ResponseWriter, r *http.Request) 
 	)
 
 	entries, err := h.store.NewEntryQueryBuilder(userID).
-		WithEntryIDs(itemIDs).
+		WithEntryIDs(itemIDs...).
 		GetEntries()
 	if err != nil {
 		response.JSONServerError(w, r, err)
@@ -650,7 +650,7 @@ func (h *greaderHandler) streamItemContentsHandler(w http.ResponseWriter, r *htt
 
 	entries, err := h.store.NewEntryQueryBuilder(userID).
 		WithEnclosures().
-		WithEntryIDs(itemIDs).
+		WithEntryIDs(itemIDs...).
 		WithSorting(model.DefaultSortingOrder, requestModifiers.SortDirection).
 		GetEntries()
 	if err != nil {
@@ -1018,7 +1018,7 @@ func (h *greaderHandler) handleReadingListStreamHandler(w http.ResponseWriter, r
 	for _, s := range rm.ExcludeTargets {
 		switch s.Type {
 		case ReadStream:
-			builder.WithStatus(model.EntryStatusUnread)
+			builder.WithStatuses(model.EntryStatusUnread)
 		default:
 			slog.Warn("[GoogleReader] Unknown ExcludeTargets filter type",
 				slog.String("handler", "handleReadingListStreamHandler"),
@@ -1071,7 +1071,7 @@ func (h *greaderHandler) handleStarredStreamHandler(w http.ResponseWriter, r *ht
 
 func (h *greaderHandler) handleReadStreamHandler(w http.ResponseWriter, r *http.Request, rm requestModifiers) {
 	builder := h.store.NewEntryQueryBuilder(rm.UserID).
-		WithStatus(model.EntryStatusRead).
+		WithStatuses(model.EntryStatusRead).
 		WithLimit(rm.Count).
 		WithOffset(rm.Offset).
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)

--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -115,22 +115,13 @@ func (e *EntryQueryBuilder) AfterEntryID(entryID int64) *EntryQueryBuilder {
 }
 
 // WithEntryIDs filter by entry IDs.
-func (e *EntryQueryBuilder) WithEntryIDs(entryIDs []int64) *EntryQueryBuilder {
+func (e *EntryQueryBuilder) WithEntryIDs(entryIDs ...int64) *EntryQueryBuilder {
 	if len(entryIDs) == 1 {
 		e.conditions = append(e.conditions, fmt.Sprintf("e.id = $%d", len(e.args)+1))
 		e.args = append(e.args, entryIDs[0])
 	} else if len(entryIDs) > 1 {
 		e.conditions = append(e.conditions, fmt.Sprintf("e.id = ANY($%d)", len(e.args)+1))
 		e.args = append(e.args, pq.Int64Array(entryIDs))
-	}
-	return e
-}
-
-// WithEntryID filter by entry ID.
-func (e *EntryQueryBuilder) WithEntryID(entryID int64) *EntryQueryBuilder {
-	if entryID != 0 {
-		e.conditions = append(e.conditions, "e.id = $"+strconv.Itoa(len(e.args)+1))
-		e.args = append(e.args, entryID)
 	}
 	return e
 }
@@ -153,17 +144,8 @@ func (e *EntryQueryBuilder) WithCategoryID(categoryID int64) *EntryQueryBuilder 
 	return e
 }
 
-// WithStatus filter by entry status.
-func (e *EntryQueryBuilder) WithStatus(status string) *EntryQueryBuilder {
-	if status != "" {
-		e.conditions = append(e.conditions, "e.status = $"+strconv.Itoa(len(e.args)+1))
-		e.args = append(e.args, status)
-	}
-	return e
-}
-
 // WithStatuses filter by a list of entry statuses.
-func (e *EntryQueryBuilder) WithStatuses(statuses []string) *EntryQueryBuilder {
+func (e *EntryQueryBuilder) WithStatuses(statuses ...string) *EntryQueryBuilder {
 	if len(statuses) == 1 {
 		e.conditions = append(e.conditions, fmt.Sprintf("e.status = $%d", len(e.args)+1))
 		e.args = append(e.args, statuses[0])
@@ -175,7 +157,7 @@ func (e *EntryQueryBuilder) WithStatuses(statuses []string) *EntryQueryBuilder {
 }
 
 // WithTags filter by a list of entry tags.
-func (e *EntryQueryBuilder) WithTags(tags []string) *EntryQueryBuilder {
+func (e *EntryQueryBuilder) WithTags(tags ...string) *EntryQueryBuilder {
 	if len(tags) > 0 {
 		for _, cat := range tags {
 			e.conditions = append(e.conditions, fmt.Sprintf("LOWER($%d) = ANY(LOWER(e.tags::text)::text[])", len(e.args)+1))

--- a/internal/ui/category_entries.go
+++ b/internal/ui/category_entries.go
@@ -37,7 +37,7 @@ func (h *handler) showCategoryEntriesPage(w http.ResponseWriter, r *http.Request
 		WithCategoryID(category.ID).
 		WithSorting(user.EntryOrder, user.EntryDirection).
 		WithSorting("id", user.EntryDirection).
-		WithStatus(model.EntryStatusUnread).
+		WithStatuses(model.EntryStatusUnread).
 		WithoutContent().
 		WithOffset(offset).
 		WithLimit(user.EntriesPerPage).

--- a/internal/ui/entry_category.go
+++ b/internal/ui/entry_category.go
@@ -24,7 +24,7 @@ func (h *handler) showCategoryEntryPage(w http.ResponseWriter, r *http.Request) 
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithCategoryID(categoryID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/entry_feed.go
+++ b/internal/ui/entry_feed.go
@@ -24,7 +24,7 @@ func (h *handler) showFeedEntryPage(w http.ResponseWriter, r *http.Request) {
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithFeedID(feedID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/entry_read.go
+++ b/internal/ui/entry_read.go
@@ -22,7 +22,7 @@ func (h *handler) showReadEntryPage(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/entry_save.go
+++ b/internal/ui/entry_save.go
@@ -15,7 +15,7 @@ func (h *handler) saveEntry(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 
 	entry, err := h.store.NewEntryQueryBuilder(request.UserID(r)).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.JSONServerError(w, r, err)

--- a/internal/ui/entry_scraper.go
+++ b/internal/ui/entry_scraper.go
@@ -18,7 +18,7 @@ func (h *handler) fetchContent(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 
 	entry, err := h.store.NewEntryQueryBuilder(loggedUserID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.JSONServerError(w, r, err)

--- a/internal/ui/entry_search.go
+++ b/internal/ui/entry_search.go
@@ -25,7 +25,7 @@ func (h *handler) showSearchEntryPage(w http.ResponseWriter, r *http.Request) {
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithSearchQuery(searchQuery).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/entry_starred.go
+++ b/internal/ui/entry_starred.go
@@ -22,7 +22,7 @@ func (h *handler) showStarredEntryPage(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/entry_tag.go
+++ b/internal/ui/entry_tag.go
@@ -28,8 +28,8 @@ func (h *handler) showTagEntryPage(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithTags([]string{tagName}).
-		WithEntryID(entryID).
+		WithTags(tagName).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/entry_unread.go
+++ b/internal/ui/entry_unread.go
@@ -22,7 +22,7 @@ func (h *handler) showUnreadEntryPage(w http.ResponseWriter, r *http.Request) {
 	entryID := request.RouteInt64Param(r, "entryID")
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/feed_entries.go
+++ b/internal/ui/feed_entries.go
@@ -35,7 +35,7 @@ func (h *handler) showFeedEntriesPage(w http.ResponseWriter, r *http.Request) {
 
 	entries, count, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithFeedID(feed.ID).
-		WithStatus(model.EntryStatusUnread).
+		WithStatuses(model.EntryStatusUnread).
 		WithSorting(user.EntryOrder, user.EntryDirection).
 		WithSorting("id", user.EntryDirection).
 		WithOffset(offset).

--- a/internal/ui/history_entries.go
+++ b/internal/ui/history_entries.go
@@ -22,7 +22,7 @@ func (h *handler) showHistoryPage(w http.ResponseWriter, r *http.Request) {
 	offset := request.QueryIntParam(r, "offset", 0)
 
 	entries, count, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithStatus(model.EntryStatusRead).
+		WithStatuses(model.EntryStatusRead).
 		WithSorting("changed_at", "DESC").
 		WithSorting("published_at", "DESC").
 		WithoutContent().

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -34,7 +34,7 @@ func (h *handler) showSearchPage(w http.ResponseWriter, r *http.Request) {
 			WithLimit(user.EntriesPerPage)
 
 		if unreadOnly {
-			builder.WithStatus(model.EntryStatusUnread)
+			builder.WithStatuses(model.EntryStatusUnread)
 		}
 
 		entries, entriesCount, err = builder.GetEntriesWithCount()

--- a/internal/ui/starred_entry_category.go
+++ b/internal/ui/starred_entry_category.go
@@ -24,7 +24,7 @@ func (h *handler) showStarredCategoryEntryPage(w http.ResponseWriter, r *http.Re
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithCategoryID(categoryID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/tag_entries_all.go
+++ b/internal/ui/tag_entries_all.go
@@ -28,7 +28,7 @@ func (h *handler) showTagEntriesAllPage(w http.ResponseWriter, r *http.Request) 
 	offset := request.QueryIntParam(r, "offset", 0)
 
 	entries, count, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithTags([]string{tagName}).
+		WithTags(tagName).
 		WithSorting("status", "asc").
 		WithSorting(user.EntryOrder, user.EntryDirection).
 		WithSorting("id", user.EntryDirection).

--- a/internal/ui/unread_entries.go
+++ b/internal/ui/unread_entries.go
@@ -22,7 +22,7 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 	offset := request.QueryIntParam(r, "offset", 0)
 
 	entries, countUnread, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithStatus(model.EntryStatusUnread).
+		WithStatuses(model.EntryStatusUnread).
 		WithSorting(user.EntryOrder, user.EntryDirection).
 		WithSorting("id", user.EntryDirection).
 		WithOffset(offset).
@@ -39,7 +39,7 @@ func (h *handler) showUnreadPage(w http.ResponseWriter, r *http.Request) {
 		offset = 0
 
 		entries, countUnread, err = h.store.NewEntryQueryBuilder(user.ID).
-			WithStatus(model.EntryStatusUnread).
+			WithStatuses(model.EntryStatusUnread).
 			WithSorting(user.EntryOrder, user.EntryDirection).
 			WithSorting("id", user.EntryDirection).
 			WithLimit(user.EntriesPerPage).

--- a/internal/ui/unread_entry_category.go
+++ b/internal/ui/unread_entry_category.go
@@ -24,7 +24,7 @@ func (h *handler) showUnreadCategoryEntryPage(w http.ResponseWriter, r *http.Req
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithCategoryID(categoryID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)

--- a/internal/ui/unread_entry_feed.go
+++ b/internal/ui/unread_entry_feed.go
@@ -24,7 +24,7 @@ func (h *handler) showUnreadFeedEntryPage(w http.ResponseWriter, r *http.Request
 
 	entry, err := h.store.NewEntryQueryBuilder(user.ID).
 		WithFeedID(feedID).
-		WithEntryID(entryID).
+		WithEntryIDs(entryID).
 		GetEntry()
 	if err != nil {
 		response.HTMLServerError(w, r, err)


### PR DESCRIPTION
Instead of relying on `WithX` and `WithXs` just stick to latter with parametrized arguments.

This make API more straightforward and avoids calls like this one:
`builder.WithTags([]string{tagName})`

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
