### PR TITLE
fix(server): restrict unix socket permissions to 0660

### DIFF
--- a/internal/http/server/server.go
+++ b/internal/http/server/server.go
@@ -245,7 +245,7 @@ func createUnixSocketListener(socketFile string) net.Listener {
 		printErrorAndExit(`Server failed to listen on Unix socket %s: %v`, socketFile, err)
 	}
 
-	if err := os.Chmod(socketFile, 0666); err != nil {
+	if err := os.Chmod(socketFile, 0660); err != nil {
 		printErrorAndExit(`Unable to change socket permission for %s: %v`, socketFile, err)
 	}
 

--- a/internal/http/server/server_test.go
+++ b/internal/http/server/server_test.go
@@ -4,6 +4,8 @@
 package server
 
 import (
+	"os"
+	"runtime"
 	"testing"
 )
 
@@ -185,5 +187,36 @@ func TestAnyTLS(t *testing.T) {
 				t.Errorf("anyTLS() = %v, want %v", got, tc.expected)
 			}
 		})
+	}
+}
+
+func TestCreateUnixSocketListenerPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+
+	tempFile, err := os.CreateTemp("/tmp", "miniflux-*.sock")
+	if err != nil {
+		t.Fatalf("Unable to allocate Unix socket path: %v", err)
+	}
+	socketFile := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		t.Fatalf("Unable to close temporary file: %v", err)
+	}
+	if err := os.Remove(socketFile); err != nil {
+		t.Fatalf("Unable to prepare Unix socket path: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(socketFile) })
+
+	listener := createUnixSocketListener(socketFile)
+	t.Cleanup(func() { listener.Close() })
+
+	fileInfo, err := os.Stat(socketFile)
+	if err != nil {
+		t.Fatalf("Unable to stat Unix socket: %v", err)
+	}
+
+	if got, want := fileInfo.Mode().Perm(), os.FileMode(0660); got != want {
+		t.Errorf("Unix socket permissions = %04o, want %04o", got, want)
 	}
 }


### PR DESCRIPTION
The listening Unix socket was created world-writable (`0666`), allowing any local user to connect. Restrict it to the owner and group.

Deployments where the reverse proxy runs as a different user now need that user to share a group with the Miniflux process.
