### PR TITLE
refactor(sanitizer): always trim spaces in StripTags

### DIFF
--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -83,11 +83,12 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		// The entry title is optional, so we need to find a fallback.
 		if entry.Title == "" {
 			for _, value := range []string{item.Summary, item.ContentText, item.ContentHTML} {
-				value = strings.TrimSpace(value)
-				if value != "" {
-					entry.Title = sanitizer.TruncateHTML(value, 100)
-					break
+				if value = sanitizer.TruncateHTML(value, 100); value == "" {
+					continue
 				}
+
+				entry.Title = value
+				break
 			}
 		}
 

--- a/internal/reader/rdf/adapter.go
+++ b/internal/reader/rdf/adapter.go
@@ -22,7 +22,7 @@ type rdfAdapter struct {
 
 func (r *rdfAdapter) buildFeed(baseURL string) *model.Feed {
 	feed := &model.Feed{
-		Title:       stripTags(r.rdf.Channel.Title),
+		Title:       sanitizer.StripTags(r.rdf.Channel.Title),
 		FeedURL:     strings.TrimSpace(baseURL),
 		SiteURL:     strings.TrimSpace(r.rdf.Channel.Link),
 		Description: strings.TrimSpace(r.rdf.Channel.Description),
@@ -95,17 +95,13 @@ func (r *rdfAdapter) buildFeed(baseURL string) *model.Feed {
 		// Populate the entry author.
 		switch {
 		case item.DublinCoreCreator != "":
-			entry.Author = stripTags(item.DublinCoreCreator)
+			entry.Author = sanitizer.StripTags(item.DublinCoreCreator)
 		case r.rdf.Channel.DublinCoreCreator != "":
-			entry.Author = stripTags(r.rdf.Channel.DublinCoreCreator)
+			entry.Author = sanitizer.StripTags(r.rdf.Channel.DublinCoreCreator)
 		}
 
 		feed.Entries = append(feed.Entries, entry)
 	}
 
 	return feed
-}
-
-func stripTags(value string) string {
-	return strings.TrimSpace(sanitizer.StripTags(value))
 }

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -177,7 +177,7 @@ func findFeedAuthor(rssChannel *rssChannel) string {
 		return ""
 	}
 
-	return strings.TrimSpace(sanitizer.StripTags(author))
+	return sanitizer.StripTags(author)
 }
 
 func findFeedTags(rssChannel *rssChannel) []string {
@@ -296,7 +296,7 @@ func findEntryAuthor(rssItem *rssItem) string {
 		return ""
 	}
 
-	return strings.TrimSpace(sanitizer.StripTags(author))
+	return sanitizer.StripTags(author)
 }
 
 func findEntryTags(rssItem *rssItem) []string {

--- a/internal/reader/sanitizer/strip_tags.go
+++ b/internal/reader/sanitizer/strip_tags.go
@@ -25,7 +25,7 @@ func StripTags(input string) string {
 		return ""
 	}
 
-	return dst.String()
+	return strings.TrimSpace(dst.String())
 }
 
 // stripIter iterates over the input [io.Reader] and calls the yield function for each [html.TextToken].

--- a/internal/reader/sanitizer/strip_tags_test.go
+++ b/internal/reader/sanitizer/strip_tags_test.go
@@ -7,7 +7,7 @@ import "testing"
 
 func TestStripTags(t *testing.T) {
 	input := `This <a href="/test.html">link is relative</a> and <strong>this</strong> image: <img src="../folder/image.png"/>`
-	expected := `This link is relative and this image: `
+	expected := `This link is relative and this image:`
 	output := StripTags(input)
 
 	if expected != output {


### PR DESCRIPTION
Little follow-up to #4287.

Outputs of `StripTags` and `TruncateHTML` never used without being trimmed.
So instead of trimming spaces outside at every call just do it inside.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
