### PR TITLE
fix(api): proxify enclosure URLs in entry list endpoints

### DIFF
--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -189,6 +189,7 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 
 	for i := range entries {
 		entries[i].Content = mediaproxy.RewriteDocumentWithAbsoluteProxyURL(entries[i].Content)
+		entries[i].Enclosures.ProxifyEnclosureURL(config.Opts.MediaProxyMode(), config.Opts.MediaProxyResourceTypes())
 	}
 
 	response.JSON(w, r, &entriesResponse{Total: count, Entries: entries})


### PR DESCRIPTION
The single-entry endpoint proxified enclosure URLs while the list endpoints did not, so the same enclosure was returned with different URLs depending on the endpoint used.
