### PR TITLE
fix(ui): restart pagination when the feed or category page falls past the end

### DIFF
--- a/internal/ui/category_entries.go
+++ b/internal/ui/category_entries.go
@@ -33,18 +33,33 @@ func (h *handler) showCategoryEntriesPage(w http.ResponseWriter, r *http.Request
 
 	offset := request.QueryIntParam(r, "offset", 0)
 
-	entries, count, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithCategoryID(category.ID).
-		WithSorting(user.EntryOrder, user.EntryDirection).
-		WithSorting("id", user.EntryDirection).
-		WithStatuses(model.EntryStatusUnread).
-		WithoutContent().
-		WithOffset(offset).
-		WithLimit(user.EntriesPerPage).
-		GetEntriesWithCount()
+	unreadEntries := func(offset int) (model.Entries, int, error) {
+		return h.store.NewEntryQueryBuilder(user.ID).
+			WithCategoryID(category.ID).
+			WithSorting(user.EntryOrder, user.EntryDirection).
+			WithSorting("id", user.EntryDirection).
+			WithStatuses(model.EntryStatusUnread).
+			WithoutContent().
+			WithOffset(offset).
+			WithLimit(user.EntriesPerPage).
+			GetEntriesWithCount()
+	}
+
+	entries, count, err := unreadEntries(offset)
 	if err != nil {
 		response.HTMLServerError(w, r, err)
 		return
+	}
+
+	// Restart from the first page when marking entries as read leaves the offset past the end.
+	if offset >= count && count > 0 {
+		offset = 0
+
+		entries, count, err = unreadEntries(offset)
+		if err != nil {
+			response.HTMLServerError(w, r, err)
+			return
+		}
 	}
 
 	view := view.New(h.tpl, r)

--- a/internal/ui/feed_entries.go
+++ b/internal/ui/feed_entries.go
@@ -33,18 +33,33 @@ func (h *handler) showFeedEntriesPage(w http.ResponseWriter, r *http.Request) {
 
 	offset := request.QueryIntParam(r, "offset", 0)
 
-	entries, count, err := h.store.NewEntryQueryBuilder(user.ID).
-		WithFeedID(feed.ID).
-		WithStatuses(model.EntryStatusUnread).
-		WithSorting(user.EntryOrder, user.EntryDirection).
-		WithSorting("id", user.EntryDirection).
-		WithOffset(offset).
-		WithLimit(user.EntriesPerPage).
-		WithoutContent().
-		GetEntriesWithCount()
+	unreadEntries := func(offset int) (model.Entries, int, error) {
+		return h.store.NewEntryQueryBuilder(user.ID).
+			WithFeedID(feed.ID).
+			WithStatuses(model.EntryStatusUnread).
+			WithSorting(user.EntryOrder, user.EntryDirection).
+			WithSorting("id", user.EntryDirection).
+			WithOffset(offset).
+			WithLimit(user.EntriesPerPage).
+			WithoutContent().
+			GetEntriesWithCount()
+	}
+
+	entries, count, err := unreadEntries(offset)
 	if err != nil {
 		response.HTMLServerError(w, r, err)
 		return
+	}
+
+	// Restart from the first page when marking entries as read leaves the offset past the end.
+	if offset >= count && count > 0 {
+		offset = 0
+
+		entries, count, err = unreadEntries(offset)
+		if err != nil {
+			response.HTMLServerError(w, r, err)
+			return
+		}
 	}
 
 	view := view.New(h.tpl, r)


### PR DESCRIPTION
Fixes #4386

### Context

On the last page of a feed, "Mark this page as read" leaves an empty page with no navigation. The unread list shrinks under the current offset, so the offset is now past the end; the template only renders the pagination block when there are entries, so the view falls back to the "no unread entries" alert with no Previous link, even though the header still reports the entries that remain. Reloading, or reopening the same URL later, lands on the same dead end.

The global unread view already handles this: `showUnreadPage` resets the offset to 0 and requeries when `offset >= countUnread && countUnread > 0`. The feed and category views are the other two with a "Mark this page as read" button and never got the same guard.

### Changes

Apply that guard to `showFeedEntriesPage` and `showCategoryEntriesPage`. The query moves into a small closure so the fallback does not duplicate the builder chain — `WithOffset` ignores 0, so the same builder cannot be reused directly.

### Scope

The three views that carry the "Mark this page as read" button are the feed, category and unread lists, and `markPageAsReadAction` in `app.js` only reloads in place when `data-show-only-unread` is set, which only the feed and category templates set. So those two were the only ones missing the guard, and no other list view can reach this dead end through that button.

Other list views can strand on a stale offset by different routes, `/starred` when an entry is unstarred, `/history` when one is marked unread, `/search?unread=1` when a result is auto-marked read on view. They are left alone here since they have no bulk action and are not what #4386 reports.

I also considered fixing this in the template instead, since `getPagination` already returns `ShowPrev` and `PrevOffset` correctly at a stale offset and the view discards them under `{{ if not .entries }}`. Rendering pagination for an empty page would restore the Previous link, but it would still show the "no unread entries" alert while unread entries exist just below the offset, so the reader is told the wrong thing. Resetting the offset shows them instead, and matches `showUnreadPage`.

Resetting to the first page rather than clamping to the new last page is also for parity with `showUnreadPage`.

### User impact

Marking the last page as read lands on the first page of what is left instead of an empty page. A page still within range is unaffected, and a feed with genuinely nothing unread keeps its alert.

### Verification

Built and run against a local PostgreSQL instance with a feed of 25 unread entries and 20 entries per page.

| Case | before | after |
|---|---|---|
| `offset=20`, 25 unread | 5 entries, pagination, Previous link | unchanged |
| `offset=20` after marking that page read (20 unread) | 0 entries, no pagination, no Previous link | 20 entries, pagination |
| `offset=100`, 25 unread | 0 entries, no pagination | 20 entries, pagination |
| `offset=0` / `offset=20`, 0 unread | "no unread entries" alert | unchanged |

`/category/1/entries?offset=20` behaves identically before and after the change.

`go vet ./internal/ui/...`, `gofmt` and `golangci-lint run ./internal/ui/...` are clean. `go test ./...` passes except `TestParseAdminPasswordFileOptionWithEmptyFile`, which fails on this Windows host before and after the change because it writes its temporary file to `C:\WINDOWS`.
