### PR TITLE
fix(ui): add accessible name to documentation links

### DIFF
--- a/internal/locale/translations/ar_SA.json
+++ b/internal/locale/translations/ar_SA.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "إلغاء",
+    "action.documentation": "التوثيق: %s",
     "action.download": "تحميل",
     "action.edit": "تعديل",
     "action.home_screen": "إضافة إلى الشاشة الرئيسية",

--- a/internal/locale/translations/de_DE.json
+++ b/internal/locale/translations/de_DE.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "abbrechen",
+    "action.documentation": "Dokumentation: %s",
     "action.download": "Herunterladen",
     "action.edit": "Bearbeiten",
     "action.home_screen": "Zum Startbildschirm hinzufügen",

--- a/internal/locale/translations/el_EL.json
+++ b/internal/locale/translations/el_EL.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "ακύρωση",
+    "action.documentation": "Τεκμηρίωση: %s",
     "action.download": "Λήψη",
     "action.edit": "Επεξεργασία",
     "action.home_screen": "Προσθήκη στην αρχική οθόνη",

--- a/internal/locale/translations/en_US.json
+++ b/internal/locale/translations/en_US.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "cancel",
+    "action.documentation": "Documentation: %s",
     "action.download": "Download",
     "action.edit": "Edit",
     "action.home_screen": "Add to home screen",

--- a/internal/locale/translations/es_ES.json
+++ b/internal/locale/translations/es_ES.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "Cancelar",
+    "action.documentation": "Documentación: %s",
     "action.download": "Descargar",
     "action.edit": "Editar",
     "action.home_screen": "Añadir a la pantalla principal",

--- a/internal/locale/translations/fi_FI.json
+++ b/internal/locale/translations/fi_FI.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "peru",
+    "action.documentation": "Dokumentaatio: %s",
     "action.download": "Lataa",
     "action.edit": "Muokkaa",
     "action.home_screen": "Lisää aloitusnäytölle",

--- a/internal/locale/translations/fr_FR.json
+++ b/internal/locale/translations/fr_FR.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "annuler",
+    "action.documentation": "Documentation : %s",
     "action.download": "Télécharger",
     "action.edit": "Modifier",
     "action.home_screen": "Ajouter à l'écran d'accueil",

--- a/internal/locale/translations/gl_ES.json
+++ b/internal/locale/translations/gl_ES.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "cancelar",
+    "action.documentation": "Documentación: %s",
     "action.download": "Descargar",
     "action.edit": "Editar",
     "action.home_screen": "Engadir á pantalla de inicio",

--- a/internal/locale/translations/hi_IN.json
+++ b/internal/locale/translations/hi_IN.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "रद्द करें",
+    "action.documentation": "दस्तावेज़ीकरण: %s",
     "action.download": "डाउनलोड",
     "action.edit": "संपाद करे",
     "action.home_screen": "होम स्क्रीन में शामिल करें",

--- a/internal/locale/translations/id_ID.json
+++ b/internal/locale/translations/id_ID.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "batal",
+    "action.documentation": "Dokumentasi: %s",
     "action.download": "Unduh",
     "action.edit": "Sunting",
     "action.home_screen": "Tambahkan ke beranda",

--- a/internal/locale/translations/it_IT.json
+++ b/internal/locale/translations/it_IT.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "cancella",
+    "action.documentation": "Documentazione: %s",
     "action.download": "Scarica",
     "action.edit": "Modifica",
     "action.home_screen": "Aggiungere alla schermata Home",

--- a/internal/locale/translations/ja_JP.json
+++ b/internal/locale/translations/ja_JP.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "取り消し",
+    "action.documentation": "ドキュメント: %s",
     "action.download": "ダウンロード",
     "action.edit": "編集",
     "action.home_screen": "ホームスクリーンに追加",

--- a/internal/locale/translations/ko_KR.json
+++ b/internal/locale/translations/ko_KR.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "취소",
+    "action.documentation": "문서: %s",
     "action.download": "다운로드",
     "action.edit": "편집",
     "action.home_screen": "홈 화면에 추가",

--- a/internal/locale/translations/nan_Latn_pehoeji.json
+++ b/internal/locale/translations/nan_Latn_pehoeji.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "Chhú-siau",
+    "action.documentation": "Soat-bêng bûn-kiāⁿ: %s",
     "action.download": "Lia̍h----loh-lâi",
     "action.edit": "Pian-chi̍p",
     "action.home_screen": "Chng tī chú ōe-bīn",

--- a/internal/locale/translations/nl_NL.json
+++ b/internal/locale/translations/nl_NL.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "annuleren",
+    "action.documentation": "Documentatie: %s",
     "action.download": "Downloaden",
     "action.edit": "Bewerken",
     "action.home_screen": "Toevoegen aan startscherm",

