### PR TITLE
feat(atom): use id for entry link if it is an http URL

### DIFF
--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -81,6 +81,16 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 			}
 		}
 
+		// If the entry has no links, attempt to use its ID as a URL
+		// and if that fails, use the site URL.
+		if entry.URL == "" {
+			if urllib.IsAbsoluteURL(atomEntry.ID) {
+				entry.URL = atomEntry.ID
+			} else {
+				entry.URL = siteURL
+			}
+		}
+
 		// Populate the entry content.
 		entry.Content = atomEntry.Content.body()
 		if entry.Content == "" {

--- a/internal/reader/atom/atom_10_test.go
+++ b/internal/reader/atom/atom_10_test.go
@@ -1837,3 +1837,31 @@ func TestParseFeedWithIconURL(t *testing.T) {
 		t.Errorf("Incorrect icon URL, got: %s", feed.IconURL)
 	}
 }
+
+func TestParseEntryWithIDAsURL(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<feed xmlns="http://www.w3.org/2005/Atom">
+		<title>Example Feed</title>
+		<link href="http://example.org/"/>
+		<link href="http://example.org/atom" rel="self"/>
+		<entry>
+			<id>http://www.example.org/entries/1</id>
+		</entry>
+		<entry>
+			<id>mailto:john.doe@example.org</id>
+		</entry>
+	</feed>`
+
+	feed, err := Parse("https://example.org/", bytes.NewReader([]byte(data)), "10")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feed.Entries[0].URL != "http://www.example.org/entries/1" {
+		t.Errorf("Incorrect entry URL, got: %s", feed.Entries[0].URL)
+	}
+
+	if feed.Entries[1].URL != "http://example.org/" {
+		t.Errorf("Incorrect entry URL, got: %s", feed.Entries[1].URL)
+	}
+}


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

It is valid for an atom 1.0 feed to include no links in the entries. For instance, `https://sinclairtarget.com/feed.xml` passes validation. miniflux currently currently parses empty urls for every entry in that feed. However, the `<id>` element for atom is specified as an IRI ... which might be a URL. This change attempts to use the `id` value as the entry URL. If that doesn't work, it uses the site URL, just to ensure the entry has a url.

There is nothing in the atom spec that recommends using the `id` if there is no link. It is just intended as a globally unique identifier. Practically, though, the permalink is valid and widely used as the `id`. Just to double check myself, I looked at what a couple of other readers do.

- FreshRSS uses the `id` as the URL unconditionally, even if it's not an http-based URL
- Tiny Tiny RSS uses the site URL if there is no link on the entry.

https://sinclairtarget.com/feed.xml is a good example to test against.