### PR TITLE
fix(karakeep): report the HTTP status when saving an entry fails

### DIFF
--- a/internal/integration/karakeep/karakeep.go
+++ b/internal/integration/karakeep/karakeep.go
@@ -136,10 +136,6 @@ func (c *Client) SaveURL(entryURL string) error {
 		return fmt.Errorf("karakeep: failed to parse response: %s", err)
 	}
 
-	if resp.Header.Get("Content-Type") != "application/json" {
-		return fmt.Errorf("karakeep: unexpected content type response: %s", resp.Header.Get("Content-Type"))
-	}
-
 	if resp.StatusCode != http.StatusCreated {
 		var errResponse errorResponse
 		if err := json.Unmarshal(responseBody, &errResponse); err != nil {

--- a/internal/integration/karakeep/karakeep_test.go
+++ b/internal/integration/karakeep/karakeep_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright The Miniflux Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package karakeep
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"miniflux.app/v2/internal/config"
+)
+
+func TestSaveURL(t *testing.T) {
+	configureIntegrationAllowPrivateNetworksOption(t)
+
+	tests := []struct {
+		name           string
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		errContains    string
+	}{
+		{
+			name: "successful save",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				w.Write([]byte(`{"id":"bookmark-id"}`))
+			},
+		},
+		{
+			name: "json error response reports the status and error code",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(`{"code":"UNAUTHORIZED","error":"invalid token"}`))
+			},
+			errContains: "status=401",
+		},
+		{
+			name: "html error response reports the status",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("<!DOCTYPE html><title>Not Found</title>"))
+			},
+			errContains: "status=404",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(tt.serverResponse))
+			defer server.Close()
+
+			err := NewClient("test-api-key", server.URL, "").SaveURL("https://example.com/article")
+
+			if tt.errContains == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got none")
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+			}
+		})
+	}
+}
+
+func configureIntegrationAllowPrivateNetworksOption(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("INTEGRATION_ALLOW_PRIVATE_NETWORKS", "1")
+
+	configParser := config.NewConfigParser()
+	parsedOptions, err := configParser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf("Unable to configure test options: %v", err)
+	}
+
+	previousOptions := config.Opts
+	config.Opts = parsedOptions
+	t.Cleanup(func() {
+		config.Opts = previousOptions
+	})
+}


### PR DESCRIPTION
Related to [#4477 — Unable to send entries to Karakeep](https://github.com/miniflux/v2/issues/4477).

## Problem

`SaveURL` checked `Content-Type` before the HTTP status. HTML error pages from a proxy, redirect, or incorrect endpoint therefore surfaced only as an unexpected content type, hiding the status that explains the failure.

## Fix

Remove the one-off content-type gate and follow the integration package's existing status-first pattern. Non-201 responses now report their status; successful responses still have to decode as the expected JSON payload.

## Deliberately not done

This improves the diagnostic but does not change private-network policy or deployment configuration. Installations targeting a private Karakeep address may still need `INTEGRATION_ALLOW_PRIVATE_NETWORKS=1`.

## User impact

Failed saves now expose the upstream HTTP status, making proxy, authentication, and endpoint problems actionable instead of reporting only `text/html`.

## Verification

- `go test ./internal/integration/...` — all integration packages passed.
- `go vet ./...` — passed.
- `go build ./...` — passed.
- `git diff --check` and `gofmt -d` — clean.

- [x] I have tested my changes
- [x] There are no breaking changes
- [x] I have thoroughly tested my changes and verified there are no regressions
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/)
- [x] I have read and understood the [contribution guidelines](https://github.com/miniflux/v2/blob/main/CONTRIBUTING.md)