### PR TITLE
reduce reader allocation

### DIFF
--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -414,7 +414,7 @@ func (h *handler) importFeedEntryHandler(w http.ResponseWriter, r *http.Request)
 		entry.ReadingTime = readingtime.EstimateReadingTime(entry.Content, user.DefaultReadingSpeed, user.CJKReadingSpeed)
 	}
 
-	created, err := h.store.InsertEntryForFeed(userID, feedID, entry)
+	created, err := h.store.InsertEntryForFeed(userID, feedID, &entry)
 	if errors.Is(err, storage.ErrEntryTombstoned) {
 		response.JSONBadRequest(w, r, err)
 		return

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -308,11 +308,10 @@ func (h *greaderHandler) editTagHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		for _, entry := range entries {
-			e := entry
-			go func() {
-				integration.SendEntry(e, settings)
-			}()
+		for i := range entries {
+			entry := &entries[i]
+
+			go integration.SendEntry(entry, settings)
 		}
 	}
 

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -664,7 +664,9 @@ func PushEntries(feed *model.Feed, entries model.Entries, userIntegrations *mode
 
 	// Integrations that only support sending individual entries
 	if userIntegrations.TelegramBotEnabled {
-		for _, entry := range entries {
+		for i := range entries {
+			entry := &entries[i]
+
 			slog.Debug("Sending a new entry to Telegram",
 				slog.Int64("user_id", userIntegrations.UserID),
 				slog.Int64("entry_id", entry.ID),

--- a/internal/model/enclosure.go
+++ b/internal/model/enclosure.go
@@ -57,11 +57,13 @@ func (e *Enclosure) ProxifyEnclosureURL(mediaProxyOption string, mediaProxyResou
 }
 
 // EnclosureList represents a list of attachments.
-type EnclosureList []*Enclosure
+type EnclosureList []Enclosure
 
 // FindMediaPlayerEnclosure returns the first enclosure that can be played by a media player.
 func (el EnclosureList) FindMediaPlayerEnclosure() *Enclosure {
-	for _, enclosure := range el {
+	for i := range el {
+		enclosure := &el[i]
+
 		if enclosure.URL != "" {
 			if enclosure.IsAudio() || enclosure.IsVideo() {
 				return enclosure
@@ -82,7 +84,7 @@ func (el EnclosureList) ContainsAudioOrVideo() bool {
 }
 
 func (el EnclosureList) ProxifyEnclosureURL(mediaProxyOption string, mediaProxyResourceTypes []string) {
-	for _, enclosure := range el {
-		enclosure.ProxifyEnclosureURL(mediaProxyOption, mediaProxyResourceTypes)
+	for i := range el {
+		el[i].ProxifyEnclosureURL(mediaProxyOption, mediaProxyResourceTypes)
 	}
 }

--- a/internal/model/enclosure_test.go
+++ b/internal/model/enclosure_test.go
@@ -54,7 +54,7 @@ func TestEnclosure_IsAudio(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			enclosure := &Enclosure{MimeType: tc.mimeType}
+			enclosure := Enclosure{MimeType: tc.mimeType}
 			if got := enclosure.IsAudio(); got != tc.expected {
 				t.Errorf("IsAudio() = %v, want %v for mime type %s", got, tc.expected, tc.mimeType)
 			}
@@ -82,7 +82,7 @@ func TestEnclosure_IsVideo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			enclosure := &Enclosure{MimeType: tc.mimeType}
+			enclosure := Enclosure{MimeType: tc.mimeType}
 			if got := enclosure.IsVideo(); got != tc.expected {
 				t.Errorf("IsVideo() = %v, want %v for mime type %s", got, tc.expected, tc.mimeType)
 			}
@@ -117,7 +117,7 @@ func TestEnclosure_IsImage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			enclosure := &Enclosure{MimeType: tc.mimeType, URL: tc.url}
+			enclosure := Enclosure{MimeType: tc.mimeType, URL: tc.url}
 			if got := enclosure.IsImage(); got != tc.expected {
 				t.Errorf("IsImage() = %v, want %v for mime type %s and URL %s", got, tc.expected, tc.mimeType, tc.url)
 			}
@@ -134,40 +134,40 @@ func TestEnclosureList_FindMediaPlayerEnclosure(t *testing.T) {
 		{
 			name: "Returns first audio enclosure",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
 			},
 			expectedNil: false,
 		},
 		{
 			name: "Returns first video enclosure",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
 			},
 			expectedNil: false,
 		},
 		{
 			name: "Skips image enclosure and returns audio",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/image.jpg", MimeType: "image/jpeg"},
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/image.jpg", MimeType: "image/jpeg"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
 			},
 			expectedNil: false,
 		},
 		{
 			name: "Skips enclosure with empty URL",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
 			},
 			expectedNil: false,
 		},
 		{
 			name: "Returns nil for no media enclosures",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/image.jpg", MimeType: "image/jpeg"},
-				&Enclosure{URL: "http://example.com/doc.pdf", MimeType: "application/pdf"},
+				{URL: "http://example.com/image.jpg", MimeType: "image/jpeg"},
+				{URL: "http://example.com/doc.pdf", MimeType: "application/pdf"},
 			},
 			expectedNil: true,
 		},
@@ -179,8 +179,8 @@ func TestEnclosureList_FindMediaPlayerEnclosure(t *testing.T) {
 		{
 			name: "Returns nil for all empty URLs",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "", MimeType: "video/mp4"},
+				{URL: "", MimeType: "audio/mpeg"},
+				{URL: "", MimeType: "video/mp4"},
 			},
 			expectedNil: true,
 		},
@@ -213,40 +213,40 @@ func TestEnclosureList_ContainsAudioOrVideo(t *testing.T) {
 		{
 			name: "Contains audio",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "audio/mpeg"},
-				&Enclosure{MimeType: "image/jpeg"},
+				{MimeType: "audio/mpeg"},
+				{MimeType: "image/jpeg"},
 			},
 			expected: true,
 		},
 		{
 			name: "Contains video",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "image/jpeg"},
-				&Enclosure{MimeType: "video/mp4"},
+				{MimeType: "image/jpeg"},
+				{MimeType: "video/mp4"},
 			},
 			expected: true,
 		},
 		{
 			name: "Contains both audio and video",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "audio/mpeg"},
-				&Enclosure{MimeType: "video/mp4"},
+				{MimeType: "audio/mpeg"},
+				{MimeType: "video/mp4"},
 			},
 			expected: true,
 		},
 		{
 			name: "Contains only images",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "image/jpeg"},
-				&Enclosure{MimeType: "image/png"},
+				{MimeType: "image/jpeg"},
+				{MimeType: "image/png"},
 			},
 			expected: false,
 		},
 		{
 			name: "Contains only documents",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "application/pdf"},
-				&Enclosure{MimeType: "text/plain"},
+				{MimeType: "application/pdf"},
+				{MimeType: "text/plain"},
 			},
 			expected: false,
 		},
