### PR TITLE
fix(googlereader): apply configured user agent in quickadd handler

### DIFF
--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -345,6 +345,7 @@ func (h *greaderHandler) quickAddHandler(w http.ResponseWriter, r *http.Request)
 	requestBuilder := fetcher.NewRequestBuilder()
 	requestBuilder.WithTimeout(config.Opts.HTTPClientTimeout())
 	requestBuilder.WithProxyRotator(proxyrotator.ProxyRotatorInstance)
+	requestBuilder.WithUserAgent("", config.Opts.HTTPClientUserAgent())
 
 	var rssBridgeURL string
 	var rssBridgeToken string


### PR DESCRIPTION
## Problem

The `/reader/api/0/subscription/quickadd` endpoint (used by clients like NetNewsWire) does not set the `User-Agent` header when fetching feeds. This causes outbound requests to use Go's default user agent (`Go-http-client/2.x`), which many sites — including Reddit — block with a 403.

As a result, adding a Reddit RSS feed via NetNewsWire fails with a 500 error, even though adding the exact same feed through the Miniflux web UI succeeds.

## Root cause

The web UI's subscription handler calls:
```go
requestBuilder.WithUserAgent(subscriptionForm.UserAgent, config.Opts.HTTPClientUserAgent())
```

The `quickAddHandler` was missing this call entirely, so the request builder used Go's default user agent instead of the operator-configured `HTTP_CLIENT_USER_AGENT`.

## Fix

Add `WithUserAgent("", config.Opts.HTTPClientUserAgent())` to the `quickAddHandler` request builder, consistent with how all other feed-fetching paths set the user agent.

## Test

1. Configure a Miniflux instance with a custom `HTTP_CLIENT_USER_AGENT`.
2. In NetNewsWire (or any Google Reader-compatible client), add `https://www.reddit.com/r/golang.rss`.
3. Before: returns 500 (Reddit responds with 403 to Go's default UA).
4. After: feed is added successfully using the configured user agent.