### PR TITLE
fix(ui): validate per-feed entry filter rules in web forms

### DIFF
--- a/internal/ui/feed_update.go
+++ b/internal/ui/feed_update.go
@@ -54,15 +54,17 @@ func (h *handler) updateFeed(w http.ResponseWriter, r *http.Request) {
 	view.Set("defaultUserAgent", config.Opts.HTTPClientUserAgent())
 
 	feedModificationRequest := &model.FeedModificationRequest{
-		FeedURL:         model.OptionalString(feedForm.FeedURL),
-		SiteURL:         model.OptionalString(feedForm.SiteURL),
-		Title:           model.OptionalString(feedForm.Title),
-		Description:     model.OptionalString(feedForm.Description),
-		CategoryID:      model.OptionalNumber(feedForm.CategoryID),
-		BlocklistRules:  model.OptionalString(feedForm.BlocklistRules),
-		KeeplistRules:   model.OptionalString(feedForm.KeeplistRules),
-		UrlRewriteRules: model.OptionalString(feedForm.UrlRewriteRules),
-		ProxyURL:        model.OptionalString(feedForm.ProxyURL),
+		FeedURL:               model.OptionalString(feedForm.FeedURL),
+		SiteURL:               model.OptionalString(feedForm.SiteURL),
+		Title:                 model.OptionalString(feedForm.Title),
+		Description:           model.OptionalString(feedForm.Description),
+		CategoryID:            model.OptionalNumber(feedForm.CategoryID),
+		BlocklistRules:        model.OptionalString(feedForm.BlocklistRules),
+		KeeplistRules:         model.OptionalString(feedForm.KeeplistRules),
+		UrlRewriteRules:       model.OptionalString(feedForm.UrlRewriteRules),
+		ProxyURL:              model.OptionalString(feedForm.ProxyURL),
+		BlockFilterEntryRules: model.OptionalString(feedForm.BlockFilterEntryRules),
+		KeepFilterEntryRules:  model.OptionalString(feedForm.KeepFilterEntryRules),
 	}
 
 	if validationErr := validator.ValidateFeedModification(h.store, loggedUser.ID, feed.ID, feedModificationRequest); validationErr != nil {

--- a/internal/ui/form/subscription.go
+++ b/internal/ui/form/subscription.go
@@ -61,6 +61,18 @@ func (s *SubscriptionForm) Validate() *locale.LocalizedError {
 		return locale.NewLocalizedError("error.invalid_feed_proxy_url")
 	}
 
+	if s.BlockFilterEntryRules != "" {
+		if err := validator.IsValidFilterRules(s.BlockFilterEntryRules, "block"); err != nil {
+			return err
+		}
+	}
+
+	if s.KeepFilterEntryRules != "" {
+		if err := validator.IsValidFilterRules(s.KeepFilterEntryRules, "keep"); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/ui/form/subscription_test.go
+++ b/internal/ui/form/subscription_test.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package form // import "miniflux.app/v2/internal/ui/form"
+
+import "testing"
+
+func TestSubscriptionFormValidateInvalidBlockFilterRules(t *testing.T) {
+	s := &SubscriptionForm{URL: "https://example.com/feed", CategoryID: 1, BlockFilterEntryRules: "BadField=foo"}
+	if err := s.Validate(); err == nil {
+		t.Error("Validate should return an error for an invalid block filter rule")
+	}
+}
+
+func TestSubscriptionFormValidateInvalidKeepFilterRules(t *testing.T) {
+	s := &SubscriptionForm{URL: "https://example.com/feed", CategoryID: 1, KeepFilterEntryRules: "BadField=foo"}
+	if err := s.Validate(); err == nil {
+		t.Error("Validate should return an error for an invalid keep filter rule")
+	}
+}
+
+func TestSubscriptionFormValidateValidFilterRules(t *testing.T) {
+	s := &SubscriptionForm{URL: "https://example.com/feed", CategoryID: 1, BlockFilterEntryRules: "EntryTitle=add"}
+	if err := s.Validate(); err != nil {
+		t.Errorf("Validate should not return an error for a valid filter rule, got: %v", err)
+	}
+}

--- a/internal/validator/feed.go
+++ b/internal/validator/feed.go
@@ -37,13 +37,13 @@ func ValidateFeedCreation(store *storage.Storage, userID int64, request *model.F
 	}
 
 	if request.BlockFilterEntryRules != "" {
-		if err := isValidFilterRules(request.BlockFilterEntryRules, "block"); err != nil {
+		if err := IsValidFilterRules(request.BlockFilterEntryRules, "block"); err != nil {
 			return err
 		}
 	}
 
 	if request.KeepFilterEntryRules != "" {
-		if err := isValidFilterRules(request.KeepFilterEntryRules, "keep"); err != nil {
+		if err := IsValidFilterRules(request.KeepFilterEntryRules, "keep"); err != nil {
 			return err
 		}
 	}
@@ -106,13 +106,13 @@ func ValidateFeedModification(store *storage.Storage, userID, feedID int64, requ
 	}
 
 	if request.BlockFilterEntryRules != nil && *request.BlockFilterEntryRules != "" {
-		if err := isValidFilterRules(*request.BlockFilterEntryRules, "block"); err != nil {
+		if err := IsValidFilterRules(*request.BlockFilterEntryRules, "block"); err != nil {
 			return err
 		}
 	}
 
 	if request.KeepFilterEntryRules != nil && *request.KeepFilterEntryRules != "" {
-		if err := isValidFilterRules(*request.KeepFilterEntryRules, "keep"); err != nil {
+		if err := IsValidFilterRules(*request.KeepFilterEntryRules, "keep"); err != nil {
 			return err
 		}
 	}

--- a/internal/validator/filter.go
+++ b/internal/validator/filter.go
@@ -10,7 +10,7 @@ import (
 	"miniflux.app/v2/internal/locale"
 )
 
-func isValidFilterRules(filterEntryRules string, filterType string) *locale.LocalizedError {
+func IsValidFilterRules(filterEntryRules string, filterType string) *locale.LocalizedError {
 	// Valid Format: FieldName=RegEx\nFieldName=RegEx...
 	fieldNames := []string{"EntryTitle", "EntryURL", "EntryCommentsURL", "EntryContent", "EntryAuthor", "EntryTag", "EntryDate"}
 

--- a/internal/validator/filter_test.go
+++ b/internal/validator/filter_test.go
@@ -46,7 +46,7 @@ func TestIsValidFilterRules(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			err := isValidFilterRules(tc.rules, "block")
+			err := IsValidFilterRules(tc.rules, "block")
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("expected error=%v, got %v", tc.wantErr, err)
 			}

--- a/internal/validator/user.go
+++ b/internal/validator/user.go
@@ -130,7 +130,7 @@ func ValidateUserModification(store *storage.Storage, userID int64, changes *mod
 
 	if changes.BlockFilterEntryRules != nil {
 		if *changes.BlockFilterEntryRules != "" {
-			if err := isValidFilterRules(*changes.BlockFilterEntryRules, "block"); err != nil {
+			if err := IsValidFilterRules(*changes.BlockFilterEntryRules, "block"); err != nil {
 				return err
 			}
 		}
@@ -138,7 +138,7 @@ func ValidateUserModification(store *storage.Storage, userID int64, changes *mod
 
 	if changes.KeepFilterEntryRules != nil {
 		if *changes.KeepFilterEntryRules != "" {
-			if err := isValidFilterRules(*changes.KeepFilterEntryRules, "keep"); err != nil {
+			if err := IsValidFilterRules(*changes.KeepFilterEntryRules, "keep"); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
**Description:**

The web UI does not validate `BlockFilterEntryRules` and `KeepFilterEntryRules` when a feed is edited or when a new subscription is added. Invalid rules (e.g. unrecognised field names or malformed regular expressions) are silently stored in the database and ignored at fetch time, with no feedback given to the user.

The same fields are validated correctly when submitted through the API (`internal/api/feed_handlers.go` calls `validator.ValidateFeedCreation()`), so this is a web-UI-only gap.

There are two affected paths:
1. **Feed edit** (`/feeds/{id}/edit`) - `internal/ui/feed_update.go` builds a `FeedModificationRequest` but omits `BlockFilterEntryRules` and `KeepFilterEntryRules`, so `ValidateFeedModification()` never checks them. The raw form values are merged directly into the feed struct and saved.
2. **Add subscription** (`/subscribe`) - `SubscriptionForm.Validate()` in `internal/ui/form/subscription.go` validates the older regex fields (`BlocklistRules`, `KeeplistRules`, `UrlRewriteRules`) but not the newer filter-rule fields.

**Testing:**
- I added `internal/ui/form/subscription_test.go` with three cases: invalid block rule, invalid keep rule, and a valid rule.
- All existing tests pass.
- And I verified the fix manually: entering `BadField=foo` in both forms now returns a validation error; entering valid rule is accepted and stored correctly.

No breaking changes.