### PR TITLE
fix(api): forbid setting OAuth identity fields via user update

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -74,8 +74,6 @@ type UserModificationRequest struct {
 	EntryOrder                *string  `json:"entry_sorting_order"`
 	Stylesheet                *string  `json:"stylesheet"`
 	CustomJS                  *string  `json:"custom_js"`
-	GoogleID                  *string  `json:"google_id"`
-	OpenIDConnectID           *string  `json:"openid_connect_id"`
 	EntriesPerPage            *int     `json:"entries_per_page"`
 	KeyboardShortcuts         *bool    `json:"keyboard_shortcuts"`
 	ShowReadingTime           *bool    `json:"show_reading_time"`

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -66,8 +66,6 @@ type UserModificationRequest struct {
 	Stylesheet                      *string  `json:"stylesheet"`
 	CustomJS                        *string  `json:"custom_js"`
 	ExternalFontHosts               *string  `json:"external_font_hosts"`
-	GoogleID                        *string  `json:"google_id"`
-	OpenIDConnectID                 *string  `json:"openid_connect_id"`
 	EntriesPerPage                  *int     `json:"entries_per_page"`
 	IsAdmin                         *bool    `json:"is_admin"`
 	KeyboardShortcuts               *bool    `json:"keyboard_shortcuts"`
@@ -132,14 +130,6 @@ func (u *UserModificationRequest) Patch(user *User) {
 
 	if u.ExternalFontHosts != nil {
 		user.ExternalFontHosts = *u.ExternalFontHosts
-	}
-
-	if u.GoogleID != nil {
-		user.GoogleID = *u.GoogleID
-	}
-
-	if u.OpenIDConnectID != nil {
-		user.OpenIDConnectID = *u.OpenIDConnectID
 	}
 
 	if u.EntriesPerPage != nil {


### PR DESCRIPTION
A non-admin could bind an arbitrary OAuth identity to their own account by patching `google_id` or `openid_connect_id`, bypassing the duplicate check enforced in the OAuth callback.

Remove both fields from the update request so binding only happens through the OAuth flow.
