### PR TITLE
perf(internal): reorder some struct members

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -37,17 +37,17 @@ const (
 
 type configValue struct {
 	parsedStringValue string
-	parsedBoolValue   bool
 	parsedIntValue    int
 	parsedInt64Value  int64
 	parsedDuration    time.Duration
 	parsedStringList  []string
 	parsedURLValue    *url.URL
 	parsedBytesValue  []byte
+	parsedBoolValue   bool
 
+	secret    bool
 	rawValue  string
 	valueType configValueType
-	secret    bool
 	targetKey string
 
 	validator func(string) error

--- a/internal/integration/telegrambot/client.go
+++ b/internal/integration/telegrambot/client.go
@@ -123,11 +123,11 @@ type InlineKeyboardButton struct {
 
 type User struct {
 	ID                      int64  `json:"id"`
-	IsBot                   bool   `json:"is_bot"`
 	FirstName               string `json:"first_name"`
 	LastName                string `json:"last_name"`
 	Username                string `json:"username"`
 	LanguageCode            string `json:"language_code"`
+	IsBot                   bool   `json:"is_bot"`
 	IsPremium               bool   `json:"is_premium"`
 	CanJoinGroups           bool   `json:"can_join_groups"`
 	CanReadAllGroupMessages bool   `json:"can_read_all_group_messages"`

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -14,7 +14,6 @@ type User struct {
 	ID                              int64      `json:"id"`
 	Username                        string     `json:"username"`
 	Password                        string     `json:"-"`
-	IsAdmin                         bool       `json:"is_admin"`
 	Theme                           string     `json:"theme"`
 	Language                        string     `json:"language"`
 	Timezone                        string     `json:"timezone"`
@@ -26,9 +25,6 @@ type User struct {
 	GoogleID                        string     `json:"google_id"`
 	OpenIDConnectID                 string     `json:"openid_connect_id"`
 	EntriesPerPage                  int        `json:"entries_per_page"`
-	KeyboardShortcuts               bool       `json:"keyboard_shortcuts"`
-	ShowReadingTime                 bool       `json:"show_reading_time"`
-	EntrySwipe                      bool       `json:"entry_swipe"`
 	GestureNav                      string     `json:"gesture_nav"`
 	LastLoginAt                     *time.Time `json:"last_login_at"`
 	DisplayMode                     string     `json:"display_mode"`
@@ -36,13 +32,17 @@ type User struct {
 	CJKReadingSpeed                 int        `json:"cjk_reading_speed"`
 	DefaultHomePage                 string     `json:"default_home_page"`
 	CategoriesSortingOrder          string     `json:"categories_sorting_order"`
-	MarkReadOnView                  bool       `json:"mark_read_on_view"`
-	MarkReadOnMediaPlayerCompletion bool       `json:"mark_read_on_media_player_completion"`
 	MediaPlaybackRate               float64    `json:"media_playback_rate"`
 	BlockFilterEntryRules           string     `json:"block_filter_entry_rules"`
 	KeepFilterEntryRules            string     `json:"keep_filter_entry_rules"`
+	MarkReadOnView                  bool       `json:"mark_read_on_view"`
+	MarkReadOnMediaPlayerCompletion bool       `json:"mark_read_on_media_player_completion"`
 	AlwaysOpenExternalLinks         bool       `json:"always_open_external_links"`
 	OpenExternalLinksInNewTab       bool       `json:"open_external_links_in_new_tab"`
+	KeyboardShortcuts               bool       `json:"keyboard_shortcuts"`
+	ShowReadingTime                 bool       `json:"show_reading_time"`
+	EntrySwipe                      bool       `json:"entry_swipe"`
+	IsAdmin                         bool       `json:"is_admin"`
 }
 
 // UserCreationRequest represents the request to create a user.

--- a/internal/ui/form/feed.go
+++ b/internal/ui/form/feed.go
@@ -23,13 +23,13 @@ type FeedForm struct {
 	KeeplistRules               string
 	BlockFilterEntryRules       string
 	KeepFilterEntryRules        string
-	Crawler                     bool
-	IgnoreEntryUpdates          bool
 	UserAgent                   string
 	Cookie                      string
 	CategoryID                  int64
 	Username                    string
 	Password                    string
+	AppriseServiceURLs          string
+	WebhookURL                  string
 	IgnoreHTTPCache             bool
 	AllowSelfSignedCertificates bool
 	FetchViaProxy               bool
@@ -37,15 +37,18 @@ type FeedForm struct {
 	NoMediaPlayer               bool
 	HideGlobally                bool
 	CategoryHidden              bool // Category has "hide_globally"
-	AppriseServiceURLs          string
-	WebhookURL                  string
-	DisableHTTP2                bool
-	NtfyEnabled                 bool
-	NtfyPriority                int
-	NtfyTopic                   string
-	PushoverEnabled             bool
-	PushoverPriority            int
-	ProxyURL                    string
+
+	NtfyEnabled  bool
+	NtfyPriority int
+	NtfyTopic    string
+
+	Crawler            bool
+	IgnoreEntryUpdates bool
+
+	DisableHTTP2     bool
+	PushoverEnabled  bool
+	PushoverPriority int
+	ProxyURL         string
 }
 
 // Merge updates the fields of the given feed.

--- a/internal/ui/form/settings.go
+++ b/internal/ui/form/settings.go
@@ -34,19 +34,15 @@ type SettingsForm struct {
 	EntryDirection         string
 	EntryOrder             string
 	EntriesPerPage         int
-	KeyboardShortcuts      bool
-	ShowReadingTime        bool
 	CustomCSS              string
 	CustomJS               string
 	ExternalFontHosts      string
-	EntrySwipe             bool
 	GestureNav             string
 	DisplayMode            string
 	DefaultReadingSpeed    int
 	CJKReadingSpeed        int
 	DefaultHomePage        string
 	CategoriesSortingOrder string
-	MarkReadOnView         bool
 	// MarkReadBehavior is a string representation of the MarkReadOnView and MarkReadOnMediaPlayerCompletion fields together
 	MarkReadBehavior          markReadBehavior
 	MediaPlaybackRate         float64
@@ -54,6 +50,10 @@ type SettingsForm struct {
 	KeepFilterEntryRules      string
 	AlwaysOpenExternalLinks   bool
 	OpenExternalLinksInNewTab bool
+	KeyboardShortcuts         bool
+	EntrySwipe                bool
+	MarkReadOnView            bool
+	ShowReadingTime           bool
 }
 
 // MarkAsReadBehavior returns the MarkReadBehavior from the given MarkReadOnView and MarkReadOnMediaPlayerCompletion values.

--- a/internal/ui/form/subscription.go
+++ b/internal/ui/form/subscription.go
@@ -14,12 +14,8 @@ import (
 
 // SubscriptionForm represents the subscription form.
 type SubscriptionForm struct {
-	URL                         string
 	CategoryID                  int64
-	Crawler                     bool
-	IgnoreEntryUpdates          bool
-	FetchViaProxy               bool
-	AllowSelfSignedCertificates bool
+	URL                         string
 	UserAgent                   string
 	Cookie                      string
 	Username                    string
@@ -31,8 +27,12 @@ type SubscriptionForm struct {
 	KeeplistRules               string
 	BlockFilterEntryRules       string
 	KeepFilterEntryRules        string
-	DisableHTTP2                bool
 	ProxyURL                    string
+	DisableHTTP2                bool
+	Crawler                     bool
+	IgnoreEntryUpdates          bool
+	FetchViaProxy               bool
+	AllowSelfSignedCertificates bool
 }
 
 // Validate makes sure the form values locale.are valid.

--- a/internal/ui/pagination.go
+++ b/internal/ui/pagination.go
@@ -5,19 +5,19 @@ package ui // import "miniflux.app/v2/internal/ui"
 
 type pagination struct {
 	Route        string
+	SearchQuery  string
 	Total        int
 	Offset       int
 	ItemsPerPage int
-	ShowNext     bool
-	ShowLast     bool
-	ShowFirst    bool
-	ShowPrev     bool
 	NextOffset   int
 	LastOffset   int
 	PrevOffset   int
 	FirstOffset  int
-	SearchQuery  string
 	UnreadOnly   bool
+	ShowNext     bool
+	ShowLast     bool
+	ShowFirst    bool
+	ShowPrev     bool
 }
 
 func getPagination(route string, total, offset, nbItemsPerPage int) pagination {


### PR DESCRIPTION
This saves a handful of memory space, and was done with aligo (https://github.com/essentialkaos/aligo), mostly `aligo check ./...` and `aligo view ./whatever/package`.

While the changes might not seem that impactful, some are dropping space taken by some structures enough to save some words (assuming 64 bits architectures), which is always nice.

More structures could be golfed, but it would significantly hurt readability, so let's no do it.