@@ -258,14 +258,14 @@ func TestEnclosureList_ContainsAudioOrVideo(t *testing.T) {
 		{
 			name: "Single audio enclosure",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "audio/wav"},
+				{MimeType: "audio/wav"},
 			},
 			expected: true,
 		},
 		{
 			name: "Single video enclosure",
 			enclosures: EnclosureList{
-				&Enclosure{MimeType: "video/webm"},
+				{MimeType: "video/webm"},
 			},
 			expected: true,
 		},
@@ -378,7 +378,7 @@ func TestEnclosure_ProxifyEnclosureURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			enclosure := &Enclosure{
+			enclosure := Enclosure{
 				URL:      tc.url,
 				MimeType: tc.mimeType,
 			}
@@ -431,10 +431,10 @@ func TestEnclosureList_ProxifyEnclosureURL(t *testing.T) {
 		{
 			name: "Mixed enclosures with all proxy mode",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "https://example.com/video.mp4", MimeType: "video/mp4"},
-				&Enclosure{URL: "http://example.com/image.jpg", MimeType: "image/jpeg"},
-				&Enclosure{URL: "http://example.com/doc.pdf", MimeType: "application/pdf"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "https://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/image.jpg", MimeType: "image/jpeg"},
+				{URL: "http://example.com/doc.pdf", MimeType: "application/pdf"},
 			},
 			mediaProxyOption:        "all",
 			mediaProxyResourceTypes: []string{"audio", "video"},
@@ -443,9 +443,9 @@ func TestEnclosureList_ProxifyEnclosureURL(t *testing.T) {
 		{
 			name: "Mixed enclosures with http-only proxy mode",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "https://example.com/video.mp4", MimeType: "video/mp4"},
-				&Enclosure{URL: "http://example.com/video2.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "https://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/video2.mp4", MimeType: "video/mp4"},
 			},
 			mediaProxyOption:        "http-only",
 			mediaProxyResourceTypes: []string{"audio", "video"},
@@ -454,8 +454,8 @@ func TestEnclosureList_ProxifyEnclosureURL(t *testing.T) {
 		{
 			name: "No media types in resource list",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
 			},
 			mediaProxyOption:        "all",
 			mediaProxyResourceTypes: []string{"image"},
@@ -464,8 +464,8 @@ func TestEnclosureList_ProxifyEnclosureURL(t *testing.T) {
 		{
 			name: "Proxy mode none",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "http://example.com/audio.mp3", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
 			},
 			mediaProxyOption:        "none",
 			mediaProxyResourceTypes: []string{"audio", "video"},
@@ -481,8 +481,8 @@ func TestEnclosureList_ProxifyEnclosureURL(t *testing.T) {
 		{
 			name: "Enclosures with empty URLs",
 			enclosures: EnclosureList{
-				&Enclosure{URL: "", MimeType: "audio/mpeg"},
-				&Enclosure{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
+				{URL: "", MimeType: "audio/mpeg"},
+				{URL: "http://example.com/video.mp4", MimeType: "video/mp4"},
 			},
 			mediaProxyOption:        "all",
 			mediaProxyResourceTypes: []string{"audio", "video"},
@@ -534,7 +534,7 @@ func TestEnclosure_ProxifyEnclosureURL_EdgeCases(t *testing.T) {
 	}
 
 	t.Run("Empty resource types slice", func(t *testing.T) {
-		enclosure := &Enclosure{
+		enclosure := Enclosure{
 			URL:      "http://example.com/audio.mp3",
 			MimeType: "audio/mpeg",
 		}
@@ -549,7 +549,7 @@ func TestEnclosure_ProxifyEnclosureURL_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("Nil resource types slice", func(t *testing.T) {
-		enclosure := &Enclosure{
+		enclosure := Enclosure{
 			URL:      "http://example.com/audio.mp3",
 			MimeType: "audio/mpeg",
 		}
@@ -563,7 +563,7 @@ func TestEnclosure_ProxifyEnclosureURL_EdgeCases(t *testing.T) {
 		}
 	})
 	t.Run("Invalid proxy mode", func(t *testing.T) {
-		enclosure := &Enclosure{
+		enclosure := Enclosure{
 			URL:      "http://example.com/audio.mp3",
 			MimeType: "audio/mpeg",
 		}

--- a/internal/model/entry.go
+++ b/internal/model/entry.go
@@ -47,10 +47,10 @@ type Entry struct {
 	Tags        []string      `json:"tags"`
 }
 
-func NewEntry() *Entry {
-	return &Entry{
-		Enclosures: make(EnclosureList, 0),
-		Tags:       make([]string, 0),
+func NewEntry() Entry {
+	return Entry{
+		Enclosures: EnclosureList{},
+		Tags:       []string{},
 		Feed: &Feed{
 			Category: &Category{},
 			Icon:     &FeedIcon{},
@@ -75,7 +75,7 @@ func (e *Entry) ShouldMarkAsReadOnView(user *User) bool {
 }
 
 // Entries represents a list of entries.
-type Entries []*Entry
+type Entries []Entry
 
 // EntriesStatusUpdateRequest represents a request to change entries status.
 type EntriesStatusUpdateRequest struct {

--- a/internal/reader/atom/atom_03_adapter.go
+++ b/internal/reader/atom/atom_03_adapter.go
@@ -50,6 +50,7 @@ func (a *atom03Adapter) buildFeed(baseURL string) *model.Feed {
 
 	feed.Language = language.Normalize(a.atomFeed.Language)
 
+	feed.Entries = make(model.Entries, 0, len(a.atomFeed.Entries))
 	for _, atomEntry := range a.atomFeed.Entries {
 		entry := model.NewEntry()
 

--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -5,6 +5,7 @@ package atom // import "miniflux.app/v2/internal/reader/atom"
 
 import (
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -71,6 +72,9 @@ func (a *atom10Adapter) buildFeed(baseURL string) *model.Feed {
 }
 
 func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
+	enclosures := make(model.EnclosureList, 0)
+	uniqueEnclosuresMap := make(map[string]bool)
+
 	entries := make(model.Entries, 0, len(a.atomFeed.Entries))
 
 	for _, atomEntry := range a.atomFeed.Entries {
@@ -176,9 +180,10 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 		}
 
 		// Populate the entry enclosures.
-		uniqueEnclosuresMap := make(map[string]bool)
+		clear(uniqueEnclosuresMap)
+		enclosures = enclosures[:0]
 
-		for _, mediaThumbnail := range atomEntry.AllMediaThumbnails() {
+		for mediaThumbnail := range atomEntry.AllMediaThumbnails() {
 			mediaURL := strings.TrimSpace(mediaThumbnail.URL)
 			if mediaURL == "" {
 				continue
@@ -200,7 +205,7 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 			uniqueEnclosuresMap[mediaAbsoluteURL] = true
 
-			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+			enclosures = append(enclosures, &model.Enclosure{
 				URL:      mediaAbsoluteURL,
 				MimeType: mediaThumbnail.MimeType(),
 				Size:     mediaThumbnail.Size(),
@@ -225,14 +230,14 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 			uniqueEnclosuresMap[absoluteEnclosureURL] = true
 
 			length, _ := strconv.ParseInt(link.Length, 10, 0)
-			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+			enclosures = append(enclosures, &model.Enclosure{
 				URL:      absoluteEnclosureURL,
 				MimeType: link.Type,
 				Size:     length,
 			})
 		}
 
-		for _, mediaContent := range atomEntry.AllMediaContents() {
+		for mediaContent := range atomEntry.AllMediaContents() {
 			mediaURL := strings.TrimSpace(mediaContent.URL)
 			if mediaURL == "" {
 				continue
@@ -254,14 +259,14 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 			uniqueEnclosuresMap[mediaAbsoluteURL] = true
 
-			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+			enclosures = append(enclosures, &model.Enclosure{
 				URL:      mediaAbsoluteURL,
 				MimeType: mediaContent.MimeType(),
 				Size:     mediaContent.Size(),
 			})
 		}
 
-		for _, mediaPeerLink := range atomEntry.AllMediaPeerLinks() {
+		for mediaPeerLink := range atomEntry.AllMediaPeerLinks() {
 			mediaURL := strings.TrimSpace(mediaPeerLink.URL)
 			if mediaURL == "" {
 				continue
@@ -283,13 +288,14 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 			uniqueEnclosuresMap[mediaAbsoluteURL] = true
 
-			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+			enclosures = append(enclosures, &model.Enclosure{
 				URL:      mediaAbsoluteURL,
 				MimeType: mediaPeerLink.MimeType(),
 				Size:     mediaPeerLink.Size(),
 			})
 		}
 
+		entry.Enclosures = slices.Clone(enclosures)
 		entries = append(entries, entry)
 	}
 

--- a/internal/reader/atom/atom_10_adapter.go
+++ b/internal/reader/atom/atom_10_adapter.go
@@ -205,7 +205,7 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 			uniqueEnclosuresMap[mediaAbsoluteURL] = true
 
-			enclosures = append(enclosures, &model.Enclosure{
+			enclosures = append(enclosures, model.Enclosure{
 				URL:      mediaAbsoluteURL,
 				MimeType: mediaThumbnail.MimeType(),
 				Size:     mediaThumbnail.Size(),
@@ -230,7 +230,7 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 			uniqueEnclosuresMap[absoluteEnclosureURL] = true
 
 			length, _ := strconv.ParseInt(link.Length, 10, 0)
-			enclosures = append(enclosures, &model.Enclosure{
+			enclosures = append(enclosures, model.Enclosure{
 				URL:      absoluteEnclosureURL,
 				MimeType: link.Type,
 				Size:     length,
@@ -259,7 +259,7 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 			uniqueEnclosuresMap[mediaAbsoluteURL] = true
 
-			enclosures = append(enclosures, &model.Enclosure{
+			enclosures = append(enclosures, model.Enclosure{
 				URL:      mediaAbsoluteURL,
 				MimeType: mediaContent.MimeType(),
 				Size:     mediaContent.Size(),
@@ -288,7 +288,7 @@ func (a *atom10Adapter) populateEntries(siteURL string) model.Entries {
 
 			uniqueEnclosuresMap[mediaAbsoluteURL] = true
 
-			enclosures = append(enclosures, &model.Enclosure{
+			enclosures = append(enclosures, model.Enclosure{
 				URL:      mediaAbsoluteURL,
 				MimeType: mediaPeerLink.MimeType(),
 				Size:     mediaPeerLink.Size(),

--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -70,6 +70,8 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		}
 	}
 
+	enclosures := make(model.EnclosureList, 0)
+
 	feed.Entries = make(model.Entries, 0, len(j.jsonFeed.Items))
 	for _, item := range j.jsonFeed.Items {
 		entry := model.NewEntry()
@@ -158,7 +160,7 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		entry.Author = strings.Join(authorNames, ", ")
 
 		// Populate the entry enclosures.
-		entry.Enclosures = make([]*model.Enclosure, 0, len(item.Attachments))
+		enclosures = enclosures[:0]
 
 		for _, attachment := range item.Attachments {
 			attachmentURL := strings.TrimSpace(attachment.URL)
@@ -176,12 +178,14 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 				continue
 			}
 
-			entry.Enclosures = append(entry.Enclosures, &model.Enclosure{
+			enclosures = append(enclosures, &model.Enclosure{
 				URL:      absoluteAttachmentURL,
 				MimeType: attachment.MimeType,
 				Size:     attachment.Size,
 			})
 		}
+
+		entry.Enclosures = slices.Clone(enclosures)
 
 		// Populate the entry tags.
 		entry.Tags = make([]string, 0, len(item.Tags))

--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -178,7 +178,7 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 				continue
 			}
 
-			enclosures = append(enclosures, &model.Enclosure{
+			enclosures = append(enclosures, model.Enclosure{
 				URL:      absoluteAttachmentURL,
 				MimeType: attachment.MimeType,
 				Size:     attachment.Size,

--- a/internal/reader/json/adapter.go
+++ b/internal/reader/json/adapter.go
@@ -70,6 +70,7 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		}
 	}
 
+	feed.Entries = make(model.Entries, 0, len(j.jsonFeed.Items))
 	for _, item := range j.jsonFeed.Items {
 		entry := model.NewEntry()
 
@@ -157,6 +158,8 @@ func (j *JSONAdapter) BuildFeed(baseURL string) *model.Feed {
 		entry.Author = strings.Join(authorNames, ", ")
 
 		// Populate the entry enclosures.
+		entry.Enclosures = make([]*model.Enclosure, 0, len(item.Attachments))
+
 		for _, attachment := range item.Attachments {
 			attachmentURL := strings.TrimSpace(attachment.URL)
 			if attachmentURL == "" {

--- a/internal/reader/media/media.go
+++ b/internal/reader/media/media.go
@@ -22,34 +22,61 @@ type MediaItemElement struct {
 	MediaPeerLinks    []PeerLink        `xml:"http://search.yahoo.com/mrss/ peerLink"`
 }
 
-// AllMediaThumbnails returns all thumbnail elements merged together.
-func (e *MediaItemElement) AllMediaThumbnails() []Thumbnail {
-	items := make([]Thumbnail, 0, len(e.MediaThumbnails)+len(e.MediaGroups))
-	items = append(items, e.MediaThumbnails...)
-	for _, mediaGroup := range e.MediaGroups {
-		items = append(items, mediaGroup.MediaThumbnails...)
+// AllMediaThumbnails returns an iterator for all thumbnail elements merged together.
+func (e *MediaItemElement) AllMediaThumbnails() iter.Seq[Thumbnail] {
+	return func(yield func(Thumbnail) bool) {
+		for _, value := range e.MediaThumbnails {
+			if !yield(value) {
+				return
+			}
+		}
+
+		for _, mediaGroup := range e.MediaGroups {
+			for _, value := range mediaGroup.MediaThumbnails {
+				if !yield(value) {
+					return
+				}
+			}
+		}
 	}
-	return items
 }
 
-// AllMediaContents returns all content elements merged together.
-func (e *MediaItemElement) AllMediaContents() []Content {
-	items := make([]Content, 0, len(e.MediaContents)+len(e.MediaGroups))
-	items = append(items, e.MediaContents...)
-	for _, mediaGroup := range e.MediaGroups {
-		items = append(items, mediaGroup.MediaContents...)
+// AllMediaContents returns an iterator for all content elements merged together.
+func (e *MediaItemElement) AllMediaContents() iter.Seq[Content] {
+	return func(yield func(Content) bool) {
+		for _, value := range e.MediaContents {
+			if !yield(value) {
+				return
+			}
+		}
+
+		for _, mediaGroup := range e.MediaGroups {
+			for _, value := range mediaGroup.MediaContents {
+				if !yield(value) {
+					return
+				}
+			}
+		}
 	}
-	return items
 }
 
-// AllMediaPeerLinks returns all peer link elements merged together.
-func (e *MediaItemElement) AllMediaPeerLinks() []PeerLink {
-	items := make([]PeerLink, 0, len(e.MediaPeerLinks)+len(e.MediaGroups))
-	items = append(items, e.MediaPeerLinks...)
-	for _, mediaGroup := range e.MediaGroups {
-		items = append(items, mediaGroup.MediaPeerLinks...)
+// AllMediaPeerLinks returns an iterator for all peer link elements merged together.
+func (e *MediaItemElement) AllMediaPeerLinks() iter.Seq[PeerLink] {
+	return func(yield func(PeerLink) bool) {
+		for _, value := range e.MediaPeerLinks {
+			if !yield(value) {
+				return
+			}
+		}
+
+		for _, mediaGroup := range e.MediaGroups {
+			for _, value := range mediaGroup.MediaPeerLinks {
+				if !yield(value) {
+					return
+				}
+			}
+		}
 	}
-	return items
 }
 
 // FirstMediaDescription returns the first description element.

--- a/internal/reader/processor/processor.go
+++ b/internal/reader/processor/processor.go
@@ -62,7 +62,9 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 		DisableHTTP2(feed.DisableHTTP2)
 
 	// Processing older entries first ensures that their creation timestamp is lower than newer entries.
-	for _, entry := range slices.Backward(feed.Entries) {
+	for i := range slices.Backward(feed.Entries) {
+		entry := &feed.Entries[i]
+
 		slog.Debug("Processing entry",
 			slog.Int64("user_id", user.ID),
 			slog.String("entry_url", entry.URL),
@@ -166,7 +168,7 @@ func ProcessFeedEntries(store *storage.Storage, feed *model.Feed, userID int64, 
 
 		updateEntryReadingTime(store, feed, entry, entryIsNew, user)
 
-		filteredEntries = append(filteredEntries, entry)
+		filteredEntries = append(filteredEntries, *entry)
 	}
 
 	if user.ShowReadingTime && shouldFetchYouTubeWatchTimeInBulk() {

--- a/internal/reader/processor/youtube.go
+++ b/internal/reader/processor/youtube.go
@@ -42,11 +42,13 @@ func fetchYouTubeWatchTimeForSingleEntry(websiteURL string) (int, error) {
 	return fetchWatchTime(websiteURL, `meta[itemprop="duration"]`, true)
 }
 
-func fetchYouTubeWatchTimeInBulk(entries []*model.Entry) {
+func fetchYouTubeWatchTimeInBulk(entries model.Entries) {
 	videosEntriesMapping := make(map[string]*model.Entry, len(entries))
 	videoIDs := make([]string, 0, len(entries))
 
-	for _, entry := range entries {
+	for i := range entries {
+		entry := &entries[i]
+
 		if !isYouTubeVideoURL(entry.URL) {
 			continue
 		}

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -313,14 +313,11 @@ func findEntryTags(rssItem *rssItem) []string {
 }
 
 func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
-	mediaThumbnails := rssItem.AllMediaThumbnails()
-	mediaContents := rssItem.AllMediaContents()
-	mediaPeerLinks := rssItem.AllMediaPeerLinks()
-	capacity := len(mediaThumbnails) + len(rssItem.Enclosures) + len(mediaContents) + len(mediaPeerLinks)
-	enclosures := make(model.EnclosureList, 0, capacity)
-	duplicates := make(map[string]bool, capacity)
+	duplicates := make(map[string]bool)
 
-	for _, mediaThumbnail := range mediaThumbnails {
+	var enclosures model.EnclosureList
+
+	for mediaThumbnail := range rssItem.AllMediaThumbnails() {
 		mediaURL := strings.TrimSpace(mediaThumbnail.URL)
 		if mediaURL == "" {
 			continue
@@ -381,7 +378,7 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 		})
 	}
 
-	for _, mediaContent := range mediaContents {
+	for mediaContent := range rssItem.AllMediaContents() {
 		mediaURL := strings.TrimSpace(mediaContent.URL)
 		if mediaURL == "" {
 			continue
@@ -410,7 +407,7 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 		})
 	}
 
-	for _, mediaPeerLink := range mediaPeerLinks {
+	for mediaPeerLink := range rssItem.AllMediaPeerLinks() {
 		mediaURL := strings.TrimSpace(mediaPeerLink.URL)
 		if mediaURL == "" {
 			continue

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -339,7 +339,7 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 
 		duplicates[mediaURL] = true
 
-		enclosures = append(enclosures, &model.Enclosure{
+		enclosures = append(enclosures, model.Enclosure{
 			URL:      mediaURL,
 			MimeType: mediaThumbnail.MimeType(),
 			Size:     mediaThumbnail.Size(),
@@ -371,7 +371,7 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 
 		duplicates[enclosureURL] = true
 
-		enclosures = append(enclosures, &model.Enclosure{
+		enclosures = append(enclosures, model.Enclosure{
 			URL:      enclosureURL,
 			MimeType: enclosure.Type,
 			Size:     enclosure.Size(),
@@ -400,7 +400,7 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 
 		duplicates[mediaURL] = true
 
-		enclosures = append(enclosures, &model.Enclosure{
+		enclosures = append(enclosures, model.Enclosure{
 			URL:      mediaURL,
 			MimeType: mediaContent.MimeType(),
 			Size:     mediaContent.Size(),
@@ -429,7 +429,7 @@ func findEntryEnclosures(rssItem *rssItem, siteURL string) model.EnclosureList {
 
 		duplicates[mediaURL] = true
 
-		enclosures = append(enclosures, &model.Enclosure{
+		enclosures = append(enclosures, model.Enclosure{
 			URL:      mediaURL,
 			MimeType: mediaPeerLink.MimeType(),
 			Size:     mediaPeerLink.Size(),

--- a/internal/reader/rss/adapter.go
+++ b/internal/reader/rss/adapter.go
@@ -82,6 +82,7 @@ func (r *rssAdapter) buildFeed(baseURL string) *model.Feed {
 	// non-conformant feeds that reuse the same <guid> for every entry.
 	seenGUIDs := make(map[string]int)
 
+	feed.Entries = make(model.Entries, 0, len(r.rss.Channel.Items))
 	for _, item := range r.rss.Channel.Items {
 		entry := model.NewEntry()
 		entry.Date = findEntryDate(&item)

--- a/internal/reader/rss/adapter_test.go
+++ b/internal/reader/rss/adapter_test.go
@@ -1,0 +1,59 @@
+package rss
+
+import (
+	"strings"
+	"testing"
+
+	"miniflux.app/v2/internal/model"
+)
+
+func BenchmarkParseRidiculousEntry(b *testing.B) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+		<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+		<channel>
+		<title>My Example Feed</title>
+		<link>https://example.org</link>
+		<item>
+			<title>Example Item</title>
+			<link>http://www.example.org/entries/1</link>
+			<enclosure type="application/x-bittorrent" url="https://example.org/file3.torrent" length="670053113">
+			</enclosure>
+			<media:group>
+				<media:content type="application/x-bittorrent" url="https://example.org/file1.torrent"></media:content>
+				<media:content type="application/x-bittorrent" url="https://example.org/file2.torrent" isDefault="true"></media:content>
+				<media:content type="application/x-bittorrent" url="https://example.org/file3.torrent"></media:content>
+				<media:content type="application/x-bittorrent" url="https://example.org/file4.torrent"></media:content>
+				<media:content type="application/x-bittorrent" url="https://example.org/file4.torrent"></media:content>
+				<media:content type="application/x-bittorrent" url=" file5.torrent  " fileSize="42"></media:content>
+				<media:content type="application/x-bittorrent" url="  " fileSize="42"></media:content>
+				<media:rating>nonadult</media:rating>
+			</media:group>
+			<media:thumbnail url="https://example.org/image.jpg" height="122" width="223"></media:thumbnail>
+			<media:thumbnail url="https://example.org/thumbnail.jpg" />
+			<media:thumbnail url="https://example.org/thumbnail.jpg" />
+			<media:thumbnail url=" thumbnail.jpg  " />
+			<media:thumbnail url="   " />
+			<media:content url="https://example.org/media1.jpg" medium="image">
+				<media:title type="html">Some Title for Media 1</media:title>
+			</media:content>
+			<media:content url="   /media2.jpg   " medium="image" />
+			<media:content url="    " medium="image" />
+			<media:peerLink type="application/x-bittorrent" href="https://www.example.org/file.torrent" />
+			<media:peerLink type="application/x-bittorrent" href="https://www.example.org/file.torrent" />
+			<media:peerLink type="application/x-bittorrent" href="  file2.torrent   " />
+			<media:peerLink type="application/x-bittorrent" href="    " />
+		</item>
+		</channel>
+		</rss>`
+
+	var feed *model.Feed
+	for b.Loop() {
+		var err error
+		feed, err = Parse("https://example.org/", strings.NewReader(data))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	_ = feed
+}

--- a/internal/reader/rss/adapter_test.go
+++ b/internal/reader/rss/adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package rss
 
 import (

--- a/internal/storage/enclosure.go
+++ b/internal/storage/enclosure.go
@@ -50,12 +50,11 @@ func (s *Storage) EnclosuresByEntryID(entryID int64) (model.EnclosureList, error
 			&enclosure.MimeType,
 			&enclosure.MediaProgression,
 		)
-
 		if err != nil {
 			return nil, fmt.Errorf(`store: unable to fetch enclosure row: %v`, err)
 		}
 
-		enclosures = append(enclosures, &enclosure)
+		enclosures = append(enclosures, enclosure)
 	}
 
 	return enclosures, nil
@@ -101,7 +100,7 @@ func (s *Storage) EnclosuresByEntryIDs(entryIDs []int64) (map[int64]model.Enclos
 			return nil, fmt.Errorf("store: unable to scan enclosure row: %w", err)
 		}
 
-		enclosuresMap[enclosure.EntryID] = append(enclosuresMap[enclosure.EntryID], &enclosure)
+		enclosuresMap[enclosure.EntryID] = append(enclosuresMap[enclosure.EntryID], enclosure)
 	}
 
 	return enclosuresMap, nil
@@ -194,12 +193,13 @@ func (s *Storage) updateEnclosures(tx *sql.Tx, entry *model.Entry) error {
 	}
 
 	sqlValues := make([]string, 0, len(entry.Enclosures))
-	for _, enclosure := range entry.Enclosures {
-		sqlValues = append(sqlValues, strings.TrimSpace(enclosure.URL))
-
+	for i := range entry.Enclosures {
+		enclosure := &entry.Enclosures[i]
 		if err := s.createEnclosure(tx, enclosure); err != nil {
 			return err
 		}
+
+		sqlValues = append(sqlValues, enclosure.URL)
 	}
 
 	query := `
@@ -241,7 +241,6 @@ func (s *Storage) UpdateEnclosure(enclosure *model.Enclosure) error {
 		enclosure.MediaProgression,
 		enclosure.ID,
 	)
-
 	if err != nil {
 		return fmt.Errorf(`store: unable to update enclosure #%d : %v`, enclosure.ID, err)
 	}

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -322,7 +322,9 @@ func (s *Storage) GetReadTime(feedID int64, entryHash string) int {
 
 // RefreshFeedEntries updates feed entries while refreshing a feed.
 func (s *Storage) RefreshFeedEntries(userID, feedID int64, entries model.Entries, updateExistingEntries bool) (newEntries model.Entries, err error) {
-	for _, entry := range entries {
+	for i := range entries {
+		entry := &entries[i]
+
 		entry.UserID = userID
 		entry.FeedID = feedID
 
@@ -349,7 +351,7 @@ func (s *Storage) RefreshFeedEntries(userID, feedID int64, entries model.Entries
 			case errors.Is(err, ErrEntryTombstoned):
 				err = nil
 			case err == nil:
-				newEntries = append(newEntries, entry)
+				newEntries = append(newEntries, *entry)
 			}
 		}
 

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -151,11 +151,13 @@ func (s *Storage) createEntry(tx *sql.Tx, entry *model.Entry) error {
 		return fmt.Errorf(`store: unable to create entry %q (feed #%d): %v`, entry.URL, entry.FeedID, err)
 	}
 
-	for _, enclosure := range entry.Enclosures {
+	for i := range entry.Enclosures {
+		enclosure := &entry.Enclosures[i]
+
 		enclosure.EntryID = entry.ID
 		enclosure.UserID = entry.UserID
-		err := s.createEnclosure(tx, enclosure)
-		if err != nil {
+
+		if err := s.createEnclosure(tx, enclosure); err != nil {
 			return err
 		}
 	}
@@ -206,7 +208,9 @@ func (s *Storage) updateEntry(tx *sql.Tx, entry *model.Entry) error {
 		return fmt.Errorf(`store: unable to update entry %q: %v`, entry.URL, err)
 	}
 
-	for _, enclosure := range entry.Enclosures {
+	for i := range entry.Enclosures {
+		enclosure := &entry.Enclosures[i]
+
 		enclosure.UserID = entry.UserID
 		enclosure.EntryID = entry.ID
 	}

--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -6,6 +6,8 @@ package storage // import "miniflux.app/v2/internal/storage"
 import (
 	"database/sql"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -258,12 +260,14 @@ func (e *EntryQueryBuilder) GetEntry() (*model.Entry, error) {
 		return nil, nil
 	}
 
-	entries[0].Enclosures, err = e.store.EnclosuresByEntryID(entries[0].ID)
+	entry := entries[0]
+
+	entry.Enclosures, err = e.store.EnclosuresByEntryID(entry.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	return entries[0], nil
+	return &entry, nil
 }
 
 // GetEntries returns a list of entries that match the condition.
@@ -351,8 +355,7 @@ func (e *EntryQueryBuilder) fetchEntries(withCount bool) (model.Entries, int, er
 
 	size := max(e.limit, 0)
 	entries := make(model.Entries, 0, size)
-	entryMap := make(map[int64]*model.Entry, size)
-	entryIDs := make([]int64, 0, size)
+	entryMap := make(map[int64]int, size)
 	var totalCount int
 
 	for rows.Next() {
@@ -432,19 +435,20 @@ func (e *EntryQueryBuilder) fetchEntries(withCount bool) (model.Entries, int, er
 		entry.Feed.Category.UserID = entry.UserID
 
 		entries = append(entries, entry)
-		entryMap[entry.ID] = entry
-		entryIDs = append(entryIDs, entry.ID)
+		entryMap[entry.ID] = len(entries) - 1
 	}
 
-	if e.fetchEnclosures && len(entryIDs) > 0 {
+	if e.fetchEnclosures && len(entries) > 0 {
+		entryIDs := slices.Collect(maps.Keys(entryMap))
+
 		enclosures, err := e.store.EnclosuresByEntryIDs(entryIDs)
 		if err != nil {
 			return nil, 0, fmt.Errorf("store: unable to fetch enclosures: %w", err)
 		}
 
 		for entryID, entryEnclosures := range enclosures {
-			if entry, exists := entryMap[entryID]; exists {
-				entry.Enclosures = entryEnclosures
+			if idx, exists := entryMap[entryID]; exists {
+				entries[idx].Enclosures = entryEnclosures
 			}
 		}
 	}

--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -293,7 +293,9 @@ func (s *Storage) CreateFeed(feed *model.Feed) error {
 		return fmt.Errorf(`store: unable to create feed %q: %v`, feed.FeedURL, err)
 	}
 
-	for _, entry := range feed.Entries {
+	for i := range feed.Entries {
+		entry := &feed.Entries[i]
+
 		entry.FeedID = feed.ID
 		entry.UserID = feed.UserID
 


### PR DESCRIPTION
This is sort of continues work done in #4274.

I've added `BenchmarkParseRidiculousEntry` which is just a bunch of entries from other tests sewn together.

Removing intermediate allocations reduced allocated _memory_ by ~5.5% (vs `master`):
```
name                    old time/op    new time/op    delta
ParseRidiculousEntry-8    90.0µs ± 2%    90.0µs ± 4%    ~     (p=0.905 n=10+9)

name                    old alloc/op   new alloc/op   delta
ParseRidiculousEntry-8    30.8kB ± 0%    29.0kB ± 0%  -5.65%  (p=0.000 n=9+8)

name                    old allocs/op  new allocs/op  delta
ParseRidiculousEntry-8       550 ± 0%       547 ± 0%  -0.55%  (p=0.000 n=10+10)
```

This is the same as cbd1771ab2759185e5b7f8d176fe7565b3c69ee5. Instead of optimizing intermediate allocations I just removed those altogether using `iter.Seq`.

Using value slices instead of pointer slices further reduces intermediate allocation count (vs prev changes):
```
name                    old time/op    new time/op    delta
ParseRidiculousEntry-8    90.0µs ± 4%    90.2µs ± 2%    ~     (p=0.497 n=9+10)

name                    old alloc/op   new alloc/op   delta
ParseRidiculousEntry-8    29.0kB ± 0%    28.9kB ± 0%  -0.35%  (p=0.000 n=8+9)

name                    old allocs/op  new allocs/op  delta
ParseRidiculousEntry-8       547 ± 0%       536 ± 0%  -2.01%  (p=0.000 n=10+10)
```

This one is kinda intrusive change, hence draft status.

---

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [ ] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
