### PR TITLE
feat(oauth2): admin role mapping

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -432,6 +432,16 @@ func NewConfigOptions() *configOptions {
 				valueType:         secretFileType,
 				targetKey:         "METRICS_USERNAME",
 			},
+			"OAUTH2_ADDITIONAL_SCOPES": {
+				parsedStringList: []string{},
+				rawValue:         "",
+				valueType:        stringListType,
+			},
+			"OAUTH2_ADMIN_GROUP": {
+				parsedStringValue: "",
+				rawValue:          "",
+				valueType:         stringType,
+			},
 			"OAUTH2_CLIENT_ID": {
 				parsedStringValue: "",
 				rawValue:          "",
@@ -455,6 +465,11 @@ func NewConfigOptions() *configOptions {
 				rawValue:          "",
 				valueType:         secretFileType,
 				targetKey:         "OAUTH2_CLIENT_SECRET",
+			},
+			"OAUTH2_GROUP_CLAIM": {
+				parsedStringValue: "",
+				rawValue:          "",
+				valueType:         stringType,
 			},
 			"OAUTH2_OIDC_DISCOVERY_ENDPOINT": {
 				parsedStringValue: "",
@@ -900,6 +915,18 @@ func (c *configOptions) MetricsRefreshInterval() time.Duration {
 
 func (c *configOptions) MetricsUsername() string {
 	return c.options["METRICS_USERNAME"].parsedStringValue
+}
+
+func (c *configOptions) Oauth2GroupClaim() string {
+	return c.options["OAUTH2_GROUP_CLAIM"].parsedStringValue
+}
+
+func (c *configOptions) Oauth2AdditionalScopes() []string {
+	return c.options["OAUTH2_ADDITIONAL_SCOPES"].parsedStringList
+}
+
+func (c *configOptions) Oauth2AdminGroup() string {
+	return c.options["OAUTH2_ADMIN_GROUP"].parsedStringValue
 }
 
 func (c *configOptions) OAuth2ClientID() string {

--- a/internal/oauth2/oidc.go
+++ b/internal/oauth2/oidc.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
+	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/model"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -56,7 +58,7 @@ func (o *oidcProvider) Config() *oauth2.Config {
 		RedirectURL:  o.redirectURL,
 		ClientID:     o.clientID,
 		ClientSecret: o.clientSecret,
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       slices.Concat([]string{oidc.ScopeOpenID, "profile", "email"}, config.Opts.Oauth2AdditionalScopes()),
 		Endpoint:     o.provider.Endpoint(),
 	}
 }
@@ -104,6 +106,28 @@ func (o *oidcProvider) Profile(ctx context.Context, code, codeVerifier string) (
 		if value != "" {
 			profile.Username = value
 			break
+		}
+	}
+
+	if groupClaim := config.Opts.Oauth2GroupClaim(); groupClaim != "" {
+		var rawUserClaims map[string]any
+		if err := userInfo.Claims(&rawUserClaims); err != nil {
+			return nil, fmt.Errorf(`oidc: failed to parse user claims: %w`, err)
+		}
+
+		rawValue := rawUserClaims[groupClaim]
+		switch value := rawValue.(type) {
+		case string:
+			profile.Groups = []string{value}
+		case []any:
+			profile.Groups = make([]string, len(value))
+			for i, rawEntry := range value {
+				if entry, ok := rawEntry.(string); ok {
+					profile.Groups[i] = entry
+				} else {
+					return nil, fmt.Errorf(`oidc: failed to parse user claims: %q must only contain strings`, groupClaim)
+				}
+			}
 		}
 	}
 

--- a/internal/oauth2/profile.go
+++ b/internal/oauth2/profile.go
@@ -12,6 +12,7 @@ type UserProfile struct {
 	Key      string
 	ID       string
 	Username string
+	Groups   []string
 }
 
 // String returns a formatted string representation of the user profile.

--- a/internal/ui/oauth2_callback.go
+++ b/internal/ui/oauth2_callback.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 
 	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/http/request"
@@ -116,6 +117,11 @@ func (h *handler) oauth2Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	groupClaim := config.Opts.Oauth2GroupClaim()
+	adminGroup := config.Opts.Oauth2AdminGroup()
+	adminRoleMappingEnabled := groupClaim != "" && adminGroup != ""
+	isAdmin := adminRoleMappingEnabled && slices.Contains(profile.Groups, adminGroup)
+
 	if user == nil {
 		if !config.Opts.IsOAuth2UserCreationAllowed() {
 			response.HTMLForbidden(w, r)
@@ -127,7 +133,7 @@ func (h *handler) oauth2Callback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		userCreationRequest := &model.UserCreationRequest{Username: profile.Username}
+		userCreationRequest := &model.UserCreationRequest{Username: profile.Username, IsAdmin: isAdmin}
 		authProvider.PopulateUserCreationWithProfileID(userCreationRequest, profile)
 
 		user, err = h.store.CreateUser(userCreationRequest)
@@ -144,6 +150,14 @@ func (h *handler) oauth2Callback(w http.ResponseWriter, r *http.Request) {
 		slog.Int64("user_id", user.ID),
 		slog.String("username", user.Username),
 	)
+
+	if adminRoleMappingEnabled && user.IsAdmin != isAdmin {
+		user.IsAdmin = isAdmin
+		if err := h.store.UpdateUser(user); err != nil {
+			response.HTMLServerError(w, r, err)
+			return
+		}
+	}
 
 	h.store.SetLastLogin(user.ID)
 	if err := authenticateWebSession(w, r, h.store, user); err != nil {

--- a/miniflux.1
+++ b/miniflux.1
@@ -491,6 +491,18 @@ endpoint HTTP authentication\&.
 .br
 Default is empty\&.
 .TP
+.B OAUTH2_ADDITIONAL_SCOPES
+Additional OAuth2 scopes to request\&.
+.br
+Default is empty\&.
+.TP
+.B OAUTH2_ADMIN_GROUP
+Group for administrators\&.
+.br
+When set, the admin role is mapped based on the specified group.\&.
+.br
+Default is empty\&.
+.TP
 .B OAUTH2_CLIENT_ID
 OAuth2 client ID\&.
 .br
@@ -510,6 +522,13 @@ Default is empty\&.
 .B OAUTH2_CLIENT_SECRET_FILE
 Path to a secret key exposed as a file, it should contain the
 \fBOAUTH2_CLIENT_SECRET\fR value\&.
+.br
+Default is empty\&.
+.TP
+.B OAUTH2_GROUP_CLAIM
+Claim that contains user groups\&.
+.br
+Used for obtaining user groups, which can be used for mapping the admin role.\&.
 .br
 Default is empty\&.
 .TP


### PR DESCRIPTION
## Description

Optionally allows users to map the admin role from OAuth claims.

The following three config options are added:

- `OAUTH2_ADDITIONAL_SCOPES`: Allows the user to request additional scopes from the IDP (e.g. `groups`)
- `OAUTH2_GROUP_CLAIM`: The claim that contains user groups
- `OAUTH2_ADMIN_GROUP`: The value of the group claim that identifies a user as an admin

If those options are set, on every OAuth2 login permissions are updated.

⚠️ I only implemented the feature for the OIDC provider type, not for Google, as I don't think that this feature is really useful in combination with public OAuth2 providers. I'd be happy to hear your opinion on this case. Should I rename the options to something like `OAUTH2_OIDC_ADDITIONAL_SCOPES` or similar?

## Motivation

This allows to fully handle user management externally in a single location (IDP) and removes the necessity to create a local admin in the first place.

## Testing

I built a Docker image with `make`, used it to set up a small instance with my personal OIDC provider configured, and tested the following:

- when not providing any of the new configuration options, the application behaves the same as without the changes
- when configuring the options correctly and signing in with a user that has the configured group, the user gains admin privileges
- after removing the group from the user and signing in again, the user looses admin privileges
- on misconfiguration (missing scope, claim, etc.) the user is treated like a regular user (without admin privileges)

## Breaking Changes

There are no breaking changes.

## Related Issues

Fixes #4509

## Guidelines

Have you followed these guidelines?

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)