--- a/internal/locale/translations/pl_PL.json
+++ b/internal/locale/translations/pl_PL.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "anuluj",
+    "action.documentation": "Dokumentacja: %s",
     "action.download": "Pobierz",
     "action.edit": "Edytuj",
     "action.home_screen": "Dodaj do ekranu głównego",

--- a/internal/locale/translations/pt_BR.json
+++ b/internal/locale/translations/pt_BR.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "Cancelar",
+    "action.documentation": "Documentação: %s",
     "action.download": "Baixar",
     "action.edit": "Editar",
     "action.home_screen": "Voltar para a tela inicial",

--- a/internal/locale/translations/ro_RO.json
+++ b/internal/locale/translations/ro_RO.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "abandon",
+    "action.documentation": "Documentație: %s",
     "action.download": "Descărcare",
     "action.edit": "Editare",
     "action.home_screen": "Adaugă pe ecranul principal",

--- a/internal/locale/translations/ru_RU.json
+++ b/internal/locale/translations/ru_RU.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "закрыть",
+    "action.documentation": "Документация: %s",
     "action.download": "Загрузить",
     "action.edit": "Изменить",
     "action.home_screen": "Добавить на домашний экран",

--- a/internal/locale/translations/tr_TR.json
+++ b/internal/locale/translations/tr_TR.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "iptal",
+    "action.documentation": "Belgeler: %s",
     "action.download": "İndir",
     "action.edit": "Düzenle",
     "action.home_screen": "Ana ekrana ekle",

--- a/internal/locale/translations/uk_UA.json
+++ b/internal/locale/translations/uk_UA.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "скасувати",
+    "action.documentation": "Документація: %s",
     "action.download": "Завантажити",
     "action.edit": "Редагувати",
     "action.home_screen": "Додати до головного екрану",

--- a/internal/locale/translations/zh_CN.json
+++ b/internal/locale/translations/zh_CN.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "取消",
+    "action.documentation": "文档：%s",
     "action.download": "下载",
     "action.edit": "编辑",
     "action.home_screen": "添加到主屏幕",

