### PR TITLE
fix(rewrite): keep content order when remove_tables unwraps tables

### DIFF
--- a/internal/reader/rewrite/content_rewrite_functions.go
+++ b/internal/reader/rewrite/content_rewrite_functions.go
@@ -508,8 +508,11 @@ func removeTables(entryContent string) string {
 				break
 			}
 
-			loopElement.Parent().AppendHtml(innerHtml)
-			loopElement.Remove()
+			// Replace the element with its own content in place, so the
+			// surrounding content keeps its original document order.
+			// Appending to the parent would move the unwrapped content to
+			// the end of the parent instead.
+			loopElement.ReplaceWithHtml(innerHtml)
 		}
 	}
 

--- a/internal/reader/rewrite/content_rewrite_test.go
+++ b/internal/reader/rewrite/content_rewrite_test.go
@@ -958,6 +958,29 @@ func TestRewriteRemoveTables(t *testing.T) {
 	}
 }
 
+func TestRewriteRemoveTablesKeepsSurroundingContentOrder(t *testing.T) {
+	// Regression test for https://github.com/miniflux/v2/issues/3110
+	// When a table is unwrapped, its content and the content surrounding it
+	// must keep their original document order. Previously the unwrapped
+	// content was appended to the end of the parent, so anything after the
+	// table (and the table content itself) ended up reordered.
+	controlEntry := &model.Entry{
+		URL:     "https://example.org/article",
+		Title:   `A title`,
+		Content: `<h1>Header</h1><p>Intro</p><img src="https://example.org/image.png"/><p>Outro</p>`,
+	}
+	testEntry := &model.Entry{
+		URL:     "https://example.org/article",
+		Title:   `A title`,
+		Content: `<h1>Header</h1><table><tbody><tr><td><p>Intro</p><img src="https://example.org/image.png"/></td></tr></tbody></table><p>Outro</p>`,
+	}
+	ApplyContentRewriteRules(testEntry, `remove_tables`)
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`Not expected output: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}
+
 func TestRemoveClickbait(t *testing.T) {
 	controlEntry := &model.Entry{
 		URL:     "https://example.org/article",


### PR DESCRIPTION
**Description**

The `remove_tables` rewrite rule unwrapped each table element by appending its inner HTML to the **end** of the parent node (`Parent().AppendHtml(...)`) and then removing the element. As a result, any content located after the table — and the table's own content — was moved to the bottom of the entry instead of staying in place, reordering the article.

This replaces the append-then-remove with an in-place `ReplaceWithHtml`, so the unwrapped content keeps its original document order.

**Motivation**

Fixes #3110. The rule is documented as "keeping the content inside," but it was rearranging it: the intro/heading above a table and paragraphs below it were pushed to the end. Verified against the reporter's scenario.

**Testing**

- `go test ./internal/reader/rewrite/...` passes.
- The existing `TestRewriteRemoveTables` is unchanged and still passes.
- Added `TestRewriteRemoveTablesKeepsSurroundingContentOrder`, which surrounds a table with a heading and a trailing paragraph. It fails on `main` (content ends up as `<h1>Header</h1><p>Outro</p><p>Intro</p><img/>`) and passes with this change.

**Breaking Changes**

None. Output is identical for tables whose content isn't surrounded by sibling content; only the reordering bug is corrected.

**Related Issues**

Closes #3110 (the content-reordering defect; the separately-requested optional selector parameter is left as a future enhancement).

**Disclosure**

This change was prepared with AI assistance (Claude); the diagnosis, fix, and tests were reviewed and verified locally.
