### PR TITLE
Speed up fetcher timeout test

### DIFF
--- a/internal/reader/fetcher/request_builder_test.go
+++ b/internal/reader/fetcher/request_builder_test.go
@@ -563,25 +563,25 @@ func TestRequestBuilder_RefusePrivateNetworkOnRedirect(t *testing.T) {
 }
 
 func TestRequestBuilder_TimeoutConfiguration(t *testing.T) {
-	// Create a slow server
+	// Create a slow server that blocks until the client disconnects, so
+	// server.Close() does not have to wait for a fixed sleep to elapse.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
-		w.WriteHeader(http.StatusOK)
+		<-r.Context().Done()
 	}))
 	defer server.Close()
 
 	builder := NewRequestBuilder()
 	start := time.Now()
-	_, err := builder.WithTimeout(1 * time.Second).ExecuteRequest(server.URL)
+	_, err := builder.WithTimeout(100 * time.Millisecond).ExecuteRequest(server.URL)
 	duration := time.Since(start)
 
 	if err == nil {
 		t.Error("Expected timeout error")
 	}
 
-	// Should timeout around 1 second, allow some margin
-	if duration > 1500*time.Millisecond {
-		t.Errorf("Expected timeout around 1s, took %v", duration)
+	// Should timeout around 100ms, allow some margin
+	if duration > 500*time.Millisecond {
+		t.Errorf("Expected timeout around 100ms, took %v", duration)
 	}
 }
 


### PR DESCRIPTION
TestRequestBuilder_TimeoutConfiguration dominated the whole test suite at ~2s. The handler slept a fixed 2s, and httptest.Server.Close() blocks until in-flight handlers finish, so the package always paid the full sleep even though the client timed out at 1s.

Block the handler on <-r.Context().Done() instead: when the client times out and drops the connection, the request context is cancelled and the handler returns immediately, so Close() no longer waits. Shrink the timeout to 100ms as well.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