--- a/internal/locale/translations/zh_TW.json
+++ b/internal/locale/translations/zh_TW.json
@@ -1,5 +1,6 @@
 {
     "action.cancel": "取消",
+    "action.documentation": "說明文件：%s",
     "action.download": "下載",
     "action.edit": "編輯",
     "action.home_screen": "新增到主螢幕",

--- a/internal/template/templates/views/add_subscription.html
+++ b/internal/template/templates/views/add_subscription.html
@@ -67,7 +67,7 @@
                         {{ t "form.feed.label.scraper_rules" }}
                     </label>
                     &nbsp;
-                    <a href="https://miniflux.app/docs/rules.html#scraper-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href="https://miniflux.app/docs/rules.html#scraper-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.scraper_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -78,7 +78,7 @@
                         {{ t "form.feed.label.rewrite_rules" }}
                     </label>
                     &nbsp;
-                    <a href="https://miniflux.app/docs/rules.html#rewrite-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href="https://miniflux.app/docs/rules.html#rewrite-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.rewrite_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -89,7 +89,7 @@
                         {{ t "form.feed.label.urlrewrite_rules" }}
                     </label>
                     &nbsp;
-                    <a href=" https://miniflux.app/docs/rules.html#rewriteurl-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href=" https://miniflux.app/docs/rules.html#rewriteurl-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.urlrewrite_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -100,7 +100,7 @@
                         {{ t "form.feed.label.blocklist_rules" }}
                     </label>
                     &nbsp;
-                    <a href=" https://miniflux.app/docs/rules.html#feed-filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href=" https://miniflux.app/docs/rules.html#feed-filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.blocklist_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -111,7 +111,7 @@
                         {{ t "form.feed.label.keeplist_rules" }}
                     </label>
                     &nbsp;
-                    <a href=" https://miniflux.app/docs/rules.html#feed-filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href=" https://miniflux.app/docs/rules.html#feed-filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.keeplist_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -122,7 +122,7 @@
                         {{ t "form.feed.label.block_filter_entry_rules" }}
                     </label>
                     &nbsp;
-                    <a href=" https://miniflux.app/docs/rules.html#filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href=" https://miniflux.app/docs/rules.html#filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.block_filter_entry_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -133,7 +133,7 @@
                         {{ t "form.feed.label.keep_filter_entry_rules" }}
                     </label>
                     &nbsp;
-                    <a href=" https://miniflux.app/docs/rules.html#filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href=" https://miniflux.app/docs/rules.html#filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.keep_filter_entry_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>

--- a/internal/template/templates/views/edit_feed.html
+++ b/internal/template/templates/views/edit_feed.html
@@ -125,7 +125,7 @@
                     {{ t "form.feed.label.scraper_rules" }}
                 </label>
                 &nbsp;
-                <a href="https://miniflux.app/docs/rules.html#scraper-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href="https://miniflux.app/docs/rules.html#scraper-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.scraper_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -136,7 +136,7 @@
                     {{ t "form.feed.label.rewrite_rules" }}
                 </label>
                 &nbsp;
-                <a href="https://miniflux.app/docs/rules.html#rewrite-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href="https://miniflux.app/docs/rules.html#rewrite-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.rewrite_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -147,7 +147,7 @@
                     {{ t "form.feed.label.urlrewrite_rules" }}
                 </label>
                 &nbsp;
-                <a href="https://miniflux.app/docs/rules.html#rewriteurl-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href="https://miniflux.app/docs/rules.html#rewriteurl-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.urlrewrite_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -158,7 +158,7 @@
                     {{ t "form.feed.label.blocklist_rules" }}
                 </label>
                 &nbsp;
-                <a href="https://miniflux.app/docs/rules.html#feed-filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href="https://miniflux.app/docs/rules.html#feed-filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.blocklist_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -169,7 +169,7 @@
                     {{ t "form.feed.label.keeplist_rules" }}
                 </label>
                 &nbsp;
-                <a href="https://miniflux.app/docs/rules.html#feed-filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href="https://miniflux.app/docs/rules.html#feed-filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.keeplist_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -180,7 +180,7 @@
                     {{ t "form.feed.label.block_filter_entry_rules" }}
                 </label>
                 &nbsp;
-                <a href=" https://miniflux.app/docs/rules.html#filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href=" https://miniflux.app/docs/rules.html#filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.block_filter_entry_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -191,7 +191,7 @@
                     {{ t "form.feed.label.keep_filter_entry_rules" }}
                 </label>
                 &nbsp;
-                <a href=" https://miniflux.app/docs/rules.html#filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href=" https://miniflux.app/docs/rules.html#filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.keep_filter_entry_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </div>
@@ -229,7 +229,7 @@
                         {{ t "form.feed.label.ntfy_priority" }}
                     </label>
                     &nbsp;
-                    <a href="https://docs.ntfy.sh/publish/#message-priority" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href="https://docs.ntfy.sh/publish/#message-priority" aria-label="{{ t "action.documentation" (t "form.feed.label.ntfy_priority") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>
@@ -250,7 +250,7 @@
                         {{ t "form.feed.label.pushover_priority" }}
                     </label>
                     &nbsp;
-                    <a href="https://pushover.net/api#priority" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                    <a href="https://pushover.net/api#priority" aria-label="{{ t "action.documentation" (t "form.feed.label.pushover_priority") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                         {{ icon "external-link" }}
                     </a>
                 </div>

--- a/internal/template/templates/views/integrations.html
+++ b/internal/template/templates/views/integrations.html
@@ -38,7 +38,7 @@
             <input type="url" name="apprise_url" id="form-apprise-url" value="{{ .form.AppriseURL }}" placeholder="http://apprise:8080" spellcheck="false">
 
             <label for="form-apprise-services-urls">{{ t "form.integration.apprise_services_url" }}
-                <a href="https://github.com/caronc/apprise/wiki" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+                <a href="https://github.com/caronc/apprise/wiki" aria-label="{{ t "action.documentation" (t "form.integration.apprise_services_url") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                     {{ icon "external-link" }}
                 </a>
             </label>

--- a/internal/template/templates/views/settings.html
+++ b/internal/template/templates/views/settings.html
@@ -169,7 +169,7 @@
         <div class="form-label-row">
             <label for="form-display-mode">{{ t "form.prefs.label.display_mode" }}</label>
             &nbsp;
-            <a href="https://developer.mozilla.org/en-US/docs/Web/Manifest/display" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/Manifest/display" aria-label="{{ t "action.documentation" (t "form.prefs.label.display_mode") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                 {{ icon "external-link" }}
             </a>
         </div>
@@ -246,7 +246,7 @@
                 {{ t "form.feed.label.block_filter_entry_rules" }}
             </label>
             &nbsp;
-            <a href=" https://miniflux.app/docs/rules.html#filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+            <a href=" https://miniflux.app/docs/rules.html#filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.block_filter_entry_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                 {{ icon "external-link" }}
             </a>
         </div>
@@ -257,7 +257,7 @@
                 {{ t "form.feed.label.keep_filter_entry_rules" }}
             </label>
             &nbsp;
-            <a href=" https://miniflux.app/docs/rules.html#filtering-rules" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
+            <a href=" https://miniflux.app/docs/rules.html#filtering-rules" aria-label="{{ t "action.documentation" (t "form.feed.label.keep_filter_entry_rules") }}" {{ if $.user.OpenExternalLinksInNewTab }}target="_blank"{{ end }}>
                 {{ icon "external-link" }}
             </a>
         </div>


### PR DESCRIPTION
Documentation links only contain an SVG icon rendered with `aria-hidden="true"`, so assistive technologies expose them without any accessible name.

Add a translatable `aria-label` built from the new `action.documentation` key and the label of the field being documented, which gives each link a unique and meaningful name.

Fixes: #4491
