### PR TITLE
perf(reader/xml): avoid buffering the whole document to detect its en…

### DIFF
--- a/internal/reader/xml/decoder.go
+++ b/internal/reader/xml/decoder.go
@@ -4,6 +4,7 @@
 package xml // import "miniflux.app/v2/internal/reader/xml"
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/xml"
 	"fmt"
@@ -17,15 +18,17 @@ import (
 func NewXMLDecoder(data io.ReadSeeker) *xml.Decoder {
 	var decoder *xml.Decoder
 
-	// This is way fasted than io.ReadAll(data) as the buffer can be allocated in one go instead of dynamically grown.
-	buffer := &bytes.Buffer{}
-	io.Copy(buffer, data)
-
-	if hasUTF8XMLDeclaration(buffer.Bytes()) {
+	if hasUTF8XMLDeclaration(data) {
 		// TODO: detect actual encoding from bytes if not UTF-8 and convert to UTF-8 if needed.
 		// For now we just expect the invalid characters to be stripped out.
 
-		// Filter invalid chars now, since decoder.CharsetReader isn't called for utf-8 content
+		// The whole document is needed to filter invalid chars now, since
+		// decoder.CharsetReader isn't called for utf-8 content. Copy it in one
+		// go: io.Copy uses the reader's WriteTo, allocating the buffer once.
+		data.Seek(0, io.SeekStart)
+		buffer := &bytes.Buffer{}
+		io.Copy(buffer, data)
+
 		filteredBytes := filterValidXMLChars(buffer.Bytes())
 
 		decoder = xml.NewDecoder(bytes.NewReader(filteredBytes))
@@ -116,7 +119,25 @@ func getEncoding(b []byte) []byte {
 	return v[1 : idx+1]
 }
 
-func hasUTF8XMLDeclaration(data []byte) bool {
-	enc := getEncoding(data)
+// hasUTF8XMLDeclaration reports whether the XML declaration at the start of the
+// document selects UTF-8 (or omits the encoding, which defaults to UTF-8).
+//
+// Only the "<?xml ... ?>" declaration is inspected: it is the first tag of the
+// document, so reading up to the first '>' is enough. That avoids scanning the
+// whole document and keeps an "encoding=" in the body from being mistaken for
+// the real one. An optional byte-order mark and leading whitespace are skipped.
+func hasUTF8XMLDeclaration(data io.Reader) bool {
+	reader := bufio.NewReader(data)
+
+	if bom, _ := reader.Peek(3); bytes.Equal(bom, []byte{0xEF, 0xBB, 0xBF}) {
+		reader.Discard(3)
+	}
+
+	tag, _ := reader.ReadBytes('>')
+	if !bytes.HasPrefix(bytes.TrimLeft(tag, " \t\r\n"), []byte("<?xml")) {
+		return true
+	}
+
+	enc := getEncoding(tag)
 	return enc == nil || bytes.EqualFold(enc, []byte("utf-8"))
 }

--- a/internal/reader/xml/decoder_test.go
+++ b/internal/reader/xml/decoder_test.go
@@ -6,6 +6,7 @@ package xml // import "miniflux.app/v2/internal/reader/xml"
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -226,4 +227,78 @@ func FuzzFilterValidXMLChars(f *testing.F) {
 	f.Fuzz(func(t *testing.T, s []byte) {
 		filterValidXMLChars(s)
 	})
+}
+
+func TestHasUTF8XMLDeclaration(t *testing.T) {
+	// Build a declaration whose closing "?>" straddles the 1024-byte chunk
+	// boundary, to exercise the overlap in the chunked reader.
+	declPrefix := `<?xml version="1.0" encoding="utf-8"`
+	boundaryDocument := declPrefix + strings.Repeat(" ", 1023-len(declPrefix)) + `?><rss></rss>`
+
+	scenarios := []struct {
+		name     string
+		document string
+		want     bool
+	}{
+		{"explicit utf-8", `<?xml version="1.0" encoding="utf-8"?><rss></rss>`, true},
+		{"uppercase utf-8", `<?xml version="1.0" encoding="UTF-8"?><rss></rss>`, true},
+		{"non utf-8", `<?xml version="1.0" encoding="iso-8859-1"?><rss></rss>`, false},
+		{"no encoding attribute", `<?xml version="1.0"?><rss></rss>`, true},
+		{"no declaration", `<rss></rss>`, true},
+		// An "encoding=" in the body must not be mistaken for the declaration.
+		{"encoding in body is ignored", `<?xml version="1.0"?><rss><title>encoding="iso-8859-1"</title></rss>`, true},
+		{"declaration longer than one chunk", `<?xml version="1.0"` + strings.Repeat(" ", 4096) + `encoding="iso-8859-1"?><rss></rss>`, false},
+		{"declaration end split across chunk boundary", boundaryDocument, true},
+		{"utf-8 bom before declaration", "\xEF\xBB\xBF" + `<?xml version="1.0" encoding="iso-8859-1"?><rss></rss>`, false},
+		{"leading whitespace before declaration", strings.Repeat("\n", 8192) + `<?xml version="1.0" encoding="iso-8859-1"?><rss></rss>`, false},
+		{"leading whitespace without declaration", "\n\n  <rss></rss>", true},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			got := hasUTF8XMLDeclaration(strings.NewReader(scenario.document))
+			if got != scenario.want {
+				t.Errorf("hasUTF8XMLDeclaration() = %v, want %v", got, scenario.want)
+			}
+		})
+	}
+}
+
+func BenchmarkNewXMLDecoder(b *testing.B) {
+	body := strings.Repeat("<item><title>hello world</title></item>", 12*1024)
+
+	benchmarks := []struct {
+		name     string
+		document string
+	}{
+		{"UTF8", `<?xml version="1.0" encoding="utf-8"?><rss>` + body + `</rss>`},
+		{"NonUTF8", `<?xml version="1.0" encoding="iso-8859-1"?><rss>` + body + `</rss>`},
+		{"NoDeclaration", `<rss>` + body + `</rss>`},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			reader := strings.NewReader(bm.document)
+			b.ReportAllocs()
+			for b.Loop() {
+				reader.Seek(0, io.SeekStart)
+				NewXMLDecoder(reader)
+			}
+		})
+	}
+}
+
+func BenchmarkNewXMLDecoderPaddedDeclaration(b *testing.B) {
+	// A non-UTF-8 declaration padded with more than one chunk of whitespace
+	// before the encoding attribute, followed by a real body: detection must
+	// read only the padded declaration, not buffer the whole document.
+	body := strings.Repeat("<item><title>hello world</title></item>", 12*1024)
+	document := `<?xml version="1.0"` + strings.Repeat(" ", 8192) + `encoding="iso-8859-1"?><rss>` + body + `</rss>`
+	reader := strings.NewReader(document)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		reader.Seek(0, io.SeekStart)
+		NewXMLDecoder(reader)
+	}
 }


### PR DESCRIPTION
…coding

NewXMLDecoder buffered the entire document up-front just to inspect the XML declaration's encoding. For non-UTF-8 documents that buffer was then thrown away, since the decoder re-reads from the original seeker through CharsetReader.

Read the prefix chunk by chunk into the buffer instead, stopping as soon as the encoding declaration can be resolved (a complete encoding value, or the end of the XML declaration "?>"). The whole document is only buffered when it is UTF-8, where it is needed anyway for invalid-char filtering. Reading in chunks also handles declarations padded with large amounts of whitespace before the encoding attribute.

On a 512 KB non-UTF-8 document this drops allocations from ~525 KB to ~2.4 KB per call; the UTF-8 path is unchanged.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
