### PR TITLE
perf(database): drop redundant entries_user_status_changed_idx

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1557,4 +1557,15 @@ var migrations = [...]func(tx *sql.Tx) error{
 		`)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		// entries_user_status_changed_idx(user_id, status, changed_at) is
+		// redundant: it is a strict prefix of
+		// entries_user_status_changed_published_idx(user_id, status,
+		// changed_at, published_at), which serves every query the shorter
+		// index could (including the history page and changed_at pagination).
+		_, err = tx.Exec(`
+			DROP INDEX IF EXISTS entries_user_status_changed_idx;
+		`)
+		return err
+	},
 }


### PR DESCRIPTION
The index entries_user_status_changed_idx(user_id, status, changed_at) is a strict prefix of entries_user_status_changed_published_idx(user_id, status, changed_at, published_at), which serves every query the shorter index could, including the history page and changed_at pagination.

The planner already prefers the four-column index when both are present, and after the drop those queries fall back to it with an identical plan. Removing the redundant index reclaims roughly 10% of the entries index space (~11 MB per 200k entries) with no query regression.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
