### PR TITLE
perf(database): index enclosure URL digest as bytea instead of hex

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1568,4 +1568,15 @@ var migrations = [...]func(tx *sql.Tx) error{
 		`)
 		return err
 	},
+	func(tx *sql.Tx) (err error) {
+		// Index the raw SHA-256 digest (32 bytes) instead of its hex text
+		// encoding (64 bytes) to roughly halve this index on disk. The
+		// ON CONFLICT clause in createEnclosure uses the same expression.
+		_, err = tx.Exec(`
+			DROP INDEX IF EXISTS enclosures_user_entry_url_unique_idx;
+			CREATE UNIQUE INDEX enclosures_user_entry_url_unique_idx
+				ON enclosures (user_id, entry_id, sha256(url::bytea));
+		`)
+		return err
+	},
 }

--- a/internal/storage/enclosure.go
+++ b/internal/storage/enclosure.go
@@ -157,7 +157,7 @@ func (s *Storage) createEnclosure(tx *sql.Tx, enclosure *model.Enclosure) error 
 			(url, size, mime_type, entry_id, user_id, media_progression)
 		VALUES
 			($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (user_id, entry_id, encode(sha256(url::bytea), 'hex')) DO NOTHING
+		ON CONFLICT (user_id, entry_id, sha256(url::bytea)) DO NOTHING
 		RETURNING
 			id
 	`


### PR DESCRIPTION
The enclosures_user_entry_url_unique_idx expression index stored the URL digest as encode(sha256(url::bytea), 'hex'), a 64-byte hex text encoding of a 32-byte value. Index the raw sha256(url::bytea) bytea instead to roughly halve the index on disk, and update the matching ON CONFLICT clause in createEnclosure so its inference still resolves to the index.

On 150k enclosures the index shrank from 27 MB to 11 MB (~59%).

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
