### PR TITLE
fix(fetcher): allow connecting to a proxy set through the environment

### DIFF
--- a/internal/reader/fetcher/request_builder.go
+++ b/internal/reader/fetcher/request_builder.go
@@ -21,6 +21,8 @@ import (
 	"miniflux.app/v2/internal/config"
 	"miniflux.app/v2/internal/proxyrotator"
 	"miniflux.app/v2/internal/urllib"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 const (
@@ -175,7 +177,19 @@ func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, erro
 		KeepAlive: 15 * time.Second, // Default is 30s.
 	}
 
+	// http.ProxyFromEnvironment caches the environment on first use and needs a
+	// request that does not exist yet here, so read the variables directly. This
+	// keeps routing and the private-network exemption below in agreement.
+	envProxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+
 	proxyDialAddress := normalizeProxyDialAddress(clientProxyURL)
+	if clientProxyURL == nil {
+		if parsedRequestURL, err := url.Parse(requestURL); err == nil {
+			if envProxyURL, err := envProxyFunc(parsedRequestURL); err == nil {
+				proxyDialAddress = normalizeProxyDialAddress(envProxyURL)
+			}
+		}
+	}
 
 	// Perform the private-network check inside the dialer's Control callback,
 	// which fires after DNS resolution but before the TCP connection is made.
@@ -199,7 +213,9 @@ func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, erro
 	}
 
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return envProxyFunc(req.URL)
+		},
 		// Setting `DialContext` disables HTTP/2, this option forces the transport to try HTTP/2 regardless.
 		ForceAttemptHTTP2: true,
 		MaxIdleConns:      50,               // Default is 100.

--- a/internal/reader/fetcher/request_builder.go
+++ b/internal/reader/fetcher/request_builder.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -177,19 +178,13 @@ func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, erro
 		KeepAlive: 15 * time.Second, // Default is 30s.
 	}
 
-	// http.ProxyFromEnvironment caches the environment on first use and needs a
-	// request that does not exist yet here, so read the variables directly. This
-	// keeps routing and the private-network exemption below in agreement.
+	// The proxy is resolved with httpproxy rather than http.ProxyFromEnvironment,
+	// which caches the environment on first use. Routing and the trusted hop below
+	// are then decided by the same call.
 	envProxyFunc := httpproxy.FromEnvironment().ProxyFunc()
 
-	proxyDialAddress := normalizeProxyDialAddress(clientProxyURL)
-	if clientProxyURL == nil {
-		if parsedRequestURL, err := url.Parse(requestURL); err == nil {
-			if envProxyURL, err := envProxyFunc(parsedRequestURL); err == nil {
-				proxyDialAddress = normalizeProxyDialAddress(envProxyURL)
-			}
-		}
-	}
+	trustedProxies := &trustedProxyAddresses{}
+	trustedProxies.add(clientProxyURL)
 
 	// Perform the private-network check inside the dialer's Control callback,
 	// which fires after DNS resolution but before the TCP connection is made.
@@ -214,7 +209,12 @@ func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, erro
 
 	transport := &http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
-			return envProxyFunc(req.URL)
+			proxyURL, err := envProxyFunc(req.URL)
+			if err == nil {
+				trustedProxies.add(proxyURL)
+			}
+
+			return proxyURL, err
 		},
 		// Setting `DialContext` disables HTTP/2, this option forces the transport to try HTTP/2 regardless.
 		ForceAttemptHTTP2: true,
@@ -223,11 +223,11 @@ func (r *RequestBuilder) ExecuteRequest(requestURL string) (*http.Response, erro
 	}
 
 	transport.DialContext = directDialer.DialContext
