### PR TITLE
fix(storage): respect category hide_globally when marking all as read

### DIFF
--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -543,7 +543,9 @@ func (s *Storage) MarkAllAsReadBeforeDate(userID int64, before time.Time) error 
 	return nil
 }
 
-// MarkGloballyVisibleFeedsAsRead updates all user entries to the read status.
+// MarkGloballyVisibleFeedsAsRead marks as read the unread entries that are
+// visible in the global unread view, i.e. those belonging to a feed and a
+// category that are both not hidden globally.
 func (s *Storage) MarkGloballyVisibleFeedsAsRead(userID int64) error {
 	query := `
 		UPDATE
@@ -553,13 +555,15 @@ func (s *Storage) MarkGloballyVisibleFeedsAsRead(userID int64) error {
 			changed_at=now()
 		FROM
 			feeds
+			JOIN categories ON (categories.id = feeds.category_id)
 		WHERE
 			entries.feed_id = feeds.id
 			AND entries.user_id=$2
 			AND entries.status=$3
-			AND feeds.hide_globally=$4
+			AND feeds.hide_globally IS FALSE
+			AND categories.hide_globally IS FALSE
 	`
-	result, err := s.db.Exec(query, model.EntryStatusRead, userID, model.EntryStatusUnread, false)
+	result, err := s.db.Exec(query, model.EntryStatusRead, userID, model.EntryStatusUnread)
 	if err != nil {
 		return fmt.Errorf(`store: unable to mark globally visible feeds as read: %v`, err)
 	}


### PR DESCRIPTION
Join the categories table and exclude feeds and categories that are hidden globally. Fixes #4444


Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
