### PR TITLE
reader: unify common code between feed readers

### DIFF
--- a/internal/reader/atom/atom_03_adapter.go
+++ b/internal/reader/atom/atom_03_adapter.go
@@ -19,7 +19,10 @@ type atom03Adapter struct {
 }
 
 func (a *atom03Adapter) buildFeed(baseURL string) *model.Feed {
-	feed := new(model.Feed)
+	feed := &model.Feed{
+		FeedURL: baseURL,
+		SiteURL: baseURL,
+	}
 
 	// Populate the feed URL.
 	feedURL := a.atomFeed.Links.firstLinkWithRelation("self")
@@ -27,8 +30,6 @@ func (a *atom03Adapter) buildFeed(baseURL string) *model.Feed {
 		if absoluteFeedURL, err := urllib.ResolveToAbsoluteURL(baseURL, feedURL); err == nil {
 			feed.FeedURL = absoluteFeedURL
 		}
-	} else {
-		feed.FeedURL = baseURL
 	}
 
 	// Populate the site URL.
@@ -37,8 +38,6 @@ func (a *atom03Adapter) buildFeed(baseURL string) *model.Feed {
 		if absoluteSiteURL, err := urllib.ResolveToAbsoluteURL(baseURL, siteURL); err == nil {
 			feed.SiteURL = absoluteSiteURL
 		}
-	} else {
-		feed.SiteURL = baseURL
 	}
 
 	// Populate the feed title.
@@ -69,6 +68,7 @@ func (a *atom03Adapter) buildFeed(baseURL string) *model.Feed {
 		if entry.Title == "" {
 			entry.Title = sanitizer.TruncateHTML(entry.Content, 100)
 		}
+
 		if entry.Title == "" {
 			entry.Title = entry.URL
 		}
@@ -81,17 +81,24 @@ func (a *atom03Adapter) buildFeed(baseURL string) *model.Feed {
 
 		// Populate the entry date.
 		for _, value := range []string{atomEntry.Issued, atomEntry.Modified, atomEntry.Created} {
-			if parsedDate, err := date.Parse(value); err == nil {
-				entry.Date = parsedDate
-				break
-			} else {
+			if value = strings.TrimSpace(value); value == "" {
+				continue
+			}
+
+			parsedDate, err := date.Parse(value)
+			if err != nil {
 				slog.Debug("Unable to parse date from Atom 0.3 feed",
 					slog.String("date", value),
 					slog.String("id", atomEntry.ID),
 					slog.Any("error", err),
 				)
+				continue
 			}
+
+			entry.Date = parsedDate
+			break
 		}
+
 		if entry.Date.IsZero() {
 			entry.Date = time.Now()
 		}

--- a/internal/reader/atom/atom_03_adapter.go
+++ b/internal/reader/atom/atom_03_adapter.go
@@ -5,6 +5,7 @@ package atom // import "miniflux.app/v2/internal/reader/atom"
 
 import (
 	"log/slog"
+	"strings"
 	"time"
 
 	"miniflux.app/v2/internal/crypto"

--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -20,11 +20,7 @@ type atom10Adapter struct {
 	atomFeed *atom10Feed
 }
 
-func NewAtom10Adapter(atomFeed *atom10Feed) *atom10Adapter {
-	return &atom10Adapter{atomFeed}
-}
-
-func (a *atom10Adapter) BuildFeed(baseURL string) *model.Feed {
+func (a *atom10Adapter) buildFeed(baseURL string) *model.Feed {
 	feed := &model.Feed{
 		FeedURL: baseURL,
 		SiteURL: baseURL,

--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -27,7 +27,10 @@ func NewAtom10Adapter(atomFeed *atom10Feed) *atom10Adapter {
 }
 
 func (a *atom10Adapter) BuildFeed(baseURL string) *model.Feed {
-	feed := new(model.Feed)
+	feed := &model.Feed{
+		FeedURL: baseURL,
+		SiteURL: baseURL,
+	}
 
 	// Populate the feed URL.
 	feedURL := a.atomFeed.Links.firstLinkWithRelation("self")
@@ -35,8 +38,6 @@ func (a *atom10Adapter) BuildFeed(baseURL string) *model.Feed {
 		if absoluteFeedURL, err := urllib.ResolveToAbsoluteURL(baseURL, feedURL); err == nil {
 			feed.FeedURL = absoluteFeedURL
 		}
-	} else {
-		feed.FeedURL = baseURL
 	}
 
 	// Populate the site URL.
@@ -45,8 +46,6 @@ func (a *atom10Adapter) BuildFeed(baseURL string) *model.Feed {
 		if absoluteSiteURL, err := urllib.ResolveToAbsoluteURL(baseURL, siteURL); err == nil {
 			feed.SiteURL = absoluteSiteURL
 		}
-	} else {
-		feed.SiteURL = baseURL
 	}
 
 	// Populate the feed title.
@@ -59,15 +58,17 @@ func (a *atom10Adapter) BuildFeed(baseURL string) *model.Feed {
 	feed.Description = a.atomFeed.Subtitle.body()
 
 	// Populate the feed icon.
-	if a.atomFeed.Icon != "" {
-		if absoluteIconURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, a.atomFeed.Icon); err == nil {
-			feed.IconURL = absoluteIconURL
+	for _, value := range []string{a.atomFeed.Icon, a.atomFeed.Logo} {
+		if value = strings.TrimSpace(value); value == "" {
+			continue
 		}
-	} else if a.atomFeed.Logo != "" {
-		if absoluteLogoURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, a.atomFeed.Logo); err == nil {
-			feed.IconURL = absoluteLogoURL
+
+		if iconURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, value); err == nil {
+			feed.IconURL = iconURL
+			break
 		}
 	}
+
 	feed.Entries = a.populateEntries(feed.SiteURL)
 	return feed
 }
@@ -115,19 +116,24 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 		// Populate the entry date.
 		for _, value := range []string{atomEntry.Published, atomEntry.Updated} {
-			if value != "" {
-				if parsedDate, err := date.Parse(value); err != nil {
-					slog.Debug("Unable to parse date from Atom 1.0 feed",
-						slog.String("date", value),
-						slog.String("url", entry.URL),
-						slog.Any("error", err),
-					)
-				} else {
-					entry.Date = parsedDate
-					break
-				}
+			if value = strings.TrimSpace(value); value == "" {
+				continue
 			}
+
+			parsedDate, err := date.Parse(value)
+			if err != nil {
+				slog.Debug("Unable to parse date from Atom 1.0 feed",
+					slog.String("date", value),
+					slog.String("url", entry.URL),
+					slog.Any("error", err),
+				)
+				continue
+			}
+
+			entry.Date = parsedDate
+			break
 		}
+
 		if entry.Date.IsZero() {
 			entry.Date = time.Now()
 		}
@@ -167,22 +173,28 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 			if mediaURL == "" {
 				continue
 			}
-			if _, found := uniqueEnclosuresMap[mediaURL]; !found {
-				if mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL); err != nil {
-					slog.Debug("Unable to build absolute URL for media thumbnail",
-						slog.String("url", mediaThumbnail.URL),
-						slog.String("site_url", siteURL),
-						slog.Any("error", err),
-					)
-				} else {
-					uniqueEnclosuresMap[mediaAbsoluteURL] = true
-					entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
-						URL:      mediaAbsoluteURL,
-						MimeType: mediaThumbnail.MimeType(),
-						Size:     mediaThumbnail.Size(),
-					})
-				}
+
+			if _, found := uniqueEnclosuresMap[mediaURL]; found {
+				continue
 			}
+
+			mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL)
+			if err != nil {
+				slog.Debug("Unable to build absolute URL for media thumbnail",
+					slog.String("url", mediaThumbnail.URL),
+					slog.String("site_url", siteURL),
+					slog.Any("error", err),
+				)
+				continue
+			}
+
+			uniqueEnclosuresMap[mediaAbsoluteURL] = true
+
+			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+				URL:      mediaAbsoluteURL,
+				MimeType: mediaThumbnail.MimeType(),
+				Size:     mediaThumbnail.Size(),
+			})
 		}
 
 		for _, link := range atomEntry.Links.findAllLinksWithRelation("enclosure") {
@@ -193,17 +205,21 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 					slog.String("entry_url", entry.URL),
 					slog.Any("error", err),
 				)
-			} else {
-				if _, found := uniqueEnclosuresMap[absoluteEnclosureURL]; !found {
-					uniqueEnclosuresMap[absoluteEnclosureURL] = true
-					length, _ := strconv.ParseInt(link.Length, 10, 0)
-					entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
-						URL:      absoluteEnclosureURL,
-						MimeType: link.Type,
-						Size:     length,
-					})
-				}
+				continue
 			}
+
+			if _, found := uniqueEnclosuresMap[absoluteEnclosureURL]; found {
+				continue
+			}
+
+			uniqueEnclosuresMap[absoluteEnclosureURL] = true
+
+			length, _ := strconv.ParseInt(link.Length, 10, 0)
+			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+				URL:      absoluteEnclosureURL,
+				MimeType: link.Type,
+				Size:     length,
+			})
 		}
 
 		for _, mediaContent := range atomEntry.AllMediaContents() {
@@ -211,22 +227,28 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 			if mediaURL == "" {
 				continue
 			}
-			if mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL); err != nil {
+
+			mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL)
+			if err != nil {
 				slog.Debug("Unable to build absolute URL for media content",
 					slog.String("url", mediaContent.URL),
 					slog.String("site_url", siteURL),
 					slog.Any("error", err),
 				)
-			} else {
-				if _, found := uniqueEnclosuresMap[mediaAbsoluteURL]; !found {
-					uniqueEnclosuresMap[mediaAbsoluteURL] = true
-					entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
-						URL:      mediaAbsoluteURL,
-						MimeType: mediaContent.MimeType(),
-						Size:     mediaContent.Size(),
-					})
-				}
+				continue
 			}
+
+			if _, found := uniqueEnclosuresMap[mediaAbsoluteURL]; found {
+				continue
+			}
+
+			uniqueEnclosuresMap[mediaAbsoluteURL] = true
+
+			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+				URL:      mediaAbsoluteURL,
+				MimeType: mediaContent.MimeType(),
+				Size:     mediaContent.Size(),
+			})
 		}
 
 		for _, mediaPeerLink := range atomEntry.AllMediaPeerLinks() {
@@ -234,22 +256,28 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 			if mediaURL == "" {
 				continue
 			}
-			if mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL); err != nil {
+
+			mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL)
+			if err != nil {
 				slog.Debug("Unable to build absolute URL for media peer link",
 					slog.String("url", mediaPeerLink.URL),
 					slog.String("site_url", siteURL),
 					slog.Any("error", err),
 				)
-			} else {
-				if _, found := uniqueEnclosuresMap[mediaAbsoluteURL]; !found {
-					uniqueEnclosuresMap[mediaAbsoluteURL] = true
-					entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
-						URL:      mediaAbsoluteURL,
-						MimeType: mediaPeerLink.MimeType(),
-						Size:     mediaPeerLink.Size(),
-					})
-				}
+				continue
 			}
+
+			if _, found := uniqueEnclosuresMap[mediaAbsoluteURL]; found {
+				continue
+			}
+
+			uniqueEnclosuresMap[mediaAbsoluteURL] = true
+
+			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+				URL:      mediaAbsoluteURL,
+				MimeType: mediaPeerLink.MimeType(),
+				Size:     mediaPeerLink.Size(),
+			})
 		}
 
 		entries = append(entries, entry)

