### PR TITLE
refactor: change existence-check helpers to return (bool, error)

### DIFF
--- a/internal/api/category_handlers.go
+++ b/internal/api/category_handlers.go
@@ -146,7 +146,12 @@ func (h *handler) removeCategoryHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !h.store.CategoryIDExists(userID, categoryID) {
+	exists, err := h.store.CategoryIDExists(userID, categoryID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.JSONNotFound(w, r)
 		return
 	}

--- a/internal/api/entry_handlers.go
+++ b/internal/api/entry_handlers.go
@@ -148,15 +148,29 @@ func (h *handler) findEntries(w http.ResponseWriter, r *http.Request, feedID int
 
 	userID := request.UserID(r)
 	categoryID = request.QueryInt64Param(r, "category_id", categoryID)
-	if categoryID > 0 && !h.store.CategoryIDExists(userID, categoryID) {
-		response.JSONBadRequest(w, r, errors.New("invalid category ID"))
-		return
+	if categoryID > 0 {
+		exists, err := h.store.CategoryIDExists(userID, categoryID)
+		if err != nil {
+			response.JSONServerError(w, r, err)
+			return
+		}
+		if !exists {
+			response.JSONBadRequest(w, r, errors.New("invalid category ID"))
+			return
+		}
 	}
 
 	feedID = request.QueryInt64Param(r, "feed_id", feedID)
-	if feedID > 0 && !h.store.FeedExists(userID, feedID) {
-		response.JSONBadRequest(w, r, errors.New("invalid feed ID"))
-		return
+	if feedID > 0 {
+		exists, err := h.store.FeedExists(userID, feedID)
+		if err != nil {
+			response.JSONServerError(w, r, err)
+			return
+		}
+		if !exists {
+			response.JSONBadRequest(w, r, errors.New("invalid feed ID"))
+			return
+		}
 	}
 
 	tags := request.QueryStringParamList(r, "tags")
@@ -346,7 +360,12 @@ func (h *handler) importFeedEntryHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !h.store.FeedExists(userID, feedID) {
+	exists, err := h.store.FeedExists(userID, feedID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.JSONBadRequest(w, r, errors.New("feed does not exist"))
 		return
 	}

--- a/internal/api/feed_handlers.go
+++ b/internal/api/feed_handlers.go
@@ -59,7 +59,12 @@ func (h *handler) refreshFeedHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := request.UserID(r)
-	if !h.store.FeedExists(userID, feedID) {
+	exists, err := h.store.FeedExists(userID, feedID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.JSONNotFound(w, r)
 		return
 	}
@@ -154,7 +159,12 @@ func (h *handler) markFeedAsReadHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !h.store.FeedExists(userID, feedID) {
+	exists, err := h.store.FeedExists(userID, feedID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.JSONNotFound(w, r)
 		return
 	}
@@ -245,7 +255,12 @@ func (h *handler) removeFeedHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := request.UserID(r)
-	if !h.store.FeedExists(userID, feedID) {
+	exists, err := h.store.FeedExists(userID, feedID)
+	if err != nil {
+		response.JSONServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.JSONNotFound(w, r)
 		return
 	}

--- a/internal/reader/handler/handler.go
+++ b/internal/reader/handler/handler.go
@@ -44,7 +44,11 @@ func CreateFeedFromSubscriptionDiscovery(store *storage.Storage, userID int64, f
 		slog.String("proxy_url", feedCreationRequest.ProxyURL),
 	)
 
-	if !store.CategoryIDExists(userID, feedCreationRequest.CategoryID) {
+	categoryExists, storeErr := store.CategoryIDExists(userID, feedCreationRequest.CategoryID)
+	if storeErr != nil {
+		return nil, locale.NewLocalizedErrorWrapper(storeErr, "error.database_error", storeErr)
+	}
+	if !categoryExists {
 		return nil, locale.NewLocalizedErrorWrapper(ErrCategoryNotFound, "error.category_not_found")
 	}
 
@@ -108,7 +112,11 @@ func CreateFeed(store *storage.Storage, userID int64, feedCreationRequest *model
 		slog.String("proxy_url", feedCreationRequest.ProxyURL),
 	)
 
-	if !store.CategoryIDExists(userID, feedCreationRequest.CategoryID) {
+	categoryExists, storeErr := store.CategoryIDExists(userID, feedCreationRequest.CategoryID)
+	if storeErr != nil {
+		return nil, locale.NewLocalizedErrorWrapper(storeErr, "error.database_error", storeErr)
+	}
+	if !categoryExists {
 		return nil, locale.NewLocalizedErrorWrapper(ErrCategoryNotFound, "error.category_not_found")
 	}
 

--- a/internal/storage/category.go
+++ b/internal/storage/category.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 
 	"github.com/lib/pq"
 	"miniflux.app/v2/internal/model"
@@ -30,21 +29,16 @@ func (s *Storage) CategoryTitleExists(userID int64, title string) bool {
 }
 
 // CategoryIDExists checks if the given category exists into the database.
-func (s *Storage) CategoryIDExists(userID, categoryID int64) bool {
+// The returned error is non-nil only for a genuine query/connection failure;
+// a category that doesn't exist is reported as (false, nil), matching the
+// underlying sql.ErrNoRows case.
+func (s *Storage) CategoryIDExists(userID, categoryID int64) (bool, error) {
 	var result bool
 	query := `SELECT true FROM categories WHERE user_id=$1 AND id=$2 LIMIT 1`
 	if err := s.db.QueryRow(query, userID, categoryID).Scan(&result); err != nil && !errors.Is(err, sql.ErrNoRows) {
-		// See FeedExists in feed.go for why a real query error is worth
-		// logging here: callers treat a false return as "no such category",
-		// so a swallowed error would silently misreport an infrastructure
-		// failure as a missing resource.
-		slog.Error("store: unable to check if category exists",
-			slog.Int64("user_id", userID),
-			slog.Int64("category_id", categoryID),
-			slog.Any("error", err),
-		)
+		return false, fmt.Errorf(`store: unable to check if category exists: %w`, err)
 	}
-	return result
+	return result, nil
 }
 
 // Category returns a category from the database.

--- a/internal/storage/feed.go
+++ b/internal/storage/feed.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sort"
 	"time"
 
@@ -33,24 +32,17 @@ func (l byStateAndName) Less(i, j int) bool {
 	return l.f[i].Title < l.f[j].Title
 }
 
-// FeedExists checks if the given feed exists.
-func (s *Storage) FeedExists(userID, feedID int64) bool {
+// FeedExists checks if the given feed exists. The returned error is
+// non-nil only for a genuine query/connection failure; a feed that doesn't
+// exist is reported as (false, nil), matching the underlying sql.ErrNoRows
+// case.
+func (s *Storage) FeedExists(userID, feedID int64) (bool, error) {
 	var result bool
 	query := `SELECT true FROM feeds WHERE user_id=$1 AND id=$2 LIMIT 1`
 	if err := s.db.QueryRow(query, userID, feedID).Scan(&result); err != nil && !errors.Is(err, sql.ErrNoRows) {
-		// A real query/connection error is not the same thing as "this feed
-		// doesn't exist" -- callers treat a false return as a 404, so a
-		// swallowed error here would silently misreport a genuine
-		// infrastructure failure as a missing resource. Logging at least
-		// makes it observable in server logs, matching the pattern already
-		// used by CountWebAuthnCredentialsByUserID in webauthn.go.
-		slog.Error("store: unable to check if feed exists",
-			slog.Int64("user_id", userID),
-			slog.Int64("feed_id", feedID),
-			slog.Any("error", err),
-		)
+		return false, fmt.Errorf(`store: unable to check if feed exists: %w`, err)
 	}
-	return result
+	return result, nil
 }
 
 // CheckedAt returns when the feed was last checked.
@@ -64,19 +56,16 @@ func (s *Storage) CheckedAt(userID, feedID int64) (time.Time, error) {
 	return result, nil
 }
 
-// CategoryFeedExists returns true if the given feed exists and belongs to the given category.
-func (s *Storage) CategoryFeedExists(userID, categoryID, feedID int64) bool {
+// CategoryFeedExists returns true if the given feed exists and belongs to
+// the given category. The returned error is non-nil only for a genuine
+// query/connection failure; see FeedExists above for the same convention.
+func (s *Storage) CategoryFeedExists(userID, categoryID, feedID int64) (bool, error) {
 	var result bool
 	query := `SELECT true FROM feeds WHERE user_id=$1 AND category_id=$2 AND id=$3 LIMIT 1`
 	if err := s.db.QueryRow(query, userID, categoryID, feedID).Scan(&result); err != nil && !errors.Is(err, sql.ErrNoRows) {
-		slog.Error("store: unable to check if feed exists in category",
-			slog.Int64("user_id", userID),
-			slog.Int64("category_id", categoryID),
-			slog.Int64("feed_id", feedID),
-			slog.Any("error", err),
-		)
+		return false, fmt.Errorf(`store: unable to check if feed exists in category: %w`, err)
 	}
-	return result
+	return result, nil
 }
 
 // FeedURLExists returns true if the given feed URL already exists for the user.

--- a/internal/ui/category_mark_feed_as_read.go
+++ b/internal/ui/category_mark_feed_as_read.go
@@ -15,7 +15,12 @@ func (h *handler) markCategoryFeedAsRead(w http.ResponseWriter, r *http.Request)
 	categoryID := request.RouteInt64Param(r, "categoryID")
 	userID := request.UserID(r)
 
-	if !h.store.CategoryFeedExists(userID, categoryID, feedID) {
+	exists, err := h.store.CategoryFeedExists(userID, categoryID, feedID)
+	if err != nil {
+		response.HTMLServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.HTMLNotFound(w, r)
 		return
 	}

--- a/internal/ui/category_remove_feed.go
+++ b/internal/ui/category_remove_feed.go
@@ -14,7 +14,12 @@ func (h *handler) removeCategoryFeed(w http.ResponseWriter, r *http.Request) {
 	feedID := request.RouteInt64Param(r, "feedID")
 	categoryID := request.RouteInt64Param(r, "categoryID")
 
-	if !h.store.CategoryFeedExists(request.UserID(r), categoryID, feedID) {
+	exists, err := h.store.CategoryFeedExists(request.UserID(r), categoryID, feedID)
+	if err != nil {
+		response.HTMLServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.HTMLNotFound(w, r)
 		return
 	}

--- a/internal/ui/feed_remove.go
+++ b/internal/ui/feed_remove.go
@@ -13,7 +13,12 @@ import (
 func (h *handler) removeFeed(w http.ResponseWriter, r *http.Request) {
 	feedID := request.RouteInt64Param(r, "feedID")
 
-	if !h.store.FeedExists(request.UserID(r), feedID) {
+	exists, err := h.store.FeedExists(request.UserID(r), feedID)
+	if err != nil {
+		response.HTMLServerError(w, r, err)
+		return
+	}
+	if !exists {
 		response.HTMLNotFound(w, r)
 		return
 	}

--- a/internal/validator/feed.go
+++ b/internal/validator/feed.go
@@ -4,6 +4,8 @@
 package validator // import "miniflux.app/v2/internal/validator"
 
 import (
+	"log/slog"
+
 	"miniflux.app/v2/internal/locale"
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/storage"
@@ -24,7 +26,23 @@ func ValidateFeedCreation(store *storage.Storage, userID int64, request *model.F
 		return locale.NewLocalizedError("error.feed_already_exists")
 	}
 
-	if !store.CategoryIDExists(userID, request.CategoryID) {
+	categoryExists, err := store.CategoryIDExists(userID, request.CategoryID)
+	if err != nil {
+		// *locale.LocalizedError (unlike *locale.LocalizedErrorWrapper elsewhere
+		// in this codebase) has no way to carry an underlying error, so a
+		// genuine backend failure here can't be distinguished from "category
+		// not found" in the value returned to the caller. Log it so the
+		// failure is at least observable, and fall back to the existing
+		// user-facing message rather than changing this function's public
+		// return type as part of this PR.
+		slog.Error("validator: unable to check if feed category exists",
+			slog.Int64("user_id", userID),
+			slog.Int64("category_id", request.CategoryID),
+			slog.Any("error", err),
+		)
+		return locale.NewLocalizedError("error.feed_category_not_found")
+	}
+	if !categoryExists {
 		return locale.NewLocalizedError("error.feed_category_not_found")
 	}
 
@@ -88,7 +106,17 @@ func ValidateFeedModification(store *storage.Storage, userID, feedID int64, requ
 	}
 
 	if request.CategoryID != nil {
-		if !store.CategoryIDExists(userID, *request.CategoryID) {
+		categoryExists, err := store.CategoryIDExists(userID, *request.CategoryID)
+		if err != nil {
+			// See the identical rationale in ValidateFeedCreation above.
+			slog.Error("validator: unable to check if feed category exists",
+				slog.Int64("user_id", userID),
+				slog.Int64("category_id", *request.CategoryID),
+				slog.Any("error", err),
+			)
+			return locale.NewLocalizedError("error.feed_category_not_found")
+		}
+		if !categoryExists {
 			return locale.NewLocalizedError("error.feed_category_not_found")
 		}
 	}


### PR DESCRIPTION
Follow-up to #4484 per the discussion there:

> Happy to follow up with the full signature-change refactor as a separate PR if that's preferred instead.

> Refactoring the signature to `(bool, error)` seems to be the right fix.

**Description:** `FeedExists`, `CategoryFeedExists` (`internal/storage/feed.go`), and `CategoryIDExists` (`internal/storage/category.go`) now return `(bool, error)` instead of just `bool`. All 14 call sites (across `internal/api`, `internal/ui`, `internal/reader/handler`, and `internal/validator`) are updated to distinguish a genuine backend failure from "resource not found":

- `internal/api/*_handlers.go` (7 sites): `response.JSONServerError` on a real error; existing `response.JSONNotFound`/`JSONBadRequest` behavior unchanged otherwise.
- `internal/ui/*.go` (3 sites): `response.HTMLServerError` on a real error; existing `response.HTMLNotFound` behavior unchanged otherwise.
- `internal/reader/handler/handler.go` (2 sites): `locale.NewLocalizedErrorWrapper(err, "error.database_error", err)` on a real error -- this matches the exact idiom already used elsewhere in this same file for other storage errors (e.g. the existing `store.CreateFeed`/`store.FeedByID` error handling a few lines below each of these).
- `internal/validator/feed.go` (2 sites): `*locale.LocalizedError` (unlike `*locale.LocalizedErrorWrapper` used elsewhere) has no way to carry an underlying error -- giving it one would be a separate, larger change to the validator package's error model, out of scope for this PR. I log the real error via `slog` and fall back to the existing `error.feed_category_not_found` message, same as before. Flagging this explicitly as a deliberate scoping decision, not an oversight -- happy to take this further if a signature change here is preferred too.

**Motivation:** As discussed in #4484, callers previously couldn't distinguish "genuinely doesn't exist" from "the existence check itself failed", which meant a real infrastructure failure was reported to the client/operator identically to a 404. #4484 made the failure observable via logging without changing behavior; this PR completes the fix by making the distinction available to every caller, so each layer can choose the right response (500 vs 404/400) instead of always collapsing to "not found".

**Testing:** `go build ./...`, `go vet ./...`, `gofmt -l` (clean on all 10 touched files), and the full `go test ./...` suite (48 packages, all pass -- confirmed no existing test calls these 3 functions directly, so none needed updating). No new test added, for the same reason #4484 gave: there's no existing DB-error-injection harness for this package, and this change doesn't alter behavior on the non-error path -- every touched call site's existing-behavior branch is unchanged.

**Breaking Changes:** None for HTTP clients or the UI -- response codes/behavior are unchanged when there's no error. This does change the exported signature of `Storage.FeedExists`, `Storage.CategoryFeedExists`, and `Storage.CategoryIDExists`, which is a breaking change for anything importing this package directly as a library (not applicable to the server binary itself).

**Related Issues:** Follow-up to #4484.