### PR TITLE
fix(ui): preserve flash message after keyboard refresh all feeds

### DIFF
--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -18,14 +18,17 @@ if (!window.trustedTypes || !trustedTypes.createPolicy) {
  *
  * @param {string} url - The URL to send the request to.
  * @param {Object} [body] - The body of the request (optional).
+ * @param {RequestInit} [fetchOptions] - Additional fetch options (optional).
  * @returns {Promise<Response>} The response from the fetch request.
  */
-function sendPOSTRequest(url, body = null) {
+function sendPOSTRequest(url, body = null, fetchOptions = {}) {
     const options = {
         method: "POST",
         headers: {
-            "X-Csrf-Token": document.body.dataset.csrfToken || ""
-        }
+            "X-Csrf-Token": document.body.dataset.csrfToken || "",
+            ...fetchOptions.headers,
+        },
+        ...fetchOptions,
     };
 
     if (body !== null) {
@@ -34,6 +37,32 @@ function sendPOSTRequest(url, body = null) {
     }
 
     return fetch(url, options);
+}
+
+/**
+ * Navigate after a POST request that may redirect with a flash message.
+ *
+ * @param {Response} response - The fetch response.
+ * @param {string} [redirectURL] - An explicit redirect URL (optional).
+ */
+function navigateAfterPOSTResponse(response, redirectURL) {
+    if (redirectURL) {
+        window.location.href = redirectURL;
+        return;
+    }
+
+    const locationHeader = response.headers.get("Location");
+    if (locationHeader) {
+        window.location.href = locationHeader;
+        return;
+    }
+
+    if (response?.redirected && response.url) {
+        window.location.href = response.url;
+        return;
+    }
+
+    window.location.reload();
 }
 
 /**
@@ -663,12 +692,8 @@ function toggleEntryStatus(element, toasting) {
 function handleRefreshAllFeedsAction() {
     const refreshAllFeedsUrl = document.body.dataset.refreshAllFeedsUrl;
     if (refreshAllFeedsUrl) {
-        sendPOSTRequest(refreshAllFeedsUrl).then((response) => {
-            if (response?.redirected && response.url) {
-                window.location.href = response.url;
-            } else {
-                window.location.reload();
-            }
+        sendPOSTRequest(refreshAllFeedsUrl, null, { redirect: "manual" }).then((response) => {
+            navigateAfterPOSTResponse(response);
         });
     }
 }
@@ -1250,14 +1275,8 @@ function initializeClickHandlers() {
     // Generic confirmation handler
     onClick(":is(a, button)[data-confirm]", (event) => {
         handleConfirmationMessage(event.target, (url, redirectURL) => {
-            sendPOSTRequest(url).then((response) => {
-                if (redirectURL) {
-                    window.location.href = redirectURL;
-                } else if (response?.redirected && response.url) {
-                    window.location.href = response.url;
-                } else {
-                    window.location.reload();
-                }
+            sendPOSTRequest(url, null, { redirect: "manual" }).then((response) => {
+                navigateAfterPOSTResponse(response, redirectURL);
             });
         });
     });


### PR DESCRIPTION
## Summary
- Fix the `R` keyboard shortcut not showing the success alert after refreshing all feeds
- Use `fetch` with `redirect: "manual"` so session flash messages are not consumed before browser navigation
- Reuse the same navigation helper for generic confirmation POST actions that rely on flash messages

## Root cause
The keyboard shortcut POSTed to `/feeds/refresh` via `fetch`, which automatically followed the redirect to `/feeds`. That internal redirect request consumed the session flash message before `window.location.href` navigation, so the success alert was missing.

The menu button uses a native form POST + redirect, so the flash message was shown correctly.

## Test plan
- [ ] On `/unread`, press `R` to refresh all feeds
- [ ] Verify the success alert appears after navigation to `/feeds`
- [ ] Verify the "Refresh all feeds" menu button still shows the same alert
- [ ] Verify other confirmation POST actions with flash messages still work

Fixes #4358