### PR TITLE
make request/response builders actually build

### DIFF
--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -175,11 +175,11 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 		globallyVisible := request.QueryBoolParam(r, "globally_visible", true)
 
 		if globallyVisible {
-			builder.WithGloballyVisible()
+			builder = builder.WithGloballyVisible()
 		}
 	}
 
-	configureFilters(builder, r)
+	builder = configureFilters(builder, r)
 
 	entries, count, err := builder.GetEntriesWithCount()
 	if err != nil {
@@ -503,51 +503,53 @@ func (h *handler) flushHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	response.JSONAccepted(w, r)
 }
 
-func configureFilters(builder *storage.EntryQueryBuilder, r *http.Request) {
+func configureFilters(builder *storage.EntryQueryBuilder, r *http.Request) *storage.EntryQueryBuilder {
 	if beforeEntryID := request.QueryInt64Param(r, "before_entry_id", 0); beforeEntryID > 0 {
-		builder.BeforeEntryID(beforeEntryID)
+		builder = builder.BeforeEntryID(beforeEntryID)
 	}
 
 	if afterEntryID := request.QueryInt64Param(r, "after_entry_id", 0); afterEntryID > 0 {
-		builder.AfterEntryID(afterEntryID)
+		builder = builder.AfterEntryID(afterEntryID)
 	}
 
 	if beforePublishedTimestamp := request.QueryInt64Param(r, "before", 0); beforePublishedTimestamp > 0 {
-		builder.BeforePublishedDate(time.Unix(beforePublishedTimestamp, 0))
+		builder = builder.BeforePublishedDate(time.Unix(beforePublishedTimestamp, 0))
 	}
 
 	if afterPublishedTimestamp := request.QueryInt64Param(r, "after", 0); afterPublishedTimestamp > 0 {
-		builder.AfterPublishedDate(time.Unix(afterPublishedTimestamp, 0))
+		builder = builder.AfterPublishedDate(time.Unix(afterPublishedTimestamp, 0))
 	}
 
 	if beforePublishedTimestamp := request.QueryInt64Param(r, "published_before", 0); beforePublishedTimestamp > 0 {
-		builder.BeforePublishedDate(time.Unix(beforePublishedTimestamp, 0))
+		builder = builder.BeforePublishedDate(time.Unix(beforePublishedTimestamp, 0))
 	}
 
 	if afterPublishedTimestamp := request.QueryInt64Param(r, "published_after", 0); afterPublishedTimestamp > 0 {
-		builder.AfterPublishedDate(time.Unix(afterPublishedTimestamp, 0))
+		builder = builder.AfterPublishedDate(time.Unix(afterPublishedTimestamp, 0))
 	}
 
 	if beforeChangedTimestamp := request.QueryInt64Param(r, "changed_before", 0); beforeChangedTimestamp > 0 {
-		builder.BeforeChangedDate(time.Unix(beforeChangedTimestamp, 0))
+		builder = builder.BeforeChangedDate(time.Unix(beforeChangedTimestamp, 0))
 	}
 
 	if afterChangedTimestamp := request.QueryInt64Param(r, "changed_after", 0); afterChangedTimestamp > 0 {
-		builder.AfterChangedDate(time.Unix(afterChangedTimestamp, 0))
+		builder = builder.AfterChangedDate(time.Unix(afterChangedTimestamp, 0))
 	}
 
 	if categoryID := request.QueryInt64Param(r, "category_id", 0); categoryID > 0 {
-		builder.WithCategoryID(categoryID)
+		builder = builder.WithCategoryID(categoryID)
 	}
 
 	if request.HasQueryParam(r, "starred") {
 		starred, err := strconv.ParseBool(r.URL.Query().Get("starred"))
 		if err == nil {
-			builder.WithStarred(starred)
+			builder = builder.WithStarred(starred)
 		}
 	}
 
 	if searchQuery := request.QueryStringParam(r, "search", ""); searchQuery != "" {
-		builder.WithSearchQuery(searchQuery)
+		builder = builder.WithSearchQuery(searchQuery)
 	}
+
+	return builder
 }

--- a/internal/api/subscription_handlers.go
+++ b/internal/api/subscription_handlers.go
@@ -37,17 +37,17 @@ func (h *handler) discoverSubscriptionsHandler(w http.ResponseWriter, r *http.Re
 		rssbridgeToken = intg.RSSBridgeToken
 	}
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(subscriptionDiscoveryRequest.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(subscriptionDiscoveryRequest.FetchViaProxy)
-	requestBuilder.WithUserAgent(subscriptionDiscoveryRequest.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(subscriptionDiscoveryRequest.Cookie)
-	requestBuilder.WithUsernameAndPassword(subscriptionDiscoveryRequest.Username, subscriptionDiscoveryRequest.Password)
-	requestBuilder.IgnoreTLSErrors(subscriptionDiscoveryRequest.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(subscriptionDiscoveryRequest.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(subscriptionDiscoveryRequest.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(subscriptionDiscoveryRequest.FetchViaProxy).
+		WithUserAgent(subscriptionDiscoveryRequest.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(subscriptionDiscoveryRequest.Cookie).
+		WithUsernameAndPassword(subscriptionDiscoveryRequest.Username, subscriptionDiscoveryRequest.Password).
+		IgnoreTLSErrors(subscriptionDiscoveryRequest.AllowSelfSignedCertificates).
+		DisableHTTP2(subscriptionDiscoveryRequest.DisableHTTP2)
 
 	subscriptions, localizedError := subscription.NewSubscriptionFinder(requestBuilder).FindSubscriptions(
 		subscriptionDiscoveryRequest.URL,

--- a/internal/fever/handler.go
+++ b/internal/fever/handler.go
@@ -249,8 +249,8 @@ func (h *feverHandler) handleItems(w http.ResponseWriter, r *http.Request) {
 				slog.Int64("user_id", userID),
 				slog.Int64("since_id", sinceID),
 			)
-			builder.AfterEntryID(sinceID)
-			builder.WithSorting("id", "ASC")
+			builder = builder.AfterEntryID(sinceID)
+			builder = builder.WithSorting("id", "ASC")
 		}
 	case request.HasQueryParam(r, "max_id"):
 		maxID := request.QueryInt64Param(r, "max_id", 0)
@@ -258,14 +258,14 @@ func (h *feverHandler) handleItems(w http.ResponseWriter, r *http.Request) {
 			slog.Debug("[Fever] Fetching most recent items",
 				slog.Int64("user_id", userID),
 			)
-			builder.WithSorting("id", "DESC")
+			builder = builder.WithSorting("id", "DESC")
 		} else if maxID > 0 {
 			slog.Debug("[Fever] Fetching items before a given item ID",
 				slog.Int64("user_id", userID),
 				slog.Int64("max_id", maxID),
 			)
-			builder.BeforeEntryID(maxID)
-			builder.WithSorting("id", "DESC")
+			builder = builder.BeforeEntryID(maxID)
+			builder = builder.WithSorting("id", "DESC")
 		}
 	case request.HasQueryParam(r, "with_ids"):
 		csvItemIDs := request.QueryStringParam(r, "with_ids", "")
@@ -278,7 +278,7 @@ func (h *feverHandler) handleItems(w http.ResponseWriter, r *http.Request) {
 				itemIDs = append(itemIDs, itemID)
 			}
 
-			builder.WithEntryIDs(itemIDs...)
+			builder = builder.WithEntryIDs(itemIDs...)
 		}
 	default:
 		slog.Debug("[Fever] Fetching oldest items",

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -342,10 +342,10 @@ func (h *greaderHandler) quickAddHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithUserAgent("", config.Opts.HTTPClientUserAgent())
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithUserAgent("", config.Opts.HTTPClientUserAgent())
 
 	var rssBridgeURL string
 	var rssBridgeToken string

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -1019,7 +1019,7 @@ func (h *greaderHandler) handleReadingListStreamHandler(w http.ResponseWriter, r
 	for _, s := range rm.ExcludeTargets {
 		switch s.Type {
 		case ReadStream:
-			builder.WithStatuses(model.EntryStatusUnread)
+			builder = builder.WithStatuses(model.EntryStatusUnread)
 		default:
 			slog.Warn("[GoogleReader] Unknown ExcludeTargets filter type",
 				slog.String("handler", "handleReadingListStreamHandler"),
@@ -1031,11 +1031,11 @@ func (h *greaderHandler) handleReadingListStreamHandler(w http.ResponseWriter, r
 	}
 
 	if rm.StartTime > 0 {
-		builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
+		builder = builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
 	}
 
 	if rm.StopTime > 0 {
-		builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
+		builder = builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
 	}
 
 	itemRefs, continuation, err := getItemRefsAndContinuation(*builder, rm)
@@ -1054,11 +1054,11 @@ func (h *greaderHandler) handleStarredStreamHandler(w http.ResponseWriter, r *ht
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 
 	if rm.StartTime > 0 {
-		builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
+		builder = builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
 	}
 
 	if rm.StopTime > 0 {
-		builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
+		builder = builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
 	}
 
 	itemRefs, continuation, err := getItemRefsAndContinuation(*builder, rm)
@@ -1078,11 +1078,11 @@ func (h *greaderHandler) handleReadStreamHandler(w http.ResponseWriter, r *http.
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 
 	if rm.StartTime > 0 {
-		builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
+		builder = builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
 	}
 
 	if rm.StopTime > 0 {
-		builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
+		builder = builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
 	}
 
 	itemRefs, continuation, err := getItemRefsAndContinuation(*builder, rm)
@@ -1130,16 +1130,16 @@ func (h *greaderHandler) handleFeedStreamHandler(w http.ResponseWriter, r *http.
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 
 	if rm.StartTime > 0 {
-		builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
+		builder = builder.AfterPublishedDate(time.Unix(rm.StartTime, 0))
 	}
 
 	if rm.StopTime > 0 {
-		builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
+		builder = builder.BeforePublishedDate(time.Unix(rm.StopTime, 0))
 	}
 
 	for _, s := range rm.ExcludeTargets {
 		if s.Type == ReadStream {
-			builder.WithoutStatus(model.EntryStatusRead)
+			builder = builder.WithoutStatus(model.EntryStatusRead)
 		}
 	}
 

--- a/internal/googlereader/response.go
+++ b/internal/googlereader/response.go
@@ -120,10 +120,10 @@ type contentItemOrigin struct {
 }
 
 func sendUnauthorizedResponse(w http.ResponseWriter, r *http.Request) {
-	builder := response.NewBuilder(w, r)
-	builder.WithStatus(http.StatusUnauthorized)
-	builder.WithHeader("X-Reader-Google-Bad-Token", "true")
-	builder.WithHeader("Content-Type", "text/plain; charset=utf-8")
-	builder.WithBodyAsString("Unauthorized")
-	builder.Write()
+	response.NewBuilder(w, r).
+		WithStatus(http.StatusUnauthorized).
+		WithHeader("X-Reader-Google-Bad-Token", "true").
+		WithHeader("Content-Type", "text/plain; charset=utf-8").
+		WithBodyAsString("Unauthorized").
+		Write()
 }

--- a/internal/http/response/html.go
+++ b/internal/http/response/html.go
@@ -15,15 +15,17 @@ import (
 
 // HTML creates a new HTML response with a 200 status code.
 func HTML[T []byte | string](w http.ResponseWriter, r *http.Request, body T) {
-	builder := NewBuilder(w, r)
-	builder.WithHeader("Content-Type", "text/html; charset=utf-8")
-	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
+	builder := NewBuilder(w, r).
+		WithHeader("Content-Type", "text/html; charset=utf-8").
+		WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
+
 	switch v := any(body).(type) {
 	case []byte:
-		builder.WithBodyAsBytes(v)
+		builder = builder.WithBodyAsBytes(v)
 	case string:
-		builder.WithBodyAsString(v)
+		builder = builder.WithBodyAsString(v)
 	}
+
 	builder.Write()
 }
 
@@ -42,13 +44,13 @@ func HTMLServerError(w http.ResponseWriter, r *http.Request, err error) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusInternalServerError)
-	builder.WithHeader("Content-Security-Policy", ContentSecurityPolicyForUntrustedContent)
-	builder.WithHeader("Content-Type", "text/plain; charset=utf-8")
-	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
-	builder.WithBodyAsString(html.EscapeString(err.Error()))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusInternalServerError).
+		WithHeader("Content-Security-Policy", ContentSecurityPolicyForUntrustedContent).
+		WithHeader("Content-Type", "text/plain; charset=utf-8").
+		WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store").
+		WithBodyAsString(html.EscapeString(err.Error())).
+		Write()
 }
 
 // HTMLBadRequest sends a bad request error to the client.
@@ -66,13 +68,13 @@ func HTMLBadRequest(w http.ResponseWriter, r *http.Request, err error) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusBadRequest)
-	builder.WithHeader("Content-Security-Policy", ContentSecurityPolicyForUntrustedContent)
-	builder.WithHeader("Content-Type", "text/plain; charset=utf-8")
-	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
-	builder.WithBodyAsString(html.EscapeString(err.Error()))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusBadRequest).
+		WithHeader("Content-Security-Policy", ContentSecurityPolicyForUntrustedContent).
+		WithHeader("Content-Type", "text/plain; charset=utf-8").
+		WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store").
+		WithBodyAsString(html.EscapeString(err.Error())).
+		Write()
 }
 
 // HTMLForbidden sends a forbidden error to the client.
@@ -89,12 +91,12 @@ func HTMLForbidden(w http.ResponseWriter, r *http.Request) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusForbidden)
-	builder.WithHeader("Content-Type", "text/html; charset=utf-8")
-	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
-	builder.WithBodyAsString("Access Forbidden")
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusForbidden).
+		WithHeader("Content-Type", "text/html; charset=utf-8").
+		WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store").
+		WithBodyAsString("Access Forbidden").
+		Write()
 }
 
 // HTMLNotFound sends a page not found error to the client.
@@ -111,12 +113,12 @@ func HTMLNotFound(w http.ResponseWriter, r *http.Request) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusNotFound)
-	builder.WithHeader("Content-Type", "text/html; charset=utf-8")
-	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
-	builder.WithBodyAsString("Page Not Found")
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusNotFound).
+		WithHeader("Content-Type", "text/html; charset=utf-8").
+		WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store").
+		WithBodyAsString("Page Not Found").
+		Write()
 }
 
 // HTMLRedirect redirects the user to a relative path or an absolute http(s) URL.
@@ -142,11 +144,11 @@ func HTMLRequestedRangeNotSatisfiable(w http.ResponseWriter, r *http.Request, co
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusRequestedRangeNotSatisfiable)
-	builder.WithHeader("Content-Type", "text/html; charset=utf-8")
-	builder.WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store")
-	builder.WithHeader("Content-Range", contentRange)
-	builder.WithBodyAsString("Range Not Satisfiable")
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusRequestedRangeNotSatisfiable).
+		WithHeader("Content-Type", "text/html; charset=utf-8").
+		WithHeader("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store").
+		WithHeader("Content-Range", contentRange).
+		WithBodyAsString("Range Not Satisfiable").
+		Write()
 }

--- a/internal/http/response/json.go
+++ b/internal/http/response/json.go
@@ -22,10 +22,10 @@ func JSON(w http.ResponseWriter, r *http.Request, body any) {
 		return
 	}
 
-	builder := NewBuilder(w, r)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(responseBody)
-	builder.Write()
+	NewBuilder(w, r).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(responseBody).
+		Write()
 }
 
 // JSONCreated sends a created response to the client.
