### PR TITLE
feat(search): swap plainto_tsquery for websearch_to_tsquery

### DIFF
--- a/internal/storage/entry_pagination_builder.go
+++ b/internal/storage/entry_pagination_builder.go
@@ -27,7 +27,7 @@ type entryPaginationBuilder struct {
 // WithSearchQuery adds full-text search query to the condition.
 func (e *entryPaginationBuilder) WithSearchQuery(query string) *entryPaginationBuilder {
 	if query != "" {
-		e.conditions = append(e.conditions, fmt.Sprintf("e.document_vectors @@ plainto_tsquery($%d)", len(e.args)+1))
+		e.conditions = append(e.conditions, fmt.Sprintf("e.document_vectors @@ websearch_to_tsquery($%d)", len(e.args)+1))
 		e.args = append(e.args, query)
 	}
 

--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -46,13 +46,13 @@ func (e *EntryQueryBuilder) WithoutContent() *EntryQueryBuilder {
 func (e *EntryQueryBuilder) WithSearchQuery(query string) *EntryQueryBuilder {
 	if query != "" {
 		nArgs := len(e.args) + 1
-		e.conditions = append(e.conditions, fmt.Sprintf("e.document_vectors @@ plainto_tsquery($%d)", nArgs))
+		e.conditions = append(e.conditions, fmt.Sprintf("e.document_vectors @@ websearch_to_tsquery($%d)", nArgs))
 		e.args = append(e.args, query)
 
 		// 0.0000001 = 0.1 / (seconds_in_a_day)
 
 		e.sortExpressions = append(e.sortExpressions,
-			fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d)) - extract (epoch from now() - published_at)::float * 0.0000001 DESC", nArgs),
+			fmt.Sprintf("ts_rank(document_vectors, websearch_to_tsquery($%d)) - extract (epoch from now() - published_at)::float * 0.0000001 DESC", nArgs),
 		)
 	}
 	return e


### PR DESCRIPTION
This switches plainto_tsquery to instead use websearch_to_tsquery, introduced in PostgreSQL 11. With unquoted text it behaves the same, but allows to use quoted text and OR and negation in the search terms.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [ ] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

To the above checklist: I ran the integrated test suite, including integration tests, and everything passed.
I ran it where I'm figuring out which reader I like more, which has ~300 feeds, but I don't use that much - it does work there, and now I can perform a `something OR other OR evenmoreoptions` search, and it returns results (they seem to be sorted by relevance more than recency?).
On nextflux connected to this miniflux instance, a simple single word search continued to work, but the complex search with `OR` did not.

And I will point out that I don't know enough to known the implications of this, I don't know what this can affect and where, and used a simple search-and-replace on the instances of the function. But, this seems to drastically increase functionality of available search.