### PR TITLE
fix(handler): apply no_media_player option during feed creation

### DIFF
--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -167,6 +167,7 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 	subscription.BlockFilterEntryRules = feedCreationRequest.BlockFilterEntryRules
 	subscription.KeepFilterEntryRules = feedCreationRequest.KeepFilterEntryRules
 	subscription.HideGlobally = feedCreationRequest.HideGlobally
+	subscription.NoMediaPlayer = feedCreationRequest.NoMediaPlayer
 	subscription.EtagHeader = responseHandler.ETag()
 	subscription.LastModifiedHeader = responseHandler.LastModified()
 	subscription.FeedURL = responseHandler.EffectiveURL()


### PR DESCRIPTION
`CreateFeed` copied every other option from the feed creation request but never `NoMediaPlayer`, so the flag was silently dropped and always stored as `false` when creating a feed.
