### PR TITLE
fix(storage): clamp non-positive entry query limits to the maximum

### DIFF
--- a/internal/storage/entry_query_builder.go
+++ b/internal/storage/entry_query_builder.go
@@ -199,19 +199,19 @@ func (e *EntryQueryBuilder) WithSorting(column, direction string) *EntryQueryBui
 	return e
 }
 
-// WithLimit set the limit.
+// WithLimit sets the limit. A non-positive limit is clamped to
+// model.MaxEntryLimit so callers cannot request an unbounded result set.
 func (e *EntryQueryBuilder) WithLimit(limit int) *EntryQueryBuilder {
-	if limit > 0 {
-		e.limit = min(limit, model.MaxEntryLimit)
-	}
-	return e
+	return e.WithLimitAndMaximum(limit, model.MaxEntryLimit)
 }
 
 // WithLimitAndMaximum sets the limit, capped at the given maximum.
+// A non-positive limit is clamped to the maximum.
 func (e *EntryQueryBuilder) WithLimitAndMaximum(limit, maximum int) *EntryQueryBuilder {
-	if limit > 0 {
-		e.limit = min(limit, maximum)
+	if limit <= 0 || limit > maximum {
+		limit = maximum
 	}
+	e.limit = limit
 	return e
 }
 


### PR DESCRIPTION
`WithLimit` ignored a zero limit, so `/v1/entries?limit=0` produced a query without a SQL `LIMIT` and returned every matching entry, bypassing the 1000-entry cap. The official API client sends `limit=0` for any filter with an unset `Limit` field, making unbounded queries easy to trigger.

Clamp non-positive values to the maximum in both `WithLimit` and `WithLimitAndMaximum` so every caller (REST API, Google Reader) stays bounded, as intended by 0909323a.
