### PR TITLE
fix(integration): stop sending empty tags to Raindrop

### DIFF
--- a/internal/integration/raindrop/raindrop.go
+++ b/internal/integration/raindrop/raindrop.go
@@ -19,7 +19,13 @@ type Client struct {
 }
 
 func NewClient(token, collectionID, tags string) *Client {
-	return &Client{token: token, collectionID: collectionID, tags: strings.Split(tags, ",")}
+	var tagList []string
+	for tag := range strings.SplitSeq(tags, ",") {
+		if trimmedTag := strings.TrimSpace(tag); trimmedTag != "" {
+			tagList = append(tagList, trimmedTag)
+		}
+	}
+	return &Client{token: token, collectionID: collectionID, tags: tagList}
 }
 
 // https://developer.raindrop.io/v1/raindrops/single#create-raindrop
@@ -54,7 +60,7 @@ type raindrop struct {
 	Link       string     `json:"link"`
 	Title      string     `json:"title"`
 	Collection collection `json:"collection"`
-	Tags       []string   `json:"tags"`
+	Tags       []string   `json:"tags,omitempty"`
 }
 
 type collection struct {

--- a/internal/integration/raindrop/raindrop_test.go
+++ b/internal/integration/raindrop/raindrop_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package raindrop
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+)
+
+func TestNewClientTagParsing(t *testing.T) {
+	tests := []struct {
+		name string
+		tags string
+		want []string
+	}{
+		{name: "empty string produces no tags", tags: "", want: nil},
+		{name: "single tag", tags: "news", want: []string{"news"}},
+		{name: "multiple tags", tags: "news,tech", want: []string{"news", "tech"}},
+		{name: "whitespace is trimmed", tags: " news , tech ", want: []string{"news", "tech"}},
+		{name: "empty items are dropped", tags: "news,,tech,", want: []string{"news", "tech"}},
+		{name: "only separators produce no tags", tags: ", ,", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient("token", "collection", tt.tags)
+			if !slices.Equal(client.tags, tt.want) {
+				t.Errorf("NewClient(%q) tags = %#v, want %#v", tt.tags, client.tags, tt.want)
+			}
+		})
+	}
+}
+
+func TestPayloadOmitsEmptyTags(t *testing.T) {
+	payload, err := json.Marshal(&raindrop{Link: "https://example.com", Title: "Example"})
+	if err != nil {
+		t.Fatalf("unable to marshal payload: %v", err)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatalf("unable to unmarshal payload: %v", err)
+	}
+
+	if _, found := fields["tags"]; found {
+		t.Errorf("payload without tags should omit the tags field, got %s", payload)
+	}
+}


### PR DESCRIPTION
`strings.Split("", ",")` returns `[""]`, so an empty tag configuration attached a single empty-string tag to every bookmark saved through the Raindrop integration.

- Split the configured tags with `SplitSeq`
- Trim whitespace and drop empty items
- Omit the `tags` field entirely from the payload when no tags are configured