@@ -36,19 +36,19 @@ func JSONCreated(w http.ResponseWriter, r *http.Request, body any) {
 		return
 	}
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusCreated)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(responseBody)
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusCreated).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(responseBody).
+		Write()
 }
 
 // JSONAccepted sends an accepted response to the client.
 func JSONAccepted(w http.ResponseWriter, r *http.Request) {
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusAccepted)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusAccepted).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		Write()
 }
 
 // JSONServerError sends an internal error to the client.
@@ -66,11 +66,11 @@ func JSONServerError(w http.ResponseWriter, r *http.Request, err error) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusInternalServerError)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(generateJSONError(err))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusInternalServerError).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(generateJSONError(err)).
+		Write()
 }
 
 // JSONBadRequest sends a bad request error to the client.
@@ -88,11 +88,11 @@ func JSONBadRequest(w http.ResponseWriter, r *http.Request, err error) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusBadRequest)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(generateJSONError(err))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusBadRequest).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(generateJSONError(err)).
+		Write()
 }
 
 // JSONUnauthorized sends a not authorized error to the client.
@@ -109,11 +109,11 @@ func JSONUnauthorized(w http.ResponseWriter, r *http.Request) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusUnauthorized)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(generateJSONError(errors.New("access unauthorized")))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusUnauthorized).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(generateJSONError(errors.New("access unauthorized"))).
+		Write()
 }
 
 // JSONForbidden sends a forbidden error to the client.
