### PR TITLE
fix: enforce domain boundary in YouTube URL hostname check

### DIFF
--- a/internal/reader/rewrite/content_rewrite_functions.go
+++ b/internal/reader/rewrite/content_rewrite_functions.go
@@ -265,7 +265,8 @@ func getYoutubVideoIDFromURL(entryURL string) string {
 		return ""
 	}
 
-	if !strings.HasSuffix(u.Hostname(), "youtube.com") {
+	hostname := u.Hostname()
+	if hostname != "youtube.com" && !strings.HasSuffix(hostname, ".youtube.com") {
 		return ""
 	}
 

--- a/internal/reader/rewrite/content_rewrite_test.go
+++ b/internal/reader/rewrite/content_rewrite_test.go
@@ -126,6 +126,26 @@ func TestRewriteIncorrectYoutubeLink(t *testing.T) {
 	}
 }
 
+func TestRewriteYoutubeLinkRejectsLookalikeDomain(t *testing.T) {
+	config.Opts = config.NewConfigOptions()
+
+	controlEntry := &model.Entry{
+		URL:     "https://notyoutube.com/watch?v=1234",
+		Title:   `A title`,
+		Content: `Video Description`,
+	}
+	testEntry := &model.Entry{
+		URL:     "https://notyoutube.com/watch?v=1234",
+		Title:   `A title`,
+		Content: `Video Description`,
+	}
+	ApplyContentRewriteRules(testEntry, `add_youtube_video`)
+
+	if !reflect.DeepEqual(testEntry, controlEntry) {
+		t.Errorf(`A domain that merely ends in "youtube.com" must not be treated as YouTube: got "%+v" instead of "%+v"`, testEntry, controlEntry)
+	}
+}
+
 func TestRewriteYoutubeLinkAndCustomEmbedURL(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("YOUTUBE_EMBED_URL_OVERRIDE", "https://invidious.custom/embed/")


### PR DESCRIPTION
**Description:** `getYoutubVideoIDFromURL` (internal/reader/rewrite/content_rewrite_functions.go) checked `strings.HasSuffix(u.Hostname(), "youtube.com")` with no leading dot, so any hostname that merely *ends* in that string (e.g. `notyoutube.com`, `totally-legit-youtube.com`) passed the check exactly like `www.youtube.com`. Fixed by requiring an exact match on `youtube.com` or a suffix match on `.youtube.com`, mirroring the existing (correct) pattern in `referer_override.go` for the same class of hostname check (e.g. `strings.HasSuffix(hostname, ".cdninstagram.com")`).

**Motivation:** A feed entry whose URL hostname ends in `youtube.com` without actually being a YouTube subdomain gets misidentified as a YouTube video by the `add_youtube_video` / `add_youtube_video_using_invidious_player` content-rewrite rules, and rewritten into a YouTube/Invidious embed iframe using the attacker-controlled `?v=` query value as the video ID. A malicious or compromised feed could exploit this. (Severity is limited — the iframe `src` domain itself is still the trusted embed domain, so this isn't an open-redirect/XSS primitive, but it's a genuine content-misclassification bug.)

**Testing:** Added `TestRewriteYoutubeLinkRejectsLookalikeDomain`, asserting a `notyoutube.com/watch?v=...` entry is left unmodified by `add_youtube_video`. Round-trip verified: the new test fails against the pre-fix code and passes against the fix. `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test ./internal/reader/rewrite/...` all clean.

**Breaking Changes:** None — this only narrows which hostnames are treated as YouTube; no legitimate `*.youtube.com`/`youtube.com` URL changes behavior.

**Related Issues:** None found via search; opening fresh.