### PR TITLE
fix(api): distinguish missing user from database error

### DIFF
--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -113,7 +113,13 @@ func (h *handler) markUserAsReadHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if _, err := h.store.UserByID(userID); err != nil {
+	user, err := h.store.UserByID(userID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+
+	if user == nil {
 		response.JSONNotFound(w, r)
 		return
 	}
@@ -128,7 +134,13 @@ func (h *handler) markUserAsReadHandler(w http.ResponseWriter, r *http.Request) 
 
 func (h *handler) getIntegrationsStatusHandler(w http.ResponseWriter, r *http.Request) {
 	userID := request.UserID(r)
-	if _, err := h.store.UserByID(userID); err != nil {
+	user, err := h.store.UserByID(userID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+
+	if user == nil {
 		response.JSONNotFound(w, r)
 		return
 	}


### PR DESCRIPTION
The mark-user-as-read and integrations-status handlers treated any error from `UserByID` as a 404, which:

- masked genuine database failures, and
- never detected a missing user, since `UserByID` returns no error when the user does not exist.

Return a server error on failure and a not found response only when the user is `nil`.
