### PR TITLE
fix(ui): guard against nil session in CSRF middleware

### DIFF
--- a/internal/ui/csrf_middleware.go
+++ b/internal/ui/csrf_middleware.go
@@ -39,7 +39,13 @@ func (m *csrfMiddleware) handle(next http.Handler) http.Handler {
 }
 
 func (m *csrfMiddleware) validate(w http.ResponseWriter, r *http.Request) bool {
-	csrfToken := request.WebSession(r).CSRF()
+	session := request.WebSession(r)
+	if session == nil {
+		response.HTMLBadRequest(w, r, errors.New("invalid or missing CSRF"))
+		return false
+	}
+
+	csrfToken := session.CSRF()
 	formValue := r.FormValue("csrf")
 	headerValue := r.Header.Get("X-Csrf-Token")
 


### PR DESCRIPTION
## Summary
- Fix nil-pointer panic when POST request is sent to static-asset paths

## Details
The CSRF middleware assumes a session is always present in the request context, but the web session middleware skips session creation for static routes (`/js/*`, `/stylesheets/*`, `/icon/*`, `/feed-icon/*`, `/favicon.ico`, `/robots.txt`).

A POST to any static path panics at `csrf_middleware.go:42` when calling `.CSRF()` on the nil session.

## Steps to reproduce
```bash
curl -X POST https://miniflux.example/js/x
# Server logs: panic: runtime error: invalid memory address or nil pointer dereference
```

## Fix
Add nil check before calling `.CSRF()` on the session. Returns 400 Bad Request when no session is present, matching the existing error handling style.