### PR TITLE
[Bug] Show refresh notice after using the R shortcut

### DIFF
--- a/internal/template/templates/common/layout.html
+++ b/internal/template/templates/common/layout.html
@@ -44,6 +44,7 @@
     data-add-subscription-url="{{ routePath "/subscribe" }}"
     data-entries-status-url="{{ routePath "/entry/status" }}"
     data-refresh-all-feeds-url="{{ routePath "/feeds/refresh" }}"
+    data-refresh-all-feeds-message="{{ t "alert.background_feed_refresh" }}"
     {{ if .webAuthnEnabled }}
     data-webauthn-register-begin-url="{{ routePath "/webauthn/register/begin" }}"
     data-webauthn-register-finish-url="{{ routePath "/webauthn/register/finish" }}"

--- a/internal/ui/static/js/app.js
+++ b/internal/ui/static/js/app.js
@@ -666,8 +666,11 @@ function handleRefreshAllFeedsAction() {
         sendPOSTRequest(refreshAllFeedsUrl).then((response) => {
             if (response?.redirected && response.url) {
                 window.location.href = response.url;
-            } else {
-                window.location.reload();
+                return;
+            }
+
+            if (response?.ok) {
+                showToastNotification("refresh", document.body.dataset.refreshAllFeedsMessage);
             }
         });
     }


### PR DESCRIPTION
## Summary
- keep the keyboard shortcut refresh path on the current page instead of consuming the server flash message through `fetch()` redirects
- surface the same background refresh success text as a client-side toast for shortcut-triggered refreshes
- preserve redirect handling for auth/session flows

## Why
Fixes #4358. The `R` shortcut refreshed feeds correctly, but its `fetch()` + reload path swallowed the flash message that the menu form submission relies on, so users got no visible confirmation.

## Verification
- `go test ./...`