### PR TITLE
fix(config): reject non-positive SCHEDULER_ENTRY_FREQUENCY_FACTOR values

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -528,6 +528,9 @@ func NewConfigOptions() *configOptions {
 				parsedIntValue: 1,
 				rawValue:       "1",
 				valueType:      intType,
+				validator: func(rawValue string) error {
+					return validateGreaterOrEqualThan(rawValue, 1)
+				},
 			},
 			"SCHEDULER_ENTRY_FREQUENCY_MAX_INTERVAL": {
 				parsedDuration: 24 * time.Hour,

--- a/internal/config/options_parsing_test.go
+++ b/internal/config/options_parsing_test.go
@@ -1149,6 +1149,14 @@ func TestSchedulerEntryFrequencyFactorOptionParsing(t *testing.T) {
 	if configParser.options.SchedulerEntryFrequencyFactor() != 2 {
 		t.Fatalf("Expected SCHEDULER_ENTRY_FREQUENCY_FACTOR to be 2")
 	}
+
+	if err := configParser.parseLines([]string{"SCHEDULER_ENTRY_FREQUENCY_FACTOR=0"}); err == nil {
+		t.Fatalf("Expected an error for SCHEDULER_ENTRY_FREQUENCY_FACTOR=0")
+	}
+
+	if err := configParser.parseLines([]string{"SCHEDULER_ENTRY_FREQUENCY_FACTOR=-1"}); err == nil {
+		t.Fatalf("Expected an error for SCHEDULER_ENTRY_FREQUENCY_FACTOR=-1")
+	}
 }
 
 func TestYouTubeEmbedUrlOverrideOptionParsing(t *testing.T) {


### PR DESCRIPTION
`SCHEDULER_ENTRY_FREQUENCY_FACTOR` was the only scheduler option without a validator, so `0` was accepted at startup. With the `entry_frequency` polling scheduler, the factor is used as part of a divisor in `ScheduleNextCheck`, and a feed with weekly entries then triggered a division-by-zero panic inside a background worker, crashing the daemon.

Require the factor to be >= 1, matching the validation of the other scheduler options, so the misconfiguration fails at startup instead.
