### PR TITLE
refactor(cli): use cleaner syntax for common exit routine

### DIFF
--- a/internal/cli/ask_credentials.go
+++ b/internal/cli/ask_credentials.go
@@ -25,24 +25,24 @@ func askCredentials() (string, string) {
 	reader := bufio.NewReader(os.Stdin)
 	username, err := reader.ReadString('\n')
 	if err != nil {
-		printErrorAndExit(fmt.Errorf("unable to read username: %w", err))
+		printfAndExit("unable to read username: %w", err)
 	}
 
 	fmt.Print("Enter Password: ")
 
 	state, err := term.GetState(fd)
 	if err != nil {
-		printErrorAndExit(fmt.Errorf("unable to get terminal state: %w", err))
+		printfAndExit("unable to get terminal state: %w", err)
 	}
 	defer func() {
 		if restoreErr := term.Restore(fd, state); restoreErr != nil {
-			printErrorAndExit(fmt.Errorf("unable to restore terminal state: %w", restoreErr))
+			printfAndExit("unable to restore terminal state: %w", restoreErr)
 		}
 	}()
 
 	bytePassword, err := term.ReadPassword(fd)
 	if err != nil {
-		printErrorAndExit(fmt.Errorf("unable to read password: %w", err))
+		printfAndExit("unable to read password: %w", err)
 	}
 
 	fmt.Print("\n")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -124,7 +124,7 @@ func Parse() {
 	default:
 		logFileHandler, err = os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
-			printErrorAndExit(fmt.Errorf("unable to open log file: %v", err))
+			printfAndExit("unable to open log file: %v", err)
 		}
 		defer logFileHandler.(*os.File).Close()
 	}
@@ -143,15 +143,15 @@ func Parse() {
 	}
 
 	if err := static.GenerateBinaryBundles(); err != nil {
-		printErrorAndExit(fmt.Errorf("unable to generate binary files bundle: %v", err))
+		printfAndExit("unable to generate binary files bundle: %v", err)
 	}
 
 	if err := static.GenerateStylesheetsBundles(); err != nil {
-		printErrorAndExit(fmt.Errorf("unable to generate stylesheets bundle: %v", err))
+		printfAndExit("unable to generate stylesheets bundle: %v", err)
 	}
 
 	if err := static.GenerateJavascriptBundles(config.Opts.WebAuthn()); err != nil {
-		printErrorAndExit(fmt.Errorf("unable to generate javascript bundle: %v", err))
+		printfAndExit("unable to generate javascript bundle: %v", err)
 	}
 
 	db, err := database.NewConnectionPool(
@@ -161,7 +161,7 @@ func Parse() {
 		config.Opts.DatabaseConnectionLifetime(),
 	)
 	if err != nil {
-		printErrorAndExit(fmt.Errorf("unable to connect to database: %v", err))
+		printfAndExit("unable to connect to database: %v", err)
 	}
 	defer db.Close()
 
@@ -231,7 +231,7 @@ func Parse() {
 		slog.Info("Initializing proxy rotation", slog.Int("proxies_count", len(config.Opts.HTTPClientProxies())))
 		proxyrotator.ProxyRotatorInstance, err = proxyrotator.NewProxyRotator(config.Opts.HTTPClientProxies())
 		if err != nil {
-			printErrorAndExit(fmt.Errorf("unable to initialize proxy rotator: %v", err))
+			printfAndExit("unable to initialize proxy rotator: %v", err)
 		}
 	}
 
@@ -251,4 +251,9 @@ func Parse() {
 func printErrorAndExit(err error) {
 	fmt.Fprintln(os.Stderr, err)
 	os.Exit(1)
+}
+
+func printfAndExit(format string, args ...any) {
+	err := fmt.Errorf(format, args...)
+	printErrorAndExit(err)
 }

--- a/internal/cli/export_feeds.go
+++ b/internal/cli/export_feeds.go
@@ -13,17 +13,17 @@ import (
 func exportUserFeeds(store *storage.Storage, username string) {
 	user, err := store.UserByUsername(username)
 	if err != nil {
-		printErrorAndExit(fmt.Errorf("unable to find user: %w", err))
+		printfAndExit("unable to find user: %w", err)
 	}
 
 	if user == nil {
-		printErrorAndExit(fmt.Errorf("user %q not found", username))
+		printfAndExit("user %q not found", username)
 	}
 
 	opmlHandler := opml.NewHandler(store)
 	opmlExport, err := opmlHandler.Export(user.ID)
 	if err != nil {
-		printErrorAndExit(fmt.Errorf("unable to export feeds: %w", err))
+		printfAndExit("unable to export feeds: %w", err)
 	}
 
 	fmt.Println(opmlExport)

--- a/internal/cli/health_check.go
+++ b/internal/cli/health_check.go
@@ -4,7 +4,6 @@
 package cli // import "miniflux.app/v2/internal/cli"
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -22,12 +21,12 @@ func doHealthCheck(healthCheckEndpoint string) {
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(healthCheckEndpoint)
 	if err != nil {
-		printErrorAndExit(fmt.Errorf(`health check failure: %v`, err))
+		printfAndExit(`health check failure: %v`, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		printErrorAndExit(fmt.Errorf(`health check failed with status code %d`, resp.StatusCode))
+		printfAndExit(`health check failed with status code %d`, resp.StatusCode)
 	}
 
 	slog.Debug(`Health check is passing`)


### PR DESCRIPTION
As using `fmt.Errorf` with `os.Exit` is quite common in `internal/cli` it seems convenient to do what without nesting error. Additional function call just inducing noise.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
