### PR TITLE
fix(migrations): use SHA-256 instead of MD5 for the enclosures unique index

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:9.5
+        image: postgres:11
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -353,7 +353,11 @@ var migrations = [...]func(tx *sql.Tx) error{
 		return err
 	},
 	func(tx *sql.Tx) (err error) {
-		sql := `CREATE INDEX enclosures_user_entry_url_idx ON enclosures(user_id, entry_id, md5(url))`
+		// This migration originally used md5(url), but it was changed to
+		// sha256 because PostgreSQL 18 disables MD5 in FIPS mode, which made
+		// fresh installs fail while replaying this migration. Existing
+		// installs that already ran it are migrated later on.
+		sql := `CREATE INDEX enclosures_user_entry_url_idx ON enclosures(user_id, entry_id, encode(sha256(url::bytea), 'hex'))`
 		_, err = tx.Exec(sql)
 		return err
 	},
@@ -724,7 +728,12 @@ var migrations = [...]func(tx *sql.Tx) error{
 		}
 
 		// Create unique index
-		_, err = tx.Exec(`CREATE UNIQUE INDEX enclosures_user_entry_url_unique_idx ON enclosures(user_id, entry_id, md5(url))`)
+		//
+		// This originally used md5(url), but it was changed to sha256 because
+		// PostgreSQL 18 disables MD5 in FIPS mode, which made fresh installs
+		// fail while replaying this migration. Existing installs that already
+		// ran it are migrated later on.
+		_, err = tx.Exec(`CREATE UNIQUE INDEX enclosures_user_entry_url_unique_idx ON enclosures(user_id, entry_id, encode(sha256(url::bytea), 'hex'))`)
 		if err != nil {
 			return err
 		}
@@ -1522,6 +1531,17 @@ var migrations = [...]func(tx *sql.Tx) error{
 		_, err = tx.Exec(`
 			DROP INDEX IF EXISTS entries_feed_idx;
 			DROP INDEX IF EXISTS entries_user_status_idx;
+		`)
+		return err
+	},
+	func(tx *sql.Tx) (err error) {
+		// PostgreSQL 18 disables MD5 when running in FIPS mode, which makes
+		// the unique index on enclosures relying on md5(url) unusable.
+		// Replace it with a SHA-256 based expression index.
+		_, err = tx.Exec(`
+			DROP INDEX IF EXISTS enclosures_user_entry_url_unique_idx;
+			CREATE UNIQUE INDEX enclosures_user_entry_url_unique_idx
+				ON enclosures (user_id, entry_id, encode(sha256(url::bytea), 'hex'));
 		`)
 		return err
 	},

--- a/internal/storage/enclosure.go
+++ b/internal/storage/enclosure.go
@@ -155,7 +155,7 @@ func (s *Storage) createEnclosure(tx *sql.Tx, enclosure *model.Enclosure) error 
 			(url, size, mime_type, entry_id, user_id, media_progression)
 		VALUES
 			($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (user_id, entry_id, md5(url)) DO NOTHING
+		ON CONFLICT (user_id, entry_id, encode(sha256(url::bytea), 'hex')) DO NOTHING
 		RETURNING
 			id
 	`


### PR DESCRIPTION
PostgreSQL 18 disables MD5 when running in FIPS mode, which made md5(url) unusable. This broke enclosure creation with:

    store: unable to create enclosure: pq: could not compute MD5
    hash: unsupported (XX000)

Replace md5(url) with encode(sha256(url::bytea), 'hex') everywhere:

- The historical migrations that created the enclosures index are changed to sha256 so fresh installs no longer fail while replaying them on FIPS-mode PostgreSQL 18.
- A new migration rebuilds enclosures_user_entry_url_unique_idx with sha256 to convert existing installs.
- The ON CONFLICT clause in createEnclosure is updated to match the new expression index.

According to `openssl speed -bytes 256 md5 sha256`, this is a performance improvement as well :D

Fixes #4350