### PR TITLE
perf(database): drop redundant entries_feed_id_status_hash_idx index

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1558,6 +1558,12 @@ var migrations = [...]func(tx *sql.Tx) error{
 		return err
 	},
 	func(tx *sql.Tx) (err error) {
+		_, err = tx.Exec(`
+			DROP INDEX IF EXISTS entries_feed_id_status_hash_idx;
+		`)
+		return err
+	},
+	func(tx *sql.Tx) (err error) {
 		// entries_user_status_changed_idx(user_id, status, changed_at) is
 		// redundant: it is a strict prefix of
 		// entries_user_status_changed_published_idx(user_id, status,

--- a/internal/storage/entry.go
+++ b/internal/storage/entry.go
@@ -606,6 +606,9 @@ func (s *Storage) MarkFeedAsRead(userID, feedID int64, before time.Time) error {
 
 // MarkCategoryAsRead updates all category entries to the read status.
 func (s *Storage) MarkCategoryAsRead(userID, categoryID int64, before time.Time) error {
+	// entries.user_id is redundant with feeds.user_id here (an entry always
+	// shares its feed's owner), but including it lets the planner use
+	// entries_user_status_feed_idx(user_id, status, feed_id).
 	query := `
 		UPDATE
 			entries
@@ -615,13 +618,15 @@ func (s *Storage) MarkCategoryAsRead(userID, categoryID int64, before time.Time)
 		FROM
 			feeds
 		WHERE
-			feed_id=feeds.id
+			entries.feed_id=feeds.id
+		AND
+			entries.user_id=$2
 		AND
 			feeds.user_id=$2
 		AND
-			status=$3
+			entries.status=$3
 		AND
-			published_at < $4
+			entries.published_at < $4
 		AND
 			feeds.category_id=$5
 	`


### PR DESCRIPTION
The index entries_feed_id_status_hash_idx(feed_id, status, hash) is redundant: all of its access paths are covered by other indexes on the entries table.

- feed_id-only access is served by the unique constraint entries_feed_id_hash_key(feed_id, hash), which is feed_id-leading. This covers both entry-existence checks ("feed_id = ? AND hash = ?" in entryExists/getEntryIDByHash/IsNewEntry/GetReadTime) and the "feed_id" foreign-key cascade delete from feeds.

- Every query combining feed_id and status also filters on user_id (MarkFeedAsRead, MarkCategoryAsRead, MarkGloballyVisibleFeedsAsRead, and the feed listing built via EntryQueryBuilder, which always injects user_id = $1). Those predicates are covered by entries_user_status_feed_idx(user_id, status, feed_id), which matches all three columns as an index prefix.

This was painstakingly verified via `EXPLAIN`. It likely saves some index maintaining overhead, and around 70MB for a miniflux instance with 500k entries, likely scaling linearly.

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
