### PR TITLE
fix(reader): fix parsing legacy rss namespaces

### DIFF
--- a/internal/reader/rss/parser.go
+++ b/internal/reader/rss/parser.go
@@ -4,17 +4,41 @@
 package rss // import "miniflux.app/v2/internal/reader/rss"
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 
 	"miniflux.app/v2/internal/model"
 	"miniflux.app/v2/internal/reader/xml"
 )
 
+// rssDefaultNamespaceRe matches a default (unprefixed) xmlns declaration on
+// the root <rss> element, e.g. <rss xmlns="http://backend.userland.com/rss2">.
+// It intentionally does not match prefixed namespaces like xmlns:atom="...".
+var rssDefaultNamespaceRe = regexp.MustCompile(`(<rss\b[^>]*?)\s+xmlns="[^"]*"`)
+
+// stripRSSDefaultNamespace removes a default namespace declared on the root
+// <rss> element. Some feeds bind all elements to a default namespace (often
+// the legacy Userland RSS2 namespace), which prevents them from matching the
+// unprefixed "rss ..." struct tags used throughout this package, since
+// DefaultSpace only applies to elements that don't already carry a namespace.
+// Stripping the declaration lets those elements fall back to DefaultSpace as
+// usual, while prefixed extension namespaces are left untouched.
+func stripRSSDefaultNamespace(data []byte) []byte {
+	return rssDefaultNamespaceRe.ReplaceAll(data, []byte("$1"))
+}
+
 // Parse returns a normalized feed struct from a RSS feed.
 func Parse(baseURL string, data io.ReadSeeker) (*model.Feed, error) {
+	body, err := io.ReadAll(data)
+	if err != nil {
+		return nil, fmt.Errorf("rss: unable to read feed: %w", err)
+	}
+	body = stripRSSDefaultNamespace(body)
+
 	rssFeed := new(rss)
-	decoder := xml.NewXMLDecoder(data)
+	decoder := xml.NewXMLDecoder(bytes.NewReader(body))
 	decoder.DefaultSpace = "rss"
 	if err := decoder.Decode(rssFeed); err != nil {
 		return nil, fmt.Errorf("rss: unable to parse feed: %w", err)

--- a/internal/reader/rss/parser_test.go
+++ b/internal/reader/rss/parser_test.go
@@ -113,6 +113,38 @@ func TestParseRss2Sample(t *testing.T) {
 	}
 }
 
+func TestParseFeedWithDefaultNamespace(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+		<rss xmlns="http://backend.userland.com/rss2" version="2.0" xmlns:yandex="https://example.org/">
+		<channel>
+			<title>Example Feed</title>
+			<link>https://example.org/</link>
+			<description>Example description</description>
+			<item>
+				<title>Example Item</title>
+				<link>https://example.org/item</link>
+			</item>
+		</channel>
+		</rss>`
+
+	feed, err := Parse("https://example.org/", bytes.NewReader([]byte(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if feed.Title != "Example Feed" {
+		t.Errorf("Incorrect title, got: %q", feed.Title)
+	}
+
+	if len(feed.Entries) != 1 {
+		t.Fatalf("Incorrect number of entries, got: %d", len(feed.Entries))
+	}
+
+	if feed.Entries[0].Title != "Example Item" {
+		t.Errorf("Incorrect entry title, got: %q", feed.Entries[0].Title)
+	}
+}
+
 func TestParseFeedWithFeedURLWithTrailingSpace(t *testing.T) {
 	data := `<?xml version="1.0"?>
 		<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)

Fixed parsing legacy rss namespaces like
```
<?xml version="1.0" encoding="utf-8"?>                                                                                                                                                                                                                                                                                                                                      
<rss xmlns="http://backend.userland.com/rss2" version="2.0" xmlns:yandex="https://sud.ua/">                                                                                                                                                                                                                                                                                 
    <channel>                                                                                                                                                                                                                                                                                                                                                               
```
example rss: https://sud.ua/rss/rss_news_uk.xml
