### PR TITLE
fix(css): add line-height to headings to prevent overlap when they wrap

### DIFF
--- a/internal/ui/static/css/common.css
+++ b/internal/ui/static/css/common.css
@@ -1106,6 +1106,12 @@ article.category-has-unread {
     margin-bottom: 10px;
 }
 
+.entry-content h1,
+.entry-content h2,
+.entry-content h3 {
+    line-height: 1.2;
+}
+
 .entry-content iframe,
 .entry-content video,
 .entry-content img {


### PR DESCRIPTION
## Description

Fixes #4399.

Headings in the article body overlap when they wrap onto two lines (see the before/after in the issue).

### Cause

`.entry-content` sets `line-height: 1.4em` — a *fixed* length computed at the body font-size. Headings have no explicit `line-height`, so they inherit that fixed value, which is smaller than their own (larger) font-size. A heading that wraps then has its lines overlap.

### Fix

Set an explicit **unitless** `line-height: 1.2` on `h1`–`h3` so the leading scales with each heading's own font-size instead of inheriting a too-small fixed value. One line, matching the fix suggested in the issue.

Verified in the browser: reproduced the `.entry-content` font-size/line-height with wrapping headings — lines overlap before the change and are cleanly spaced after.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
