### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It's simple, fast, lightweight and super easy to install.
 
 Official website: <https://miniflux.app>
 
+Prefer a managed instance? [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/miniflux)
+
 Features
 --------
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Miniflux to our marketplace, so this PR adds a small "Deploy with Zenith" link under the Technical Stuff section (links to https://zenith.hosting/host/miniflux).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting