### PR TITLE
fix(validator): allow clearing the feed proxy URL

### DIFF
--- a/internal/validator/feed.go
+++ b/internal/validator/feed.go
@@ -117,11 +117,7 @@ func ValidateFeedModification(store *storage.Storage, userID, feedID int64, requ
 		}
 	}
 
-	if request.ProxyURL != nil {
-		if *request.ProxyURL == "" {
-			return locale.NewLocalizedError("error.proxy_url_not_empty")
-		}
-
+	if request.ProxyURL != nil && *request.ProxyURL != "" {
 		if !urllib.IsValidProxyURL(*request.ProxyURL) {
 			return locale.NewLocalizedError("error.invalid_feed_proxy_url")
 		}

--- a/internal/validator/feed_test.go
+++ b/internal/validator/feed_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package validator // import "miniflux.app/v2/internal/validator"
+
+import (
+	"testing"
+
+	"miniflux.app/v2/internal/model"
+)
+
+func TestValidateFeedModificationProxyURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		proxyURL string
+		wantErr  bool
+	}{
+		{
+			name:     "empty proxy URL",
+			proxyURL: "",
+			wantErr:  false,
+		},
+		{
+			name:     "valid proxy URL",
+			proxyURL: "http://127.0.0.1:3128",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid proxy URL",
+			proxyURL: "example.org",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			request := &model.FeedModificationRequest{ProxyURL: &tc.proxyURL}
+			if err := ValidateFeedModification(nil, 0, 0, request); (err != nil) != tc.wantErr {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An empty `proxy_url` in a feed modification request was rejected with `error.proxy_url_not_empty`, so a proxy URL could never be unset once configured.

- Accept the empty string to clear it, matching feed creation.
- Only validate non-empty values.
