### PR TITLE
fix(validator): restrict entry_sorting_order to database enum values

### DIFF
--- a/internal/validator/user.go
+++ b/internal/validator/user.go
@@ -75,8 +75,8 @@ func ValidateUserModification(store *storage.Storage, userID int64, changes *mod
 	}
 
 	if changes.EntryOrder != nil {
-		if err := ValidateEntryOrder(*changes.EntryOrder); err != nil {
-			return locale.NewLocalizedError("error.invalid_entry_order")
+		if err := validateEntrySortingOrder(*changes.EntryOrder); err != nil {
+			return err
 		}
 	}
 
@@ -214,6 +214,15 @@ func validateTimezone(timezoneValue string) *locale.LocalizedError {
 func validateEntriesPerPage(entriesPerPage int) *locale.LocalizedError {
 	if entriesPerPage < 1 || entriesPerPage > model.MaxEntryLimit {
 		return locale.NewLocalizedError("error.entries_per_page_invalid")
+	}
+	return nil
+}
+
+// validateEntrySortingOrder must accept only the values of the
+// entry_sorting_order enum type in the database.
+func validateEntrySortingOrder(order string) *locale.LocalizedError {
+	if order != "published_at" && order != "created_at" {
+		return locale.NewLocalizedError("error.invalid_entry_order")
 	}
 	return nil
 }

--- a/internal/validator/user_test.go
+++ b/internal/validator/user_test.go
@@ -123,6 +123,25 @@ func TestValidateEntriesPerPage(t *testing.T) {
 	}
 }
 
+func TestValidateEntrySortingOrder(t *testing.T) {
+	for _, order := range []string{"published_at", "created_at"} {
+		if err := validateEntrySortingOrder(order); err != nil {
+			t.Errorf("expected valid order %q to pass, got %v", order, err)
+		}
+	}
+
+	// Valid entry-listing orders that are not part of the entry_sorting_order enum.
+	for _, order := range []string{"id", "status", "changed_at", "category_title", "category_id", "title", "author"} {
+		if err := validateEntrySortingOrder(order); err == nil {
+			t.Errorf("expected order %q to be rejected", order)
+		}
+	}
+
+	if err := validateEntrySortingOrder("invalid"); err == nil {
+		t.Error("expected invalid order to fail")
+	}
+}
+
 func TestValidateCategoriesSortingOrder(t *testing.T) {
 	for _, order := range []string{"alphabetical", "unread_count"} {
 		if err := validateCategoriesSortingOrder(order); err != nil {


### PR DESCRIPTION
`ValidateUserModification` reused `ValidateEntryOrder`, which accepts nine sorting fields valid for the entry-listing `order` query parameter, while the `users.entry_order` column is an `entry_sorting_order` enum allowing only `published_at` and `created_at`.

Requests such as `PUT /v1/users/{id}` with `entry_sorting_order=title` passed validation and failed in PostgreSQL, returning `500` instead of `400`.

## Changes

- Validate the user preference against the enum values with a dedicated `validateEntrySortingOrder` function.
- Keep `ValidateEntryOrder` for the entry-listing endpoint.
