### PR TITLE
fix(api): remove duplicate category filter in entry list

### DIFF
--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -604,10 +604,6 @@ func configureFilters(builder *storage.EntryQueryBuilder, r *http.Request) *stor
 		builder = builder.AfterChangedDate(time.Unix(afterChangedTimestamp, 0))
 	}
 
-	if categoryID := request.QueryInt64Param(r, "category_id", 0); categoryID > 0 {
-		builder = builder.WithCategoryID(categoryID)
-	}
-
 	if request.HasQueryParam(r, "starred") {
 		starred, err := strconv.ParseBool(r.URL.Query().Get("starred"))
 		if err == nil {


### PR DESCRIPTION
The entry list path applied the `category_id` query parameter twice: once with validation in `findEntries` and again without validation in `configureFilters`.

Drop the unvalidated second application so an invalid `category_id` consistently returns a bad request.
