### PR TITLE
docs: Specify unit of time for POLLING_FREQUENCY and list-separation for TRUSTED_REVERSE_PROXY_NETWORKS

### DIFF
--- a/miniflux.1
+++ b/miniflux.1
@@ -546,7 +546,7 @@ a linked OAuth2 account to sign in\&.
 Disabled by default\&.
 .TP
 .B POLLING_FREQUENCY
-Interval for the background job scheduler.
+Interval in minutes for the background job scheduler.
 .br
 Determines how often a batch of feeds is selected for refresh,
 based on their last refresh time\&.

--- a/miniflux.1
+++ b/miniflux.1
@@ -625,7 +625,7 @@ Minimum interval in minutes for the round robin scheduler\&.
 Default is 60 minutes\&.
 .TP
 .B TRUSTED_REVERSE_PROXY_NETWORKS
-List of networks (CIDR notation) allowed to use the proxy
+A comma-separated list of networks (CIDR notation) allowed to use the proxy
 authentication header, \fBX-Forwarded-For\fR,
 \fBX-Forwarded-Proto\fR, and \fBX-Real-Ip\fR headers\&.
 .br


### PR DESCRIPTION
The documentation specifies a unit of time for all configurable intervals except POLLING_FREQUENCY.

It also specifies how list-items are separated for most lists except TRUSTED_REVERSE_PROXY_NETWORKS.

This PR fixes both.

---

**Have you followed these guidelines?** - No, I have not. This is a trivial change that adds four words to the documentation.

- [ ] I have tested my changes
- [ ] There are no breaking changes
- [ ] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