@@ -130,11 +130,11 @@ func JSONForbidden(w http.ResponseWriter, r *http.Request) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusForbidden)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(generateJSONError(errors.New("access forbidden")))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusForbidden).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(generateJSONError(errors.New("access forbidden"))).
+		Write()
 }
 
 // JSONNotFound sends a page not found error to the client.
@@ -151,11 +151,11 @@ func JSONNotFound(w http.ResponseWriter, r *http.Request) {
 		),
 	)
 
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusNotFound)
-	builder.WithHeader("Content-Type", jsonContentTypeHeader)
-	builder.WithBodyAsBytes(generateJSONError(errors.New("resource not found")))
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusNotFound).
+		WithHeader("Content-Type", jsonContentTypeHeader).
+		WithBodyAsBytes(generateJSONError(errors.New("resource not found"))).
+		Write()
 }
 
 func generateJSONError(err error) []byte {

--- a/internal/http/response/response.go
+++ b/internal/http/response/response.go
@@ -17,7 +17,7 @@ const ContentSecurityPolicyForUntrustedContent = `default-src 'none'; form-actio
 
 // NoContent sends a no content response to the client.
 func NoContent(w http.ResponseWriter, r *http.Request) {
-	builder := NewBuilder(w, r)
-	builder.WithStatus(http.StatusNoContent)
-	builder.Write()
+	NewBuilder(w, r).
+		WithStatus(http.StatusNoContent).
+		Write()
 }

--- a/internal/http/response/text.go
+++ b/internal/http/response/text.go
@@ -7,8 +7,8 @@ import "net/http"
 
 // Text writes a standard text response with a status 200 OK.
 func Text(w http.ResponseWriter, r *http.Request, body string) {
-	builder := NewBuilder(w, r)
-	builder.WithHeader("Content-Type", `text/plain; charset=utf-8`)
-	builder.WithBodyAsString(body)
-	builder.Write()
+	NewBuilder(w, r).
+		WithHeader("Content-Type", `text/plain; charset=utf-8`).
+		WithBodyAsString(body).
+		Write()
 }

--- a/internal/http/response/xml.go
+++ b/internal/http/response/xml.go
@@ -7,17 +7,17 @@ import "net/http"
 
 // XML writes a standard XML response with a status 200 OK.
 func XML(w http.ResponseWriter, r *http.Request, body string) {
-	builder := NewBuilder(w, r)
-	builder.WithHeader("Content-Type", "text/xml; charset=utf-8")
-	builder.WithBodyAsString(body)
-	builder.Write()
+	NewBuilder(w, r).
+		WithHeader("Content-Type", "text/xml; charset=utf-8").
+		WithBodyAsString(body).
+		Write()
 }
 
 // XMLAttachment forces the XML document to be downloaded by the web browser.
 func XMLAttachment(w http.ResponseWriter, r *http.Request, filename string, body string) {
-	builder := NewBuilder(w, r)
-	builder.WithHeader("Content-Type", "text/xml; charset=utf-8")
-	builder.WithAttachment(filename)
-	builder.WithBodyAsString(body)
-	builder.Write()
+	NewBuilder(w, r).
+		WithHeader("Content-Type", "text/xml; charset=utf-8").
+		WithAttachment(filename).
+		WithBodyAsString(body).
+		Write()
 }

--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -95,18 +95,6 @@ func CreateFeedFromSubscriptionDiscovery(store *storage.Storage, userID int64, f
 		slog.String("feed_url", subscription.FeedURL),
 	)
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithUsernameAndPassword(feedCreationRequest.Username, feedCreationRequest.Password)
-	requestBuilder.WithUserAgent(feedCreationRequest.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(feedCreationRequest.Cookie)
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(feedCreationRequest.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(feedCreationRequest.FetchViaProxy)
-	requestBuilder.IgnoreTLSErrors(feedCreationRequest.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(feedCreationRequest.DisableHTTP2)
-
 	icon.NewIconChecker(store, subscription).UpdateOrCreateFeedIcon()
 
 	return subscription, nil
@@ -124,17 +112,17 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 		return nil, locale.NewLocalizedErrorWrapper(ErrCategoryNotFound, "error.category_not_found")
 	}
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithUsernameAndPassword(feedCreationRequest.Username, feedCreationRequest.Password)
-	requestBuilder.WithUserAgent(feedCreationRequest.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(feedCreationRequest.Cookie)
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(feedCreationRequest.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(feedCreationRequest.FetchViaProxy)
-	requestBuilder.IgnoreTLSErrors(feedCreationRequest.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(feedCreationRequest.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithUsernameAndPassword(feedCreationRequest.Username, feedCreationRequest.Password).
+		WithUserAgent(feedCreationRequest.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(feedCreationRequest.Cookie).
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(feedCreationRequest.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(feedCreationRequest.FetchViaProxy).
+		IgnoreTLSErrors(feedCreationRequest.AllowSelfSignedCertificates).
+		DisableHTTP2(feedCreationRequest.DisableHTTP2)
 
 	responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(feedCreationRequest.FeedURL))
 	defer responseHandler.Close()
@@ -232,22 +220,23 @@ func RefreshFeed(store *storage.Storage, userID, feedID int64, forceRefresh bool
 	originalFeed.CheckedNow()
 	originalFeed.ScheduleNextCheck(weeklyEntryCount, time.Duration(0))
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithUsernameAndPassword(originalFeed.Username, originalFeed.Password)
-	requestBuilder.WithUserAgent(originalFeed.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(originalFeed.Cookie)
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(originalFeed.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(originalFeed.FetchViaProxy)
-	requestBuilder.IgnoreTLSErrors(originalFeed.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(originalFeed.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithUsernameAndPassword(originalFeed.Username, originalFeed.Password).
+		WithUserAgent(originalFeed.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(originalFeed.Cookie).
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(originalFeed.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(originalFeed.FetchViaProxy).
+		IgnoreTLSErrors(originalFeed.AllowSelfSignedCertificates).
+		DisableHTTP2(originalFeed.DisableHTTP2)
 
 	ignoreHTTPCache := originalFeed.IgnoreHTTPCache || forceRefresh
 	if !ignoreHTTPCache {
-		requestBuilder.WithETag(originalFeed.EtagHeader)
-		requestBuilder.WithLastModified(originalFeed.LastModifiedHeader)
+		requestBuilder = requestBuilder.
+			WithETag(originalFeed.EtagHeader).
+			WithLastModified(originalFeed.LastModifiedHeader)
 	}
 
 	responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(originalFeed.FeedURL))

--- a/internal/reader/icon/checker.go
+++ b/internal/reader/icon/checker.go
@@ -26,16 +26,16 @@ func NewIconChecker(store *storage.Storage, feed *model.Feed) *iconChecker {
 }
 
 func (c *iconChecker) UpdateOrCreateFeedIcon() {
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithUserAgent(c.feed.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(c.feed.Cookie)
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(c.feed.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(c.feed.FetchViaProxy)
-	requestBuilder.IgnoreTLSErrors(c.feed.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(c.feed.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithUserAgent(c.feed.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(c.feed.Cookie).
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(c.feed.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(c.feed.FetchViaProxy).
+		IgnoreTLSErrors(c.feed.AllowSelfSignedCertificates).
+		DisableHTTP2(c.feed.DisableHTTP2)
 
 	iconFinder := newIconFinder(requestBuilder, c.feed.SiteURL, c.feed.IconURL)
 	if icon, err := iconFinder.findIcon(); err != nil {

--- a/internal/reader/processor/bilibili.go
+++ b/internal/reader/processor/bilibili.go
@@ -43,9 +43,9 @@ func extractBilibiliVideoID(websiteURL string) (string, string, error) {
 }
 
 func fetchBilibiliWatchTime(websiteURL string) (int, error) {
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance)
 
 	idType, videoID, extractErr := extractBilibiliVideoID(websiteURL)
 	if extractErr != nil {

--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -50,16 +50,16 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 		slog.Int64("feed_id", feed.ID),
 	)
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithUserAgent(feed.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(feed.Cookie)
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(feed.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(feed.FetchViaProxy)
-	requestBuilder.IgnoreTLSErrors(feed.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(feed.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithUserAgent(feed.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(feed.Cookie).
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(feed.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(feed.FetchViaProxy).
+		IgnoreTLSErrors(feed.AllowSelfSignedCertificates).
+		DisableHTTP2(feed.DisableHTTP2)
 
 	// Processing older entries first ensures that their creation timestamp is lower than newer entries.
 	for _, entry := range slices.Backward(feed.Entries) {
@@ -181,16 +181,16 @@ func ProcessEntryWebPage(feed *model.Feed, entry *model.Entry, user *model.User)
 	startTime := time.Now()
 	entry.URL = rewrite.RewriteEntryURL(feed, entry)
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithUserAgent(feed.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(feed.Cookie)
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(feed.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(feed.FetchViaProxy)
-	requestBuilder.IgnoreTLSErrors(feed.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(feed.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithUserAgent(feed.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(feed.Cookie).
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(feed.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(feed.FetchViaProxy).
+		IgnoreTLSErrors(feed.AllowSelfSignedCertificates).
+		DisableHTTP2(feed.DisableHTTP2)
 
 	webpageBaseURL, extractedContent, scraperErr := scraper.ScrapeWebsite(
 		requestBuilder,

--- a/internal/reader/processor/reading_time.go
+++ b/internal/reader/processor/reading_time.go
@@ -19,9 +19,9 @@ import (
 )
 
 func fetchWatchTime(websiteURL, query string, isoDate bool) (int, error) {
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance)
 
 	responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(websiteURL))
 	defer responseHandler.Close()

--- a/internal/reader/processor/youtube.go
+++ b/internal/reader/processor/youtube.go
@@ -92,9 +92,9 @@ func fetchYouTubeWatchTimeFromApiInBulk(videoIDs []string) (map[string]time.Dura
 		RawQuery: apiQuery.Encode(),
 	}
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance)
 
 	responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(apiURL.String()))
 	defer responseHandler.Close()

--- a/internal/reader/subscription/finder.go
+++ b/internal/reader/subscription/finder.go
@@ -221,9 +221,9 @@ func (f *subscriptionFinder) findSubscriptionsFromWellKnownURLs(websiteURL strin
 			// Some websites redirects unknown URLs to the home page.
 			// As result, the list of known URLs is returned to the subscription list.
 			// We don't want the user to choose between invalid feed URLs.
-			f.requestBuilder.WithoutRedirects()
+			requestBuilder := f.requestBuilder.WithoutRedirects()
 
-			responseHandler := fetcher.NewResponseHandler(f.requestBuilder.ExecuteRequest(fullURL))
+			responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(fullURL))
 			localizedError := responseHandler.LocalizedError()
 			responseHandler.Close()
 

--- a/internal/ui/entry_search.go
+++ b/internal/ui/entry_search.go
@@ -56,9 +56,9 @@ func (h *handler) showSearchEntryPage(w http.ResponseWriter, r *http.Request) {
 		WithSearchQuery(searchQuery)
 	if unreadOnly {
 		if entry.Status == model.EntryStatusRead {
-			entryPaginationBuilder.WithStatusOrEntryID(model.EntryStatusUnread, entry.ID)
+			entryPaginationBuilder = entryPaginationBuilder.WithStatusOrEntryID(model.EntryStatusUnread, entry.ID)
 		} else {
-			entryPaginationBuilder.WithStatus(model.EntryStatusUnread)
+			entryPaginationBuilder = entryPaginationBuilder.WithStatus(model.EntryStatusUnread)
 		}
 	}
 

--- a/internal/ui/opml_upload.go
+++ b/internal/ui/opml_upload.go
@@ -90,9 +90,9 @@ func (h *handler) fetchOPML(w http.ResponseWriter, r *http.Request) {
 	view.Set("countUnread", navMetadata.CountUnread)
 	view.Set("countErrorFeeds", navMetadata.CountErrorFeeds)
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance)
 
 	responseHandler := fetcher.NewResponseHandler(requestBuilder.ExecuteRequest(opmlFileURL))
 	defer responseHandler.Close()

--- a/internal/ui/proxy.go
+++ b/internal/ui/proxy.go
@@ -86,20 +86,18 @@ func (h *handler) mediaProxy(w http.ResponseWriter, r *http.Request) {
 		slog.String("media_url", mediaURL),
 	)
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.MediaProxyHTTPClientTimeout())
-
-	// Disable compression for the media proxy requests (not implemented).
-	requestBuilder.WithoutCompression()
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.MediaProxyHTTPClientTimeout()).
+		WithoutCompression() // Disable compression for the media proxy requests (not implemented).
 
 	if referer := rewrite.GetRefererForURL(mediaURL); referer != "" {
-		requestBuilder.WithHeader("Referer", referer)
+		requestBuilder = requestBuilder.WithHeader("Referer", referer)
 	}
 
 	forwardedRequestHeader := [...]string{"Range", "Accept", "Accept-Encoding", "User-Agent"}
 	for _, requestHeaderName := range forwardedRequestHeader {
 		if r.Header.Get(requestHeaderName) != "" {
-			requestBuilder.WithHeader(requestHeaderName, r.Header.Get(requestHeaderName))
+			requestBuilder = requestBuilder.WithHeader(requestHeaderName, r.Header.Get(requestHeaderName))
 		}
 	}
 

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -34,7 +34,7 @@ func (h *handler) showSearchPage(w http.ResponseWriter, r *http.Request) {
 			WithLimit(user.EntriesPerPage)
 
 		if unreadOnly {
-			builder.WithStatuses(model.EntryStatusUnread)
+			builder = builder.WithStatuses(model.EntryStatusUnread)
 		}
 
 		entries, entriesCount, err = builder.GetEntriesWithCount()

--- a/internal/ui/subscription_submit.go
+++ b/internal/ui/subscription_submit.go
@@ -57,17 +57,17 @@ func (h *handler) submitSubscription(w http.ResponseWriter, r *http.Request) {
 		rssBridgeToken = intg.RSSBridgeToken
 	}
 
-	requestBuilder := fetcher.NewRequestBuilder()
-	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
-	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
-	requestBuilder.WithCustomFeedProxyURL(subscriptionForm.ProxyURL)
-	requestBuilder.WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL())
-	requestBuilder.UseCustomApplicationProxyURL(subscriptionForm.FetchViaProxy)
-	requestBuilder.WithUserAgent(subscriptionForm.UserAgent, config.Opts.HTTPClientUserAgent())
-	requestBuilder.WithCookie(subscriptionForm.Cookie)
-	requestBuilder.WithUsernameAndPassword(subscriptionForm.Username, subscriptionForm.Password)
-	requestBuilder.IgnoreTLSErrors(subscriptionForm.AllowSelfSignedCertificates)
-	requestBuilder.DisableHTTP2(subscriptionForm.DisableHTTP2)
+	requestBuilder := fetcher.NewRequestBuilder().
+		WithTimeout(config.Opts.HTTPClientTimeout()).
+		WithProxyRotator(proxyrotator.ProxyRotatorInstance).
+		WithCustomFeedProxyURL(subscriptionForm.ProxyURL).
+		WithCustomApplicationProxyURL(config.Opts.HTTPClientProxyURL()).
+		UseCustomApplicationProxyURL(subscriptionForm.FetchViaProxy).
+		WithUserAgent(subscriptionForm.UserAgent, config.Opts.HTTPClientUserAgent()).
+		WithCookie(subscriptionForm.Cookie).
+		WithUsernameAndPassword(subscriptionForm.Username, subscriptionForm.Password).
+		IgnoreTLSErrors(subscriptionForm.AllowSelfSignedCertificates).
+		DisableHTTP2(subscriptionForm.DisableHTTP2)
 
 	subscriptionFinder := subscription.NewSubscriptionFinder(requestBuilder)
 	subscriptions, localizedError := subscriptionFinder.FindSubscriptions(


### PR DESCRIPTION
It's a follow-up for #4353. Sorry for the noise.

Didn't occur to me that request/response builders are actually not being used as builders. 

Couple notes here:

1. `CreateFeedFromSubscriptionDiscovery` made useless builder. It is _supposedly_ intended to be used with `NewIconChecker` but `NewIconChecker` makes its own builder.
I removed builder in `CreateFeedFromSubscriptionDiscovery` because it wasn't used. If that's the one actually should've been used in first place, please let me know.

2. _In theory_ builders should be immutable. I.e. if you do `newBuilder := oldBuilder.Sumsin(...)`, state of `oldBuilder` is unchanged.

With that assumption in mind (this is just my guess) `subscriptionFinder.findSubscriptionsFromWellKnownURLs` called `WithoutRedirects` in a loop for each URL. That _in theory_ should create ephemeral builder with redirects disabled but in fact it just disables redirects over and over for no reason.

To be able to use that technique one probably should actually make real builder that doesn't change global builder state. However, currently no builder in miniflux does that and it'd be quite tedious task for basically no gain.

I've decided to just move `WithoutRedirects` up so it's just explicitly does what it's already doing. If something else should be done insted, I'm all ears.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [ ] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
