### PR TITLE
fix(ui): keep proxy checkbox on subscription choose error re-render

### DIFF
--- a/internal/ui/subscription_choose.go
+++ b/internal/ui/subscription_choose.go
@@ -36,6 +36,7 @@ func (h *handler) showChooseSubscriptionPage(w http.ResponseWriter, r *http.Requ
 	view.Set("countUnread", navMetadata.CountUnread)
 	view.Set("countErrorFeeds", navMetadata.CountErrorFeeds)
 	view.Set("defaultUserAgent", config.Opts.HTTPClientUserAgent())
+	view.Set("hasProxyConfigured", config.Opts.HasHTTPClientProxyURLConfigured())
 
 	subscriptionForm := form.NewSubscriptionForm(r)
 	if validationErr := subscriptionForm.Validate(); validationErr != nil {


### PR DESCRIPTION
The `showChooseSubscriptionPage` handler never set `hasProxyConfigured` on the view, so when the `add_subscription` template was re-rendered after a validation or feed creation error, the `fetch_via_proxy` checkbox silently disappeared from the form.

Set the flag during view setup, matching the other subscription handlers.
