### PR TITLE
fix(api): check for nil user before using the result

### DIFF
--- a/internal/api/category_handlers.go
+++ b/internal/api/category_handlers.go
@@ -120,6 +120,12 @@ func (h *handler) getCategoriesHandler(w http.ResponseWriter, r *http.Request) {
 			response.JSONServerError(w, r, userErr)
 			return
 		}
+
+		if user == nil {
+			response.JSONNotFound(w, r)
+			return
+		}
+
 		categories, err = h.store.CategoriesWithFeedCount(user.ID, user.CategoriesSortingOrder)
 	} else {
 		categories, err = h.store.Categories(request.UserID(r))

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -22,6 +22,11 @@ func (h *handler) currentUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if user == nil {
+		response.JSONNotFound(w, r)
+		return
+	}
+
 	response.JSON(w, r, user)
 }
 


### PR DESCRIPTION
The current-user and categories handlers used the value returned by `UserByID` without checking whether it was nil.

Since `UserByID` returns no error when the user does not exist, the categories handler could dereference a nil user.

Return a not found response when the user is nil.