-	if !allowPrivateNetworks && proxyDialAddress != "" {
+	if !allowPrivateNetworks {
 		// Explicitly configured proxies are a trusted hop. Keep the private-network
 		// check for direct requests and redirects, but allow the connection to the proxy itself.
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if normalizeDialAddress(addr) == proxyDialAddress {
+			if trustedProxies.contains(normalizeDialAddress(addr)) {
 				return proxyDialer.DialContext(ctx, network, addr)
 			}
 
@@ -337,4 +337,33 @@ func normalizeProxyDialAddress(proxyURL *url.URL) string {
 	}
 
 	return net.JoinHostPort(strings.ToLower(proxyURL.Hostname()), port)
+}
+
+// trustedProxyAddresses holds the dial addresses of the proxies used for a
+// request. The proxy taken from the environment is resolved per request URL, so
+// a redirect can select a different proxy than the initial request did.
+type trustedProxyAddresses struct {
+	mu        sync.Mutex
+	addresses []string
+}
+
+func (p *trustedProxyAddresses) add(proxyURL *url.URL) {
+	address := normalizeProxyDialAddress(proxyURL)
+	if address == "" {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !slices.Contains(p.addresses, address) {
+		p.addresses = append(p.addresses, address)
+	}
+}
+
+func (p *trustedProxyAddresses) contains(address string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return slices.Contains(p.addresses, address)
 }

--- a/internal/reader/fetcher/request_builder_test.go
+++ b/internal/reader/fetcher/request_builder_test.go
@@ -534,6 +534,73 @@ func TestRequestBuilder_AllowPrivateConfiguredProxy(t *testing.T) {
 	}
 }
 
+func TestRequestBuilder_AllowPrivateEnvironmentProxy(t *testing.T) {
+	configureFetcherAllowPrivateNetworksOption(t, "0")
+
+	targetURL := "http://feed.invalid/rss.xml"
+	proxyRequests := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case proxyRequests <- r.URL.String():
+		default:
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxyServer.Close()
+
+	t.Setenv("HTTP_PROXY", proxyServer.URL)
+
+	resp, err := NewRequestBuilder().ExecuteRequest(targetURL)
+	if err != nil {
+		t.Fatalf("Expected request through the environment proxy to succeed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	select {
+	case gotURL := <-proxyRequests:
+		if gotURL != targetURL {
+			t.Fatalf("Expected proxy request URL to be %q, got %q", targetURL, gotURL)
+		}
+	default:
+		t.Fatal("Expected request to be sent through the environment proxy")
+	}
+}
+
+func TestRequestBuilder_RefusePrivateNetworkWhenExcludedFromEnvironmentProxy(t *testing.T) {
+	configureFetcherAllowPrivateNetworksOption(t, "0")
+
+	privateServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer privateServer.Close()
+
+	proxyRequests := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case proxyRequests <- r.URL.String():
+		default:
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxyServer.Close()
+
+	t.Setenv("HTTP_PROXY", proxyServer.URL)
+	t.Setenv("NO_PROXY", "feed.invalid")
+
+	_, err := NewRequestBuilder().ExecuteRequest("http://feed.invalid/rss.xml")
+	if err == nil {
+		t.Fatal("Expected request excluded from the environment proxy to fail")
+	}
+
+	select {
+	case gotURL := <-proxyRequests:
+		t.Fatalf("Expected request to bypass the environment proxy, but the proxy received %q", gotURL)
+	default:
+	}
+}
+
 func TestRequestBuilder_RefusePrivateNetworkOnRedirect(t *testing.T) {
 	configureFetcherAllowPrivateNetworksOption(t, "0")
 

--- a/internal/reader/fetcher/request_builder_test.go
+++ b/internal/reader/fetcher/request_builder_test.go
@@ -601,6 +601,44 @@ func TestRequestBuilder_RefusePrivateNetworkWhenExcludedFromEnvironmentProxy(t *
 	}
 }
 
+func TestRequestBuilder_AllowPrivateEnvironmentProxyOnRedirect(t *testing.T) {
+	configureFetcherAllowPrivateNetworksOption(t, "0")
+
+	connectRequests := make(chan string, 1)
+	httpsProxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case connectRequests <- r.Host:
+		default:
+		}
+
+		http.Error(w, "tunneling is not supported by this test proxy", http.StatusBadGateway)
+	}))
+	defer httpsProxyServer.Close()
+
+	httpProxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://secure.invalid/rss.xml", http.StatusFound)
+	}))
+	defer httpProxyServer.Close()
+
+	t.Setenv("HTTP_PROXY", httpProxyServer.URL)
+	t.Setenv("HTTPS_PROXY", httpsProxyServer.URL)
+
+	if _, err := NewRequestBuilder().ExecuteRequest("http://feed.invalid/rss.xml"); err != nil {
+		if strings.Contains(err.Error(), "refusing to access private network host") {
+			t.Fatalf("Expected the proxy selected after the redirect to be reachable: %v", err)
+		}
+	}
+
+	select {
+	case gotHost := <-connectRequests:
+		if gotHost != "secure.invalid:443" {
+			t.Fatalf("Expected the HTTPS proxy to receive a CONNECT request for %q, got %q", "secure.invalid:443", gotHost)
+		}
+	default:
+		t.Fatal("Expected the redirect to be sent through the HTTPS environment proxy")
+	}
+}
+
 func TestRequestBuilder_RefusePrivateNetworkOnRedirect(t *testing.T) {
 	configureFetcherAllowPrivateNetworksOption(t, "0")
 


### PR DESCRIPTION
**Description:** Fixes #4456. With `FETCHER_ALLOW_PRIVATE_NETWORKS=0`, a proxy configured through `HTTP_PROXY` / `HTTPS_PROXY` is still used for routing, but the connection to the proxy itself is refused when the proxy sits on a private address:

```
proxyconnect tcp: dial tcp 127.0.0.1:8888: fetcher: refusing to access private network host "127.0.0.1"
```

**Motivation:** #4245 made explicitly configured proxies a trusted hop, but it enumerated the three miniflux-side sources (feed proxy, application proxy, proxy rotator). The environment variables were not included, so `proxyDialAddress` stays empty and the blocking dialer is used for the hop to the proxy, while `transport.Proxy` still routes through it. The proxy is enabled and blocked at the same time.

This matters because the environment variables are the documented way to proxy everything, and the example in the docs is `http://127.0.0.1:8888`, which is exactly the case that stopped working.

The trusted hop is recorded inside the transport's `Proxy` function, which is the single place where the proxy for a hop is decided. The environment proxy is resolved per request URL, so a redirect can select a different proxy than the initial request did (`HTTP_PROXY` -> `HTTPS_PROXY`), and collecting the addresses as the transport picks them keeps every hop it actually makes covered and nothing else. Resolving it once from the initial URL missed the second proxy, which is what @fguillot pointed out in review.

`x/net/http/httpproxy` is used instead of `http.ProxyFromEnvironment` because the latter caches the environment on first use.

`NO_PROXY` stays honoured per request URL, so a host excluded from the proxy is still dialled directly and still checked. That is the second test below.

`x/net` is already a direct dependency. `go.mod` and `go.sum` are unchanged.

**Testing:** Three tests added to `internal/reader/fetcher/request_builder_test.go`:

- `TestRequestBuilder_AllowPrivateEnvironmentProxy` stands up an `httptest` proxy on loopback, points `HTTP_PROXY` at it, and asserts the request arrives at the proxy. On main it fails with the reporter's exact error:
  ```
  Expected request through the environment proxy to succeed: Get "http://feed.invalid/rss.xml":
  proxyconnect tcp: dial tcp 127.0.0.1:37269: fetcher: refusing to access private network host "127.0.0.1"
  ```
- `TestRequestBuilder_RefusePrivateNetworkWhenExcludedFromEnvironmentProxy` sets `NO_PROXY=feed.invalid` and asserts the proxy is bypassed and the request still fails, so the exemption cannot be used to reach an arbitrary private host.
- `TestRequestBuilder_AllowPrivateEnvironmentProxyOnRedirect` points `HTTP_PROXY` and `HTTPS_PROXY` at two different loopback proxies and redirects from an http URL to an https one, so the hop after the redirect goes through the other proxy. Before b08db3ac it failed with the same refusal, for the second proxy:
  ```
  Get "https://secure.invalid/rss.xml": proxyconnect tcp: dial tcp 127.0.0.1:64438:
  fetcher: refusing to access private network host "127.0.0.1"
  ```

Ran on Go 1.26: `go build ./...`, `go vet ./internal/reader/fetcher/`, `gofmt` clean, and `go test -count=1 ./internal/...` with zero failures. `TestRequestBuilder_RefusePrivateNetworkByDefault`, `TestRequestBuilder_RefusePrivateNetworkOnRedirect` and the three `AllowPrivateConfiguredProxy` cases still pass.

**Breaking changes:** None. Behaviour only changes where the connection was previously refused.

