### PR TITLE
fix(api): return server error on user lookup failure

### DIFF
--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -198,7 +198,7 @@ func (h *handler) userByIDHandler(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.store.UserByID(userID)
 	if err != nil {
-		response.JSONBadRequest(w, r, errors.New("unable to fetch this user from the database"))
+		response.JSONServerError(w, r, err)
 		return
 	}
 
@@ -220,7 +220,7 @@ func (h *handler) userByUsernameHandler(w http.ResponseWriter, r *http.Request) 
 	username := request.RouteStringParam(r, "username")
 	user, err := h.store.UserByUsername(username)
 	if err != nil {
-		response.JSONBadRequest(w, r, errors.New("unable to fetch this user from the database"))
+		response.JSONServerError(w, r, err)
 		return
 	}
 


### PR DESCRIPTION
The admin user lookup handlers reported a database error from `UserByID` and `UserByUsername` as a bad request with a generic message.

Return a server error instead, consistent with the other user handlers.
