### PR TITLE
fix(api): return server error when feed lookup fails on update

### DIFF
--- a/internal/api/feed_handlers.go
+++ b/internal/api/feed_handlers.go
@@ -115,7 +115,7 @@ func (h *handler) updateFeedHandler(w http.ResponseWriter, r *http.Request) {
 	userID := request.UserID(r)
 	originalFeed, err := h.store.FeedByID(userID, feedID)
 	if err != nil {
-		response.JSONNotFound(w, r)
+		response.JSONServerError(w, r, err)
 		return
 	}
 


### PR DESCRIPTION
The update-feed handler returned a not found response for any error from `FeedByID`, masking genuine database failures.

Return a server error on failure and keep the not found response for a nil feed.