--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -5,8 +5,6 @@ package atom // import "miniflux.app/v2/internal/reader/atom"
 
 import (
 	"log/slog"
-	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -110,8 +108,7 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 		if len(authors) == 0 {
 			authors = a.atomFeed.Authors.personNames()
 		}
-		sort.Strings(authors)
-		authors = slices.Compact(authors)
+
 		entry.Author = strings.Join(authors, ", ")
 
 		// Populate the entry date.
@@ -139,14 +136,10 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 		}
 
 		// Populate categories.
-		categories := atomEntry.Categories.CategoryNames()
-		if len(categories) == 0 {
-			categories = a.atomFeed.Categories.CategoryNames()
+		entry.Tags = atomEntry.Categories.CategoryNames()
+		if len(entry.Tags) == 0 {
+			entry.Tags = a.atomFeed.Categories.CategoryNames()
 		}
-
-		// Sort and deduplicate categories.
-		sort.Strings(categories)
-		entry.Tags = slices.Compact(categories)
 
 		// Populate the commentsURL if defined.
 		// See https://tools.ietf.org/html/rfc4685#section-4

--- a/internal/reader/atom/atom_common.go
+++ b/internal/reader/atom/atom_common.go
@@ -4,6 +4,8 @@
 package atom // import "miniflux.app/v2/internal/reader/atom"
 
 import (
+	"cmp"
+	"slices"
 	"strings"
 )
 
@@ -32,19 +34,9 @@ func (a *AtomPerson) PersonName() string {
 
 type atomPersons []*AtomPerson
 
+// personNames returns sorted and deduplicated author names.
 func (a atomPersons) personNames() []string {
-	names := make([]string, 0, len(a))
-	authorNamesMap := make(map[string]bool, len(a))
-
-	for _, person := range a {
-		personName := person.PersonName()
-		if _, ok := authorNamesMap[personName]; !ok {
-			names = append(names, personName)
-			authorNamesMap[personName] = true
-		}
-	}
-
-	return names
+	return makeSorted((*AtomPerson).PersonName, a)
 }
 
 // Specs: https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.7
@@ -134,22 +126,45 @@ type atomCategory struct {
 	Label string `xml:"label,attr"`
 }
 
-type atomCategories []atomCategory
-
-func (ac atomCategories) CategoryNames() []string {
-	categories := make([]string, 0, len(ac))
-
-	for _, category := range ac {
-		label := strings.TrimSpace(category.Label)
-		if label != "" {
-			categories = append(categories, label)
-		} else {
-			term := strings.TrimSpace(category.Term)
-			if term != "" {
-				categories = append(categories, term)
-			}
-		}
+func (ac atomCategory) name() string {
+	name := strings.TrimSpace(ac.Label)
+	if name != "" {
+		return name
 	}
 
-	return categories
+	name = strings.TrimSpace(ac.Term)
+	if name != "" {
+		return name
+	}
+
+	return ""
+}
+
+type atomCategories []atomCategory
+
+// CategoryNames returns sorted and deduplicated category names.
+func (ac atomCategories) CategoryNames() []string {
+	return makeSorted(atomCategory.name, ac)
+}
+
+func makeSorted[I any, O cmp.Ordered](fn func(I) O, values []I) []O {
+	var zero O
+
+	sorted := make([]O, 0, len(values))
+	for _, in := range values {
+		out := fn(in)
+		if out == zero {
+			continue
+		}
+
+		where, found := slices.BinarySearch(sorted, out)
+		if found {
+			continue
+		}
+
+		// Insert sorted to avoid duplicates.
+		sorted = slices.Insert(sorted, where, out)
+	}
+
+	return sorted
 }

--- a/internal/reader/atom/parser.go
+++ b/internal/reader/atom/parser.go
@@ -27,6 +27,6 @@ func Parse(baseURL string, r io.ReadSeeker, version string) (*model.Feed, error)
 			return nil, fmt.Errorf("atom: unable to parse Atom 1.0 feed: %w", err)
 		}
 		adapter := &atom10Adapter{atomFeed}
-		return adapter.BuildFeed(baseURL), nil
+		return adapter.buildFeed(baseURL), nil
 	}
 }

--- a/internal/reader/itunes/itunes.go
+++ b/internal/reader/itunes/itunes.go
@@ -3,7 +3,10 @@
 
 package itunes // import "miniflux.app/v2/internal/reader/itunes"
 
-import "strings"
+import (
+	"iter"
+	"strings"
+)
 
 // Specs: https://help.apple.com/itc/podcasts_connect/#/itcb54353390
 type ItunesChannelElement struct {
@@ -22,15 +25,16 @@ type ItunesChannelElement struct {
 	ItunesType       string                  `xml:"http://www.itunes.com/dtds/podcast-1.0.dtd type"`
 }
 
-func (i *ItunesChannelElement) GetItunesCategories() []string {
-	categories := make([]string, 0, len(i.ItunesCategories))
-	for _, category := range i.ItunesCategories {
-		categories = append(categories, category.Text)
-		if category.SubCategory != nil {
-			categories = append(categories, category.SubCategory.Text)
+func (i *ItunesChannelElement) ItunesCategoriesSeq() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, category := range i.ItunesCategories {
+			for text := range category.All() {
+				if !yield(text) {
+					return
+				}
+			}
 		}
 	}
-	return categories
 }
 
 type ItunesItemElement struct {
@@ -54,6 +58,22 @@ type ItunesImageElement struct {
 type ItunesCategoryElement struct {
 	Text        string                 `xml:"text,attr"`
 	SubCategory *ItunesCategoryElement `xml:"http://www.itunes.com/dtds/podcast-1.0.dtd category"`
+}
+
+// All returns iterator for all category names including every nested [ItunesCategoryElement.SubCategory].
+func (cat *ItunesCategoryElement) All() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for ; cat != nil; cat = cat.SubCategory {
+			text := strings.TrimSpace(cat.Text)
+			if text == "" {
+				continue
+			}
+
+			if !yield(text) {
+				return
+			}
+		}
+	}
 }
 
 type ItunesOwnerElement struct {

--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -56,32 +56,34 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 
 	// Populate the icon URL if present.
 	for _, iconURL := range []string{j.jsonFeed.FaviconURL, j.jsonFeed.IconURL} {
-		iconURL = strings.TrimSpace(iconURL)
-		if iconURL != "" {
-			if absoluteIconURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, iconURL); err == nil {
-				feed.IconURL = absoluteIconURL
-				break
-			}
+		if iconURL = strings.TrimSpace(iconURL); iconURL == "" {
+			continue
+		}
+
+		if absoluteIconURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, iconURL); err == nil {
+			feed.IconURL = absoluteIconURL
+			break
 		}
 	}
 
 	for _, item := range j.jsonFeed.Items {
 		entry := model.NewEntry()
-		entry.Title = strings.TrimSpace(item.Title)
 
 		for _, itemURL := range []string{item.URL, item.ExternalURL} {
-			itemURL = strings.TrimSpace(itemURL)
-			if itemURL != "" {
-				// Make sure the entry URL is absolute.
-				if entryURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, itemURL); err == nil {
-					entry.URL = entryURL
-				}
+			if itemURL = strings.TrimSpace(itemURL); itemURL == "" {
+				continue
+			}
+
+			// Make sure the entry URL is absolute.
+			if entryURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, itemURL); err == nil {
+				entry.URL = entryURL
 				break
 			}
 		}
 
-		// The entry title is optional, so we need to find a fallback.
+		entry.Title = strings.TrimSpace(item.Title)
 		if entry.Title == "" {
+			// The entry title is optional, so we need to find a fallback.
 			for _, value := range []string{item.Summary, item.ContentText, item.ContentHTML} {
 				if value = sanitizer.TruncateHTML(value, 100); value == "" {
 					continue
@@ -99,29 +101,34 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 
 		// Populate the entry content.
 		for _, value := range []string{item.ContentHTML, item.ContentText, item.Summary} {
-			value = strings.TrimSpace(value)
-			if value != "" {
-				entry.Content = value
-				break
+			if value = strings.TrimSpace(value); value == "" {
+				continue
 			}
+
+			entry.Content = value
+			break
 		}
 
 		// Populate the entry date.
 		for _, value := range []string{item.DatePublished, item.DateModified} {
-			value = strings.TrimSpace(value)
-			if value != "" {
-				if date, err := date.Parse(value); err != nil {
-					slog.Debug("Unable to parse date from JSON feed",
-						slog.String("date", value),
-						slog.String("url", entry.URL),
-						slog.Any("error", err),
-					)
-				} else {
-					entry.Date = date
-					break
-				}
+			if value = strings.TrimSpace(value); value == "" {
+				continue
 			}
+
+			parsedDate, err := date.Parse(value)
+			if err != nil {
+				slog.Debug("Unable to parse date from JSON feed",
+					slog.String("date", value),
+					slog.String("url", entry.URL),
+					slog.Any("error", err),
+				)
+				continue
+			}
+
+			entry.Date = parsedDate
+			break
 		}
+
 		if entry.Date.IsZero() {
 			entry.Date = time.Now()
 		}
@@ -146,15 +153,25 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		// Populate the entry enclosures.
 		for _, attachment := range item.Attachments {
 			attachmentURL := strings.TrimSpace(attachment.URL)
-			if attachmentURL != "" {
-				if absoluteAttachmentURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, attachmentURL); err == nil {
-					entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
-						URL:      absoluteAttachmentURL,
-						MimeType: attachment.MimeType,
-						Size:     attachment.Size,
-					})
-				}
+			if attachmentURL == "" {
+				continue
 			}
+
+			absoluteAttachmentURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, attachmentURL)
+			if err != nil {
+				slog.Debug("Unable to build absolute URL for attachment",
+					slog.String("url", attachmentURL),
+					slog.String("site_url", feed.SiteURL),
+					slog.Any("error", err),
+				)
+				continue
+			}
+
+			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+				URL:      absoluteAttachmentURL,
+				MimeType: attachment.MimeType,
+				Size:     attachment.Size,
+			})
 		}
 
 		// Populate the entry tags.

--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -4,6 +4,7 @@
 package json // import "miniflux.app/v2/internal/reader/json"
 
 import (
+	"cmp"
 	"log/slog"
 	"slices"
 	"strings"
@@ -134,20 +135,12 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		}
 
 		// Populate the entry author.
-		itemAuthors := j.jsonFeed.Authors
-		itemAuthors = append(itemAuthors, item.Authors...)
-		itemAuthors = append(itemAuthors, item.Author, j.jsonFeed.Author)
+		authorNames := make([]string, 0, len(j.jsonFeed.Authors)+len(item.Authors)+1+1)
 
-		var authorNames = make([]string, 0, len(itemAuthors))
-		for _, author := range itemAuthors {
-			authorName := strings.TrimSpace(author.Name)
-			if authorName != "" {
-				authorNames = append(authorNames, authorName)
-			}
-		}
+		authorNames = appendSorted(authorNames, JSONAuthor.name, j.jsonFeed.Authors...)
+		authorNames = appendSorted(authorNames, JSONAuthor.name, item.Authors...)
+		authorNames = appendSorted(authorNames, JSONAuthor.name, item.Author, j.jsonFeed.Author)
 
-		slices.Sort(authorNames)
-		authorNames = slices.Compact(authorNames)
 		entry.Author = strings.Join(authorNames, ", ")
 
 		// Populate the entry enclosures.
@@ -175,16 +168,8 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		}
 
 		// Populate the entry tags.
-		for _, tag := range item.Tags {
-			tag = strings.TrimSpace(tag)
-			if tag != "" {
-				entry.Tags = append(entry.Tags, tag)
-			}
-		}
-
-		// Sort and deduplicate tags.
-		slices.Sort(entry.Tags)
-		entry.Tags = slices.Compact(entry.Tags)
+		entry.Tags = make([]string, 0, len(item.Tags))
+		entry.Tags = appendSorted(entry.Tags, strings.TrimSpace, item.Tags...)
 
 		// Generate a hash for the entry.
 		for _, value := range []string{item.ID, item.URL, item.ExternalURL, item.ContentText + item.ContentHTML + item.Summary} {
@@ -199,4 +184,30 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 	}
 
 	return feed
+}
+
+// appendSortedSeq appends elements from "values" slice into "sorted" slice.
+//   - "fn" applied to every element of "values"
+//   - elements inserted into "sorted" slice so it stays sorted
+//   - duplicate elements are not inserted
+func appendSorted[I any, O cmp.Ordered](sorted []O, fn func(I) O, values ...I) []O {
+	var zero O
+
+	sorted = slices.Grow(sorted, len(values))
+	for in := range slices.Values(values) {
+		out := fn(in)
+		if out == zero {
+			continue
+		}
+
+		where, found := slices.BinarySearch(sorted, out)
+		if found {
+			continue
+		}
+
+		// Insert sorted to avoid duplicates.
+		sorted = slices.Insert(sorted, where, out)
+	}
+
+	return sorted
 }

--- a/internal/reader/json/json.go
+++ b/internal/reader/json/json.go
@@ -3,7 +3,10 @@
 
 package json // import "miniflux.app/v2/internal/reader/json"
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // JSON Feed specs:
 // https://www.jsonfeed.org/version/1.1/
@@ -62,6 +65,10 @@ type JSONAuthor struct {
 
 	// Author's avatar URL.
 	AvatarURL string `json:"avatar"`
+}
+
+func (a JSONAuthor) name() string {
+	return strings.TrimSpace(a.Name)
 }
 
 // JSONAuthors unmarshals either an array or a single author object.

--- a/internal/reader/media/media.go
+++ b/internal/reader/media/media.go
@@ -4,6 +4,7 @@
 package media // import "miniflux.app/v2/internal/reader/media"
 
 import (
+	"iter"
 	"regexp"
 	"strconv"
 	"strings"
@@ -174,15 +175,15 @@ func (dl DescriptionList) First() string {
 
 type MediaCategoryList []MediaCategory
 
-func (mcl MediaCategoryList) Labels() []string {
-	var labels []string
-	for _, category := range mcl {
-		label := strings.TrimSpace(category.Label)
-		if label != "" {
-			labels = append(labels, label)
+func (mcl MediaCategoryList) LabelsSeq() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, category := range mcl {
+			label := strings.TrimSpace(category.Label)
+			if !yield(label) {
+				return
+			}
 		}
 	}
-	return labels
 }
 
 type MediaCategory struct {

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -36,14 +36,16 @@ func (r *rssAdapter) buildFeed(baseURL string) *model.Feed {
 		feed.SiteURL = absoluteSiteURL
 	}
 
-	// Try to find the feed URL from the Atom links.
-	for _, atomLink := range r.rss.Channel.Links {
-		atomLinkHref := strings.TrimSpace(atomLink.Href)
-		if atomLinkHref != "" && atomLink.Rel == "self" {
-			if absoluteFeedURL, err := urllib.ResolveToAbsoluteURL(feed.FeedURL, atomLinkHref); err == nil {
-				feed.FeedURL = absoluteFeedURL
-				break
-			}
+	// Try to find the feed URL from the Channel links.
+	for _, link := range r.rss.Channel.Links {
+		href := strings.TrimSpace(link.Href)
+		if href == "" || link.Rel != "self" {
+			continue
+		}
+
+		if absoluteFeedURL, err := urllib.ResolveToAbsoluteURL(feed.FeedURL, href); err == nil {
+			feed.FeedURL = absoluteFeedURL
+			break
 		}
 	}
 
@@ -78,19 +80,20 @@ func (r *rssAdapter) buildFeed(baseURL string) *model.Feed {
 
 		// Populate the entry URL.
 		entryURL := findEntryURL(&item)
-		if entryURL == "" {
+		if entryURL != "" {
+			entry.URL = entryURL
+			if absoluteEntryURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, entryURL); err == nil {
+				entry.URL = absoluteEntryURL
+			}
+		}
+
+		if entry.URL == "" {
+			// Fallback to the feed URL if no entry URL is found.
+			entry.URL = feed.SiteURL
+
 			// Fallback to the first enclosure URL if it exists.
 			if len(entry.Enclosures) > 0 && entry.Enclosures[0].URL != "" {
 				entry.URL = entry.Enclosures[0].URL
-			} else {
-				// Fallback to the feed URL if no entry URL is found.
-				entry.URL = feed.SiteURL
-			}
-		} else {
-			if absoluteEntryURL, err := urllib.ResolveToAbsoluteURL(feed.SiteURL, entryURL); err == nil {
-				entry.URL = absoluteEntryURL
-			} else {
-				entry.URL = entryURL
 			}
 		}
 
@@ -259,21 +262,21 @@ func findEntryDate(rssItem *rssItem) time.Time {
 		value = rssItem.DublinCoreDate
 	}
 
-	if value != "" {
-		result, err := date.Parse(value)
-		if err != nil {
-			slog.Debug("Unable to parse date from RSS feed",
-				slog.String("date", value),
-				slog.String("guid", rssItem.GUID.Data),
-				slog.Any("error", err),
-			)
-			return time.Now()
-		}
-
-		return result
+	if value = strings.TrimSpace(value); value == "" {
+		return time.Now()
 	}
 
-	return time.Now()
+	parsedDate, err := date.Parse(value)
+	if err != nil {
+		slog.Debug("Unable to parse date from RSS feed",
+			slog.String("date", value),
+			slog.String("guid", rssItem.GUID.Data),
+			slog.Any("error", err),
+		)
+		return time.Now()
+	}
+
+	return parsedDate
 }
 
 func findEntryAuthor(rssItem *rssItem) string {
@@ -333,22 +336,28 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 		if mediaURL == "" {
 			continue
 		}
-		if _, found := duplicates[mediaURL]; !found {
-			if mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL); err != nil {
-				slog.Debug("Unable to build absolute URL for media thumbnail",
-					slog.String("url", mediaThumbnail.URL),
-					slog.String("site_url", siteURL),
-					slog.Any("error", err),
-				)
-			} else {
-				duplicates[mediaAbsoluteURL] = true
-				enclosures = append(enclosures, &model.Enclosure{
-					URL:      mediaAbsoluteURL,
-					MimeType: mediaThumbnail.MimeType(),
-					Size:     mediaThumbnail.Size(),
-				})
-			}
+
+		mediaURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL)
+		if err != nil {
+			slog.Debug("Unable to build absolute URL for media thumbnail",
+				slog.String("url", mediaThumbnail.URL),
+				slog.String("site_url", siteURL),
+				slog.Any("error", err),
+			)
+			continue
 		}
+
+		if _, found := duplicates[mediaURL]; found {
+			continue
+		}
+
+		duplicates[mediaURL] = true
+
+		enclosures = append(enclosures, &model.Enclosure{
+			URL:      mediaURL,
+			MimeType: mediaThumbnail.MimeType(),
+			Size:     mediaThumbnail.Size(),
+		})
 	}
 
 	for _, enclosure := range rssItem.Enclosures {
@@ -370,15 +379,17 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 			enclosureURL = absoluteEnclosureURL
 		}
 
-		if _, found := duplicates[enclosureURL]; !found {
-			duplicates[enclosureURL] = true
-
-			enclosures = append(enclosures, &model.Enclosure{
-				URL:      enclosureURL,
-				MimeType: enclosure.Type,
-				Size:     enclosure.Size(),
-			})
+		if _, found := duplicates[enclosureURL]; found {
+			continue
 		}
+
+		duplicates[enclosureURL] = true
+
+		enclosures = append(enclosures, &model.Enclosure{
+			URL:      enclosureURL,
+			MimeType: enclosure.Type,
+			Size:     enclosure.Size(),
+		})
 	}
 
 	for _, mediaContent := range mediaContents {
@@ -386,23 +397,28 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 		if mediaURL == "" {
 			continue
 		}
-		if _, found := duplicates[mediaURL]; !found {
-			mediaURL := strings.TrimSpace(mediaContent.URL)
-			if mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL); err != nil {
-				slog.Debug("Unable to build absolute URL for media content",
-					slog.String("url", mediaContent.URL),
-					slog.String("site_url", siteURL),
-					slog.Any("error", err),
-				)
-			} else {
-				duplicates[mediaAbsoluteURL] = true
-				enclosures = append(enclosures, &model.Enclosure{
-					URL:      mediaAbsoluteURL,
-					MimeType: mediaContent.MimeType(),
-					Size:     mediaContent.Size(),
-				})
-			}
+
+		mediaURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL)
+		if err != nil {
+			slog.Debug("Unable to build absolute URL for media content",
+				slog.String("url", mediaContent.URL),
+				slog.String("site_url", siteURL),
+				slog.Any("error", err),
+			)
+			continue
 		}
+
+		if _, found := duplicates[mediaURL]; found {
+			continue
+		}
+
+		duplicates[mediaURL] = true
+
+		enclosures = append(enclosures, &model.Enclosure{
+			URL:      mediaURL,
+			MimeType: mediaContent.MimeType(),
+			Size:     mediaContent.Size(),
+		})
 	}
 
 	for _, mediaPeerLink := range mediaPeerLinks {
@@ -410,23 +426,28 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 		if mediaURL == "" {
 			continue
 		}
-		if _, found := duplicates[mediaURL]; !found {
-			mediaURL := strings.TrimSpace(mediaPeerLink.URL)
-			if mediaAbsoluteURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL); err != nil {
-				slog.Debug("Unable to build absolute URL for media peer link",
-					slog.String("url", mediaPeerLink.URL),
-					slog.String("site_url", siteURL),
-					slog.Any("error", err),
-				)
-			} else {
-				duplicates[mediaAbsoluteURL] = true
-				enclosures = append(enclosures, &model.Enclosure{
-					URL:      mediaAbsoluteURL,
-					MimeType: mediaPeerLink.MimeType(),
-					Size:     mediaPeerLink.Size(),
-				})
-			}
+
+		mediaURL, err := urllib.ResolveToAbsoluteURL(siteURL, mediaURL)
+		if err != nil {
+			slog.Debug("Unable to build absolute URL for media peer link",
+				slog.String("url", mediaPeerLink.URL),
+				slog.String("site_url", siteURL),
+				slog.Any("error", err),
+			)
+			continue
 		}
+
+		if _, found := duplicates[mediaURL]; found {
+			continue
+		}
+
+		duplicates[mediaURL] = true
+
+		enclosures = append(enclosures, &model.Enclosure{
+			URL:      mediaURL,
+			MimeType: mediaPeerLink.MimeType(),
+			Size:     mediaPeerLink.Size(),
+		})
 	}
 
 	return enclosures

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -4,7 +4,9 @@
 package rss // import "miniflux.app/v2/internal/reader/rss"
 
 import (
+	"cmp"
 	"html"
+	"iter"
 	"log/slog"
 	"path"
 	"slices"
@@ -153,9 +155,6 @@ func (r *rssAdapter) buildFeed(baseURL string) *model.Feed {
 		if len(entry.Tags) == 0 {
 			entry.Tags = findFeedTags(&r.rss.Channel)
 		}
-		// Sort and deduplicate tags.
-		slices.Sort(entry.Tags)
-		entry.Tags = slices.Compact(entry.Tags)
 
 		feed.Entries = append(feed.Entries, entry)
 	}
@@ -184,26 +183,12 @@ func findFeedAuthor(rssChannel *rssChannel) string {
 }
 
 func findFeedTags(rssChannel *rssChannel) []string {
-	itunesCategories := rssChannel.GetItunesCategories()
-	tags := make([]string, 0, len(rssChannel.Categories)+len(itunesCategories)+1)
+	tags := make([]string, 0, len(rssChannel.Categories)+2*len(rssChannel.ItunesCategories)+1)
 
-	for _, tag := range rssChannel.Categories {
-		tag = strings.TrimSpace(tag)
-		if tag != "" {
-			tags = append(tags, tag)
-		}
-	}
+	tags = appendSorted(tags, strings.TrimSpace, rssChannel.Categories...)
+	tags = appendSortedSeq(tags, strings.TrimSpace, rssChannel.ItunesCategoriesSeq())
 
-	for _, tag := range itunesCategories {
-		tag = strings.TrimSpace(tag)
-		if tag != "" {
-			tags = append(tags, tag)
-		}
-	}
-
-	if tag := strings.TrimSpace(rssChannel.GooglePlayCategory.Text); tag != "" {
-		tags = append(tags, tag)
-	}
+	tags = appendSorted(tags, strings.TrimSpace, rssChannel.GooglePlayCategory.Text)
 
 	return tags
 }
@@ -303,22 +288,10 @@ func findEntryAuthor(rssItem *rssItem) string {
 }
 
 func findEntryTags(rssItem *rssItem) []string {
-	mediaLabels := rssItem.MediaCategories.Labels()
-	tags := make([]string, 0, len(rssItem.Categories)+len(mediaLabels))
+	tags := make([]string, 0, len(rssItem.Categories)+len(rssItem.MediaCategories))
 
-	for _, tag := range rssItem.Categories {
-		tag = strings.TrimSpace(tag)
-		if tag != "" {
-			tags = append(tags, tag)
-		}
-	}
-
-	for _, tag := range mediaLabels {
-		tag = strings.TrimSpace(tag)
-		if tag != "" {
-			tags = append(tags, tag)
-		}
-	}
+	tags = appendSorted(tags, strings.TrimSpace, rssItem.Categories...)
+	tags = appendSortedSeq(tags, strings.TrimSpace, rssItem.MediaCategories.LabelsSeq())
 
 	return tags
 }
@@ -451,4 +424,35 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 	}
 
 	return enclosures
+}
+
+// appendSorted is identical to [appendSortedSeq] except receives variadic values rather than [iter.Seq].
+func appendSorted[I any, O cmp.Ordered](sorted []O, fn func(I) O, values ...I) []O {
+	sorted = slices.Grow(sorted, len(values))
+	return appendSortedSeq(sorted, fn, slices.Values(values))
+}
+
+// appendSortedSeq appends elements from "values" iterator into "sorted" slice.
+//   - "fn" applied to every element of "values"
+//   - elements inserted into "sorted" slice so it stays sorted
+//   - duplicate elements are not inserted
+func appendSortedSeq[I any, O cmp.Ordered](sorted []O, fn func(I) O, values iter.Seq[I]) []O {
+	var zero O
+
+	for in := range values {
+		out := fn(in)
+		if out == zero {
+			continue
+		}
+
+		where, found := slices.BinarySearch(sorted, out)
+		if found {
+			continue
+		}
+
+		// Insert sorted to avoid duplicates.
+		sorted = slices.Insert(sorted, where, out)
+	}
+
+	return sorted
 }

--- a/internal/reader/rss/parser_test.go
+++ b/internal/reader/rss/parser_test.go
@@ -1687,7 +1687,7 @@ func TestParseEntryWithMediaContent(t *testing.T) {
 	if len(feed.Entries) != 1 {
 		t.Fatalf("Incorrect number of entries, got: %d", len(feed.Entries))
 	}
-	if len(feed.Entries[0].Enclosures) != 4 {
+	if len(feed.Entries[0].Enclosures) != 3 {
 		t.Fatalf("Incorrect number of enclosures, got: %d", len(feed.Entries[0].Enclosures))
 	}
 
@@ -1696,7 +1696,6 @@ func TestParseEntryWithMediaContent(t *testing.T) {
 		mimeType string
 		size     int64
 	}{
-		{"https://example.org/thumbnail.jpg", "image/*", 0},
 		{"https://example.org/thumbnail.jpg", "image/*", 0},
 		{"https://example.org/media1.jpg", "image/*", 0},
 		{"https://example.org/media2.jpg", "image/*", 0},


### PR DESCRIPTION
I guess different readers were touched by different people in a very different circumstances.
As the result, sometimes code that does exactly the same looks different.

Here, some things were moved around to make code look consistent overall.

I've split everything into different commits but if this PR is too loaded I probably can split them into different PRs if needed. That was done just for the sake of not doing a rebase later.

Not sure how to correctly test for regressions, but I've noticed that only `TestParseEntryWithMediaContent` were failing and it seems like it was relying on the wrong behaviour in first place.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [ ] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
