### PR TITLE
fix(googlereader): raise item IDs limit to 10000

### DIFF
--- a/internal/googlereader/README.md
+++ b/internal/googlereader/README.md
@@ -417,7 +417,7 @@ Required query parameters:
 
 Optional query parameters:
 
-- `n`: maximum number of items to return
+- `n`: maximum number of items to return, capped at 10000
 - `c`: numeric offset continuation token
 - `r`: sort direction, `o` for ascending, anything else for descending
 - `ot`: only items published after this Unix timestamp in seconds
@@ -437,7 +437,8 @@ Notes:
 - exactly one `s` value is expected
 - label streams are not supported here
 - when `xt` contains the `read` stream, `reading-list` and `feed/<id>` behave as unread-only queries
-- if `n` is omitted, the query is effectively unbounded
+- if `n` is omitted, or is above 10000 or non-positive, 10000 items are returned at most
+- clients must follow `continuation` to retrieve the remaining items
 - `continuation` is a numeric offset encoded as a JSON string, not an opaque token
 
 Response shape:

--- a/internal/googlereader/handler.go
+++ b/internal/googlereader/handler.go
@@ -1012,7 +1012,7 @@ func (h *greaderHandler) handleReadingListStreamHandler(w http.ResponseWriter, r
 	)
 
 	builder := h.store.NewEntryQueryBuilder(rm.UserID).
-		WithLimit(rm.Count).
+		WithLimitAndMaximum(rm.Count, model.MaxEntryIDsLimit).
 		WithOffset(rm.Offset).
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 
@@ -1049,7 +1049,7 @@ func (h *greaderHandler) handleReadingListStreamHandler(w http.ResponseWriter, r
 func (h *greaderHandler) handleStarredStreamHandler(w http.ResponseWriter, r *http.Request, rm requestModifiers) {
 	builder := h.store.NewEntryQueryBuilder(rm.UserID).
 		WithStarred(true).
-		WithLimit(rm.Count).
+		WithLimitAndMaximum(rm.Count, model.MaxEntryIDsLimit).
 		WithOffset(rm.Offset).
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 
@@ -1073,7 +1073,7 @@ func (h *greaderHandler) handleStarredStreamHandler(w http.ResponseWriter, r *ht
 func (h *greaderHandler) handleReadStreamHandler(w http.ResponseWriter, r *http.Request, rm requestModifiers) {
 	builder := h.store.NewEntryQueryBuilder(rm.UserID).
 		WithStatuses(model.EntryStatusRead).
-		WithLimit(rm.Count).
+		WithLimitAndMaximum(rm.Count, model.MaxEntryIDsLimit).
 		WithOffset(rm.Offset).
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 
@@ -1125,7 +1125,7 @@ func (h *greaderHandler) handleFeedStreamHandler(w http.ResponseWriter, r *http.
 
 	builder := h.store.NewEntryQueryBuilder(rm.UserID).
 		WithFeedID(feedID).
-		WithLimit(rm.Count).
+		WithLimitAndMaximum(rm.Count, model.MaxEntryIDsLimit).
 		WithOffset(rm.Offset).
 		WithSorting(model.DefaultSortingOrder, rm.SortDirection)
 


### PR DESCRIPTION
Since fbbff63f, a non-positive limit is clamped to `model.MaxEntryLimit`
instead of producing an unbounded query. `/stream/items/ids` defaults `n`
to `0`, so omitting it started returning at most 1000 IDs, whereas
previous versions returned every matching entry.

Cap the four ID stream handlers at `model.MaxEntryIDsLimit` instead, like
the REST API does for `/v1/entries/ids`: ID lists are cheap, and clients
can still follow the continuation offset for the remainder.

Refs: #4479